### PR TITLE
Better Sacrifice Teleporting

### DIFF
--- a/Content.Server/_Goobstation/Heretic/Ritual/CustomBehavior.Sacrifice.cs
+++ b/Content.Server/_Goobstation/Heretic/Ritual/CustomBehavior.Sacrifice.cs
@@ -9,6 +9,7 @@ using Content.Shared.Damage;
 using Content.Shared.Heretic;
 using Content.Server.Heretic.EntitySystems;
 using Content.Server.Chat.Managers;
+using Content.Server.Atmos.EntitySystems;
 using Robust.Shared.Random;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.Mobs;
@@ -17,6 +18,7 @@ using Content.Shared.Inventory;
 using Robust.Server.GameObjects;
 using Content.Shared.Chat;
 using System.Linq;
+using Robust.Shared.Physics;
 
 namespace Content.Server.Heretic.Ritual;
 
@@ -199,8 +201,9 @@ public partial class RitualSacrificeBehavior : RitualCustomBehavior
         var xformSystem = args.EntityManager.System<TransformSystem>();
         var randomSystem = IoCManager.Resolve<IRobustRandom>();
         var sharedXformSystem = args.EntityManager.System<SharedTransformSystem>();
+        var atmosSystem = args.EntityManager.System<AtmosphereSystem>();
 
-        var maxrandomtp = 40; // this is how many attempts it will try before breaking the loop -space
+        var maxrandomtp = 50; // this is how many attempts it will try before breaking the loop -space
         var maxrandomradius = 40; // this is the max range it will do -space
 
         if (!args.EntityManager.TryGetComponent<TransformComponent>(uid, out var transformComponent))
@@ -213,11 +216,14 @@ public partial class RitualSacrificeBehavior : RitualCustomBehavior
             var randVector = randomSystem.NextVector2(maxrandomradius);
             newCoords = coords.Offset(randVector);
 
+            xformSystem.SetCoordinates(uid, newCoords); //move person teleported to check if they're under a tile (the tiles intersecting doesnt account for this so we need to do this) -space
+
+            var air = atmosSystem.GetContainingMixture((uid, transformComponent)); //check if the room has any sort of atmos (this prevents getting teleported into solars and grilles outta the station) -space
+
             // if they're not in space and not in wall, it will choose these coords and end the loop -space
-            if (transformComponent.GridUid != null && !lookupSystem.GetEntitiesIntersecting(newCoords.ToMap(args.EntityManager, sharedXformSystem), LookupFlags.Static).Any())
+            if (transformComponent.GridUid != null && air != null && !lookupSystem.GetEntitiesIntersecting(newCoords.ToMap(args.EntityManager, sharedXformSystem), LookupFlags.Static).Any())
                 break;
         }
 
-        xformSystem.SetCoordinates(uid, newCoords);
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Just changed the loop so it actually works like its meant to, and also will now refuse to send you into solars or off station.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It's just better teleporting so you don't get teleported into solars and die a horrible death.

## Technical details
<!-- Summary of code changes for easier review. -->
Added it so it moves the player when testing to see if the spot works. This isn't visible through normal gameplay since its so fast so there's no reason to not do this. This allows me to check if the player has atmos and if they're on a grid.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Getting sacrificed places you in better spots
