### PR TITLE
Heretics and changelings can no longer be revolutionaries

### DIFF
--- a/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
@@ -34,6 +34,8 @@ using Content.Server.Communications;
 using System.Linq;
 using Content.Shared.Chat;
 using Content.Server.Chat.Systems;
+using Content.Shared.Changeling;
+using Content.Shared.Heretic;
 
 namespace Content.Server.GameTicking.Rules;
 
@@ -172,6 +174,10 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
         var alwaysConvertible = HasComp<AlwaysRevolutionaryConvertibleComponent>(ev.Target);
 
         if (!_mind.TryGetMind(ev.Target, out var mindId, out var mind) && !alwaysConvertible)
+            return;
+
+        // funkystation - Heretics and Changelings shouldn't be revved
+        if (HasComp<ChangelingComponent>(ev.Target) || HasComp<HereticComponent>(ev.Target))
             return;
 
         // GoobStation - added check if rev is head rev to enable back his convert ability


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Added a check to see if a player has a Heretic or Changeling component.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Heretics and Changelings able to turn into revolutionaries causes confusion with both groups of players. Heretics have separate goals that need to be achieved (ultimately ascension) and Changelings ultimately don't care about what happens

## Technical details
<!-- Summary of code changes for easier review. -->
See the About.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
- tweak: Changelings and Heretics can no longer be converted to the revolution.
