### PR TITLE
Barratrauma

### DIFF
--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -20,5 +20,5 @@
   - Train
   - FlandHighPop
   - OasisHighPop
-  - Barratry # Goobstation - Re-add barratry
+  #- Barratry # Goobstation - Re-add barratry - Funkystation - Barratrauma
   - Kettle # Goobstation - Re-add kettle (before it was gemini!)


### PR DESCRIPTION
Removes Barratry from the map pool

:cl:
- remove: Removes Barratry from the map pool