### PR TITLE
Slows down the Survival gamemode a bit

### DIFF
--- a/Content.Server/StationEvents/Components/RampingStationEventSchedulerComponent.cs
+++ b/Content.Server/StationEvents/Components/RampingStationEventSchedulerComponent.cs
@@ -17,7 +17,7 @@ public sealed partial class RampingStationEventSchedulerComponent : Component
     ///     Close to how long you expect a round to last, so you'll probably have to tweak this on downstreams.
     /// </summary>
     [DataField]
-    public float AverageEndTime = 90f;
+    public float AverageEndTime = 120f;
 
     [DataField]
     public float EndTime;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Increased avg. round-end time in RampingStationEventScheduler (the survival scheduler) to 2 hours, which is about what we're aiming for with shifts. Current Survival modes end ramping up considerably after the 1 hour mark which usually ends up with a ninja, a few ratkings, and a dragon spawning within 10 minutes which, while often fun, is a little excessive for what should really be the midround.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: tweak: Slowed down Survival a little bit.
