### PR TITLE
Aloxadone buffed to the original vision

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1230,7 +1230,7 @@
           max: 213.0
         damage:
           types:
-            Heat: -3.0
+            Heat: -5.0
             Shock: -3.0
             Caustic: -1.0
 

--- a/Resources/Prototypes/Recipes/Reactions/medicine.yml
+++ b/Resources/Prototypes/Recipes/Reactions/medicine.yml
@@ -589,13 +589,13 @@
   impact: Medium
   reactants:
     Cryoxadone:
-      amount: 1
+      amount: 3
     Aloe:
-      amount: 2
+      amount: 1
     Sigynate:
-      amount: 2
+      amount: 1
   products:
-      Aloxadone: 4
+      Aloxadone: 5
 
 - type: reaction
   id: Psicodine


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Buffed Aloxadone to what I had wanted it to be originally. Boosting it's heat healing from 3 to 5, and changing the recipe to be less costly.

## Why / Balance
Aloxadone was originally made very expensive by me to appeal to WizDen maintainers, even if it made it fairly annoying to actually make and use. This buffs it to how near what I had originally envisioned it to be.

## Media
![image](https://github.com/user-attachments/assets/311672bb-1e21-4ee0-9e5c-611d60cdb1f6)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl:
- tweak: Aloxadone now heals 5 heat damage, up from 3.
- tweak: Aloxadone's recipe has been buffed to be 20u Aloe, 20u Sigynate, and 60u Cryoxadone for 100u Aloxadone. This results in 2.5x more product per resource intensive ingredient.
