### PR TITLE
Minor spelling fixes w/ centcomm & blueshield backpacks

### DIFF
--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Back/backpacks.yml
@@ -10,7 +10,7 @@
 - type: entity
   parent: [ClothingBackpack, BaseCentcommContraband]
   id: ClothingBackpackBlueshield
-  name: bluesheild backpack
+  name: blueshield backpack
   description: A very protective backpack, smells like energy gun.
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Back/backpacks.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Back/backpacks.yml
@@ -1,7 +1,7 @@
 - type: entity
-  parent: ClothingBackpack
+  parent: [ClothingBackpack, BaseCentcommContraband]
   id: ClothingBackpackCentcom
-  name: Centcom backpack
+  name: centcomm backpack
   description: A luxurious backpack, smells like money.
   components:
   - type: Sprite


### PR DESCRIPTION
Goobstation backpacks, not sure if I should add a comment about this or if it's so minor it doesn't matter.
Fixed grammar & spelling in the 2.

:cl: tweak: Fixed spelling of centcomm & blueshield backpacks.