### PR TITLE
John Ion Storm

### DIFF
--- a/Resources/Prototypes/Datasets/ion_storm.yml
+++ b/Resources/Prototypes/Datasets/ion_storm.yml
@@ -355,6 +355,7 @@
   - STATION ENGINEERS
   # - VIROLOGISTS
   - WARDENS
+  - JOHNS
 
 # only including complex dangerous or funny drinks no water allowed
 - type: dataset
@@ -977,6 +978,7 @@
   - XENOS
   - ZOMBIES
   - ZOMBIE MICE
+  - JOHNS
 
 - type: dataset
   id: IonStormVerbs


### PR DESCRIPTION

## About the PR
Added Johns to ion storm laws, as threats and part of the crew

## Why / Balance
JOHNS MUST NEVER BE ALLOWED TO ESCAPE HUMAN HARM

:cl:
- add: Johns are now included in ion storm laws


