### PR TITLE
update bz formation to be more in line with /tg/ mechanics

### DIFF
--- a/Content.Server/Atmos/Reactions/BZFormationReaction.cs
+++ b/Content.Server/Atmos/Reactions/BZFormationReaction.cs
@@ -13,28 +13,40 @@ public sealed partial class BZFormationReaction : IGasReactionEffect
 {
     public ReactionResult React(GasMixture mixture, IGasMixtureHolder? holder, AtmosphereSystem atmosphereSystem, float heatScale)
     {
+        if (mixture.Temperature > 313f)
+            return ReactionResult.NoReaction;
+
         var initN2O = mixture.GetMoles(Gas.NitrousOxide);
         var initPlasma = mixture.GetMoles(Gas.Plasma);
         var pressure = mixture.Pressure;
         var volume = mixture.Volume;
 
         var environmentEfficiency = volume / pressure; // more volume and less pressure gives better rates
-        var ratioEfficiency = Math.Min(initN2O / initPlasma, 1); // less n2o than plasma gives lower rates
+        var ratioEfficiency = Math.Min(initN2O / initPlasma, 1f); // less n2o than plasma gives lower rates
+        var bzFormed = Math.Min(0.01f * ratioEfficiency * environmentEfficiency, Math.Min(initN2O * 2.5f, initPlasma * 1.25f));
 
-        var totalRate = environmentEfficiency * ratioEfficiency / Atmospherics.BZFormationRate;
-
-        var n2oRemoved = totalRate * 2f;
-        var plasmaRemoved = totalRate * 4f;
-        var bzFormed = totalRate * 5f;
+        var nitrousOxideDecomposed =  Math.Max(4f * (initPlasma / (initN2O + initPlasma) - 0.75f), 0);
+        var nitrogenAdded = 0f;
+        var oxygenAdded = 0f;
+        if (nitrousOxideDecomposed > 0) {
+            var amountDecomposed = 0.4f * bzFormed * nitrousOxideDecomposed;
+            nitrogenAdded = amountDecomposed;
+            oxygenAdded = 0.5f * amountDecomposed;
+        }
+        var bzAdded = bzFormed * (1f-nitrousOxideDecomposed);
+        var n2oRemoved = 0.4f * bzFormed;
+        var plasmaRemoved = 0.8f * bzFormed * (1f-nitrousOxideDecomposed);
 
         if (n2oRemoved > initN2O || plasmaRemoved > initPlasma)
             return ReactionResult.NoReaction;
 
         mixture.AdjustMoles(Gas.NitrousOxide, -n2oRemoved);
         mixture.AdjustMoles(Gas.Plasma, -plasmaRemoved);
-        mixture.AdjustMoles(Gas.BZ, bzFormed);
+        mixture.AdjustMoles(Gas.Nitrogen, nitrogenAdded);
+        mixture.AdjustMoles(Gas.Oxygen, oxygenAdded);
+        mixture.AdjustMoles(Gas.BZ, bzAdded);
 
-        var energyReleased = bzFormed * Atmospherics.BZFormationEnergy;
+        var energyReleased = bzFormed * (Atmospherics.BZFormationEnergy + nitrousOxideDecomposed);
         var heatCap = atmosphereSystem.GetHeatCapacity(mixture, true);
         if (heatCap > Atmospherics.MinimumHeatCapacity)
             mixture.Temperature = Math.Max((mixture.Temperature * heatCap + energyReleased) / heatCap, Atmospherics.TCMB);

--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -256,11 +256,6 @@ namespace Content.Shared.Atmos
         public const float BZFormationEnergy = 80e3f;
 
         /// <summary>
-        ///     Some number taken from the air to keep BZ from instantly converting everything.
-        /// </summary>
-        public const float BZFormationRate = 5f;
-
-        /// <summary>
         ///     The amount of energy 1 mol of Healium forming from BZ and frezon releases.
         /// </summary>
         public const float HealiumProductionEnergy = 10e3f;


### PR DESCRIPTION
## About the PR
Changes BZ formation mechanics to be more in line with original /tg/ code

## Why / Balance
BZ formation was unwieldy and was not acting as intended.

## Technical details
BZ can now be formed with fewer mols. When plasma levels are significantly higher than n2o levels, the mixture will decompose into oxygen and nitrogen. BZ will not be formed at temperatures that can ignite plasma or tritium. 

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None

**Changelog**
:cl:
- tweak: BZ Formation mechanics
