### PR TITLE
oops - SOP fix!

### DIFF
--- a/Resources/Prototypes/_Funkystation/Guidebook/sop.yml
+++ b/Resources/Prototypes/_Funkystation/Guidebook/sop.yml
@@ -7,6 +7,8 @@
   - SecuritySOP
   - MedicalSOP
   - ServiceSOP
+  - EngineeringSOP
+  - CargoSOP
   - AlertLevelsSOP
   - EnemiesOfTheCorporation
 


### PR DESCRIPTION
Moved Cargo & Engineering SOP back down to SOP 101 :)

:cl:
- fix: SOP placement error in guidebook