### PR TITLE
Dynamic doesn't suck now - why was this not done months ago?

### DIFF
--- a/Resources/Locale/en-US/_Goobstation/game-ticking/dynamic.ftl
+++ b/Resources/Locale/en-US/_Goobstation/game-ticking/dynamic.ftl
@@ -5,12 +5,16 @@ dynamic-roundend-points-midround = Midround budget: {$points}.
 dynamic-roundend-gamerules-title = Executed Gamerules:
 
 dynamic-gamerule-unknown-title = Unknown Gamerule
-dynamic-gamerule-traitor-title = [color=crimson]Traitors[/color]
-dynamic-gamerule-changeling-title = [color=yellow]Changelings[/color]
-dynamic-gamerule-heretic-title = [color=purple]Heretics[/color]
+dynamic-gamerule-traitor-low-title = [color=crimson]Traitor - Low[/color]
+dynamic-gamerule-traitor-medium-title = [color=crimson]Traitor - Medium[/color]
+dynamic-gamerule-traitor-high-title = [color=crimson]Traitor - High[/color]
+dynamic-gamerule-changeling-low-title = [color=yellow]Changeling - Low[/color]
+dynamic-gamerule-changeling-high-title = [color=yellow]Changeling - High[/color]
+dynamic-gamerule-heretic-low-title = [color=purple]Heretic - Low[/color]
+dynamic-gamerule-heretic-high-title = [color=purple]Heretic - High[/color]
 dynamic-gamerule-thief-title = [color=gray]Thieves[/color]
-dynamic-gamerule-revolutionary-title = [color=cyan]Revolutionaries[/color]
-dynamic-gamerule-zombies-title = [color=pink]Initial Infected[/color]
+dynamic-gamerule-revolutionary-title = [color=cyan]Revolution[/color]
+dynamic-gamerule-zombies-title = [color=pink]Zombies[/color]
 dynamic-gamerule-nukeops-title = [color=red]Nuclear Emergency[/color]
 
 dynamic-gamerule-threat-perrule = {$num} threat.

--- a/Resources/Prototypes/_Goobstation/GameRules/Dynamic/base.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/Dynamic/base.yml
@@ -15,7 +15,7 @@
   - type: AntagRandomObjectives
     sets:
     - groups: TraitorObjectiveGroups
-    maxDifficulty: 10
+    maxDifficulty: 6 # Funky Station - Fixes upstream objective hell 
   - type: AntagSelection
     agentName: traitor-round-end-agent-name
 

--- a/Resources/Prototypes/_Goobstation/GameRules/Dynamic/dynamic.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/Dynamic/dynamic.yml
@@ -4,13 +4,17 @@
 # - all the other major gamerules are cancelled out (roundstart)
 
 # add all roundstart antags here
-- type: dataset
+- type: dataset # Funky station unfucked dynamic
   id: DynamicRoundstartGamerules
   values:
-  - TraitorDynamic # traitors
+  - TraitorDynamicLow # traitors
+  - TraitorDynamicMedium
+  - TraitorDynamicHigh
   - ThiefDynamic # thieves (spy todo)
-  - ChangelingDynamic # changelings
-  - HereticDynamic # heretics
+  - ChangelingDynamicLow # changelings
+  - ChangelingDynamicHigh
+  - HereticDynamicLow # heretics
+  - HereticDynamicHigh
   - RevolutionDynamic # revs (M)
   - NukeopsDynamic # nukies (M)
   # cult todo (M)

--- a/Resources/Prototypes/_Goobstation/GameRules/Dynamic/midround.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/Dynamic/midround.yml
@@ -1,15 +1,16 @@
 # same with roundstart, highImpact means it can only be spawned once
 # the only weights that work are in DynamicRuleset
+# Many changes to unfuck it - Funky Station
 
 # Midround Traitors
 - type: entity
-  parent: TraitorDynamic
+  parent: TraitorDynamicLow # shityml but does the job to be fair, better than pre-unfuck
   id: TraitorDynamicMidround
   components:
   - type: DynamicRuleset
     nameLoc: dynamic-gamerule-midround-traitor-title
-    weight: 8
-    cost: 3
+    weight: 30 
+    cost: 9 # Lmao at 3 cost, the average game has 10-30 midgame pretty often
   - type: StationEvent
     earliestStart: 30
     weight: 10
@@ -23,13 +24,13 @@
 
 # Midround Changelings
 - type: entity
-  parent: ChangelingDynamic
+  parent: ChangelingDynamicLow
   id: ChangelingDynamicMidround
   components:
   - type: DynamicRuleset
     nameLoc: dynamic-gamerule-midround-changeling-title
-    weight: 4
-    cost: 6
+    weight: 15
+    cost: 12 
   - type: StationEvent
     earliestStart: 20
     weight: 3
@@ -43,13 +44,13 @@
 
 # Midround Heretics
 - type: entity
-  parent: HereticDynamic
+  parent: HereticDynamicLow
   id: HereticDynamicMidround
   components:
   - type: DynamicRuleset
     nameLoc: dynamic-gamerule-midround-heretic-title
-    weight: 4
-    cost: 5
+    weight: 15
+    cost: 15
   - type: StationEvent
     earliestStart: 20 
     weight: 3 
@@ -68,8 +69,8 @@
   components:
   - type: DynamicRuleset
     nameLoc: dynamic-gamerule-midround-revolutionary-title
-    weight: 3
-    cost: 7
+    weight: 5
+    cost: 30
     highImpact: true
   - type: StationEvent
     earliestStart: 20 
@@ -86,8 +87,8 @@
   components:
   - type: DynamicRuleset
     nameLoc: dynamic-gamerule-skeleton-title
-    weight: 6
-    cost: 3
+    weight: 20
+    cost: 5
   - type: StationEvent
     weight: 5
     duration: 1
@@ -102,8 +103,8 @@
   components:
   - type: DynamicRuleset
     nameLoc: dynamic-gamerule-dragon-title
-    weight: 4
-    cost: 7
+    weight: 10
+    cost: 15
     highImpact: true
   - type: StationEvent
     weight: 6.5
@@ -136,8 +137,8 @@
   components:
   - type: DynamicRuleset
     nameLoc: dynamic-gamerule-ninja-title
-    weight: 4
-    cost: 7
+    weight: 10
+    cost: 10
     highImpact: true
   - type: StationEvent
     weight: 6
@@ -190,8 +191,8 @@
   components:
   - type: DynamicRuleset
     nameLoc: dynamic-gamerule-revenant-title
-    weight: 4
-    cost: 5
+    weight: 5
+    cost: 7
     highImpact: true
   - type: StationEvent
     weight: 7.5
@@ -208,8 +209,8 @@
   components:
   - type: DynamicRuleset
     nameLoc: dynamic-gamerule-midround-zombies-title
-    weight: 2
-    cost: 10
+    weight: 5
+    cost: 30
     highImpact: true
   - type: StationEvent
     earliestStart: 90
@@ -220,8 +221,8 @@
   - type: AntagSelection
     definitions:
     - prefRoles: [ InitialInfected ]
-      max: 3
-      playerRatio: 10
+      max: 4
+      playerRatio: 15
       blacklist:
         components:
         - ZombieImmune
@@ -247,8 +248,8 @@
   components:
   - type: DynamicRuleset
     nameLoc: dynamic-gamerule-loneop-title
-    weight: 4
-    cost: 7
+    weight: 5
+    cost: 15
     highImpact: true
   - type: StationEvent
     earliestStart: 35
@@ -286,8 +287,8 @@
   components:
   - type: DynamicRuleset
     nameLoc: dynamic-gamerule-ratking-title
-    weight: 4
-    cost: 5
+    weight: 10
+    cost: 7
     highImpact: true
   - type: StationEvent
     startAnnouncement: station-event-vent-creatures-start-announcement

--- a/Resources/Prototypes/_Goobstation/GameRules/Dynamic/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/Dynamic/roundstart.yml
@@ -1,39 +1,93 @@
 # major antags that get picked once during roundstart.
 # the max number of antags is so small because it's used for midround events too.
 # regards.
+# Funky Station unfucked dynamic, not gonna mark EVERY change here.
+# Guide to adding shit:
+# Low/Mid Threat Antag - 5 weight low [2 max, 30 Player Ratio] and a 10 weight high [4 max, 20 player ratio]
+# Side Antag like obsessed - Copy thief and replace the antag and cost accordingly
+# Major Team Antag - Always 5 weight unless major team are ALL too rare, then up all by 1. High impact.
+# High Threat Solo AKA wizard - 10 weight, 1-2 antags at a high level cost. Probably needs their own "only one" category like high impact
+# As extra antags get added, increase basic tot weight
+# Love, the girl that unfucked dynamic <3 - Funky Station
 
-# Traitor
+# Traitor - Low Threat Solo
 - type: entity
   parent: BaseTraitorRuleDynamic
-  id: TraitorDynamic
+  id: TraitorDynamicLow
   components:
   - type: DynamicRuleset
-    nameLoc: dynamic-gamerule-traitor-title
+    nameLoc: dynamic-gamerule-traitor-low-title
     weight: 5
-    cost: 8
-    scalingCost: 9
+    cost: 7
+    scalingCost: 8
+  - type: GameRule
+    minPlayers: 45 # when the difference between low/med/high actually changes antag count
   - type: AntagSelection
     definitions:
     - prefRoles: [ Traitor ]
       max: 2
-      playerRatio: 10
+      playerRatio: 30
       blacklist:
         components:
         - AntagImmune
       lateJoinAdditional: true
       mindRoles:
       - MindRoleTraitor
-
-# Thief (Spy wyci)
+      
+- type: entity
+  parent: BaseTraitorRuleDynamic
+  id: TraitorDynamicMedium
+  components:
+  - type: DynamicRuleset
+    nameLoc: dynamic-gamerule-traitor-medium-title
+    weight: 15
+    cost: 16
+    scalingCost: 18
+  - type: AntagSelection
+    definitions:
+    - prefRoles: [ Traitor ]
+      max: 4
+      playerRatio: 20
+      blacklist:
+        components:
+        - AntagImmune
+      lateJoinAdditional: true
+      mindRoles:
+      - MindRoleTraitor
+      
+- type: entity
+  parent: BaseTraitorRuleDynamic
+  id: TraitorDynamicHigh
+  components:
+  - type: DynamicRuleset
+    nameLoc: dynamic-gamerule-traitor-high-title
+    weight: 10
+    cost: 25
+    scalingCost: 28
+  - type: GameRule
+    minPlayers: 30
+  - type: AntagSelection
+    definitions:
+    - prefRoles: [ Traitor ]
+      max: 6
+      playerRatio: 15
+      blacklist:
+        components:
+        - AntagImmune
+      lateJoinAdditional: true
+      mindRoles:
+      - MindRoleTraitor
+      
+# Thief (Spy wyci) - Low Threat Solo, Side Antag
 - type: entity
   parent: BaseGameRuleDynamic
   id: ThiefDynamic
   components:
   - type: DynamicRuleset
     nameLoc: dynamic-gamerule-thief-title
-    weight: 5
-    cost: 8
-    scalingCost: 9
+    weight: 20 # Technically the highest, but other antags have to spread their weight. Better than same as tot at least. - Funky
+    cost: 6
+    scalingCost: 7
   - type: ThiefRule
   - type: AntagObjectives
     objectives:
@@ -51,7 +105,7 @@
     definitions:
     - prefRoles: [ Thief ]
       max: 2
-      playerRatio: 15
+      playerRatio: 25
       lateJoinAdditional: true
       allowNonHumans: true
       multiAntagSetting: NotExclusive
@@ -61,19 +115,19 @@
       briefing:
         sound: "/Audio/Misc/thief_greeting.ogg"
 
-# Changeling
+# Changeling - Medium Threat Solo 
 - type: entity
   parent: BaseGameRuleDynamic
-  id: ChangelingDynamic
+  id: ChangelingDynamicLow
   components:
   - type: DynamicRuleset
-    nameLoc: dynamic-gamerule-changeling-title
-    weight: 3
-    cost: 16
-    scalingCost: 10
+    nameLoc: dynamic-gamerule-changeling-low-title
+    weight: 5
+    cost: 10
+    scalingCost: 11
   - type: ChangelingRule
   - type: GameRule
-    minPlayers: 15
+    minPlayers: 40 # 40 required to make the low preset different from high
   - type: AntagObjectives
     objectives:
     - ChangelingStealDNAObjective
@@ -84,7 +138,7 @@
     definitions:
     - prefRoles: [ Changeling ]
       max: 2
-      playerRatio: 10
+      playerRatio: 30
       blacklist:
         components:
         - AntagImmune
@@ -94,16 +148,78 @@
       mindRoles:
       - MindRoleChangeling
 
-# Heretic
 - type: entity
   parent: BaseGameRuleDynamic
-  id: HereticDynamic
+  id: ChangelingDynamicHigh
   components:
   - type: DynamicRuleset
-    nameLoc: dynamic-gamerule-heretic-title
-    weight: 3
-    cost: 10
-    scalingCost: 9
+    nameLoc: dynamic-gamerule-changeling-high-title
+    weight: 10
+    cost: 21
+    scalingCost: 23
+  - type: ChangelingRule
+  - type: GameRule
+    minPlayers: 20 # Changelings are great low pop antags but it doesn't work for dynamic that well :[ 
+  - type: AntagObjectives
+    objectives:
+    - ChangelingStealDNAObjective
+    - EscapeIdentityObjective
+    - ChangelingSurviveObjective
+  - type: AntagSelection
+    agentName: changeling-roundend-name
+    definitions:
+    - prefRoles: [ Changeling ]
+      max: 4
+      playerRatio: 20
+      blacklist:
+        components:
+        - AntagImmune
+        - Traitor
+        - Heretic
+      lateJoinAdditional: true
+      mindRoles:
+      - MindRoleChangeling
+
+# Heretic - Medium Threat Solo
+- type: entity
+  parent: BaseGameRuleDynamic
+  id: HereticDynamicLow
+  components:
+  - type: DynamicRuleset
+    nameLoc: dynamic-gamerule-heretic-low-title
+    weight: 5
+    cost: 12
+    scalingCost: 13
+  - type: HereticRule
+  - type: GameRule
+    minPlayers: 40
+  - type: AntagSelection
+    agentName: heretic-roundend-name
+    definitions:
+    - prefRoles: [ Heretic ]
+      max: 2
+      playerRatio: 30
+      blacklist:
+        components:
+        - AntagImmune
+      lateJoinAdditional: true
+      mindRoles:
+      - MindRoleHeretic
+  - type: AntagObjectives
+    objectives:
+    - HereticKnowledgeObjective
+    - HereticSacrificeObjective
+    - HereticSacrificeHeadObjective
+
+- type: entity
+  parent: BaseGameRuleDynamic
+  id: HereticDynamicHigh
+  components:
+  - type: DynamicRuleset
+    nameLoc: dynamic-gamerule-heretic-high-title
+    weight: 10
+    cost: 24
+    scalingCost: 26
   - type: HereticRule
   - type: GameRule
     minPlayers: 20
@@ -111,8 +227,8 @@
     agentName: heretic-roundend-name
     definitions:
     - prefRoles: [ Heretic ]
-      max: 2
-      playerRatio: 15
+      max: 4
+      playerRatio: 20
       blacklist:
         components:
         - AntagImmune
@@ -132,8 +248,8 @@
   components:
   - type: DynamicRuleset
     nameLoc: dynamic-gamerule-revolutionary-title
-    weight: 3
-    cost: 20
+    weight: 10 # Take 5 from this to add to cult when that comes- majors are intended to be 5 weight :3
+    cost: 25
     highImpact: true
   - type: RevolutionaryRule
   - type: GameRule
@@ -142,7 +258,7 @@
     definitions:
     - prefRoles: [ HeadRev ]
       max: 3
-      playerRatio: 15
+      playerRatio: 20
       blacklist:
         components:
         - AntagImmune
@@ -165,8 +281,8 @@
   components:
   - type: DynamicRuleset
     nameLoc: dynamic-gamerule-nukeops-title
-    weight: 3
-    cost: 20
+    weight: 10 # Take 5 from here when wiz gets added and add that to wizard
+    cost: 25
     highImpact: true
   - type: GameRule
     minPlayers: 25


### PR DESCRIPTION
## About the PR
Dynamic is not laughably bad anymore, and _actually_ scales past the 20 player mark. 

## Why / Balance
Traitor objectives - 10 shits out 4-6 objective games regularly. 6 brings that back to the 2-4 we all know from back in the day and probably love. 

Midgame Changes - Shit actually depletes the threat level more than maybe 10 a game when it regularly is at 15-30, and major antags actually require the game to of dumped threat into mid game [Leaving very little for the start] or the shift to be at shitfest levels already.

Costs have generally been readjusted, with the solo antags generally being in the same realm without being EXACTLY the same- Lings aren't literally double traitors, just  a little extra, and heretics a little extra than lings- and on the other side thieves slightly less than traitors, not exactly the same.

Scaling has been "implemented" [An actual attempt requires a recode of dynamic and the entire gamerule system and 95% of the same effect can be done by .yml, not worth the effort really] by splitting the traitor gamerule into 3 [Low/Med/High] and Lings/Heretics into 2 [Low/High] - Low for scales as 2 max at 30 ratio, Traitor's medium and the rest's high scales as 4 max at 20 ratio [AKA an attempt at half the average game of lings/tots], and Traitor's High scales as 6 at a 15 ratio. Lings and Heretics break down at higher antag counts thus no larger variant.

The average game has around 40-60 Threat and 2/3rds often goes to game start antags- aka 30-40 threat, which has been set as the general balance point with tot medium/rest high set as around half or so of this level. Low's usually slightly below half and traitor's high slightly above 1.5x half. The intent's to make most games w/ 0 major antags 1/10 antags or so, mixing 2 or so rules with smaller and larger rules being rarer but making some variety. Thieves are excluded and stay as a low cost 2 max rule as they are a side antag, with the playerratio increased. Thieves weigh higher than ling/heretic but less than traitor, ending thief spam while keeping them common as they only spawn 2 max.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Dynamic Traitors have normal objective count now. Say "Byeeee!!!" to 5 kill objective games or the grand theft ripoff thief.
- fix: Dynamic actually scales past 20 players now.
- fix: Midround antags actually use more than... 3 threat... thanks, real smart. AKA, Midround threat level actually gets used and matters.
- tweak: Costs and weights for dynamic have been majorly reworked. Changelings don't eat crazy threat, Thieves don't spawn like crazy, and Traitors actually share codewords with more than one person and are the common antag they are supposed to be.
