### PR TITLE
Felinid balances pt.1

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/felinid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/felinid.yml
@@ -25,6 +25,25 @@
     prototype: Felinid
   - type: Damageable
     damageModifierSet: Felinid
+  # Funkystation - felinids are hairless cats, so they take more cold damage.
+  - type: Temperature
+    heatDamageThreshold: 325
+    coldDamageThreshold: 285
+    currentTemperature: 310.15
+    specificHeat: 46
+    coldDamage:
+      types:
+        Cold: 0.1 #per second, scales with temperature & other constants
+  # Funkystation - same as lizard for now, could probably work on a rebalance
+  - type: TemperatureSpeed
+    thresholds:
+      301: 0.8
+      295: 0.6
+      285: 0.4
+  # Funkystation - cars get thirsty!
+  # TODO make it so felinids are only able to drink from sinks since cars irl do not drink still water
+  - type: Thirst
+    baseDecayRate: 0.12
   # Goobstation - Siouxcide, felinids have standard slow on damage numbers
 # - type: SlowOnDamage
 #   speedModifierThresholds:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Adds a damage modifier to cold, so spacing for felinids is more dangerous. Also adds a thirst modifier, making felinids thirsty.

## Why / Balance
Felinids are essentially big hairless cats. They cannot regulate body temperature. They are also the exact same to humans, except just a smaller hitbox. This PR aims to balance felinids with more thirst management and extra vectors for something to go wrong (i.e, spacing is a bigger deal now).

## Technical details
YAML lol

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
- tweak: Felinids now take more cold damage
- tweak: Felinids are thirsty
