### PR TITLE
Remove age requirements from the remaining command roles.

### DIFF
--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
@@ -12,8 +12,6 @@
     - !type:DepartmentTimeRequirement
       department: Security
       time: 36000 # 10 hours
-    - !type:AgeRequirement
-      requiredAge: 21
   weight: 20
   startingGear: BlueshieldOfficerGear
   icon: "JobIconNanotrasen"

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/nanotrasen_representative.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/nanotrasen_representative.yml
@@ -7,8 +7,6 @@
     - !type:DepartmentTimeRequirement
       department: Command
       time: 36000  #10 hrs
-    - !type:AgeRequirement
-      requiredAge: 21
   weight: 20
   startingGear: NanotrasenRepresentativeGear
   icon: "JobIconNanotrasenRepresentative"


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Removed the age requirement of BSO and NTR.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
1. No other roles have one.
2. Why put an in-character age requirement on something you should enforce OOC?

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl: sleepyapril
- tweak: Removed BSO and NTR age requirement because no other roles have one.
