### PR TITLE
Adjust healium effects for balance

### DIFF
--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -474,6 +474,7 @@
         - !type:ReagentThreshold
           reagent: Healium
           min: 1
+          max: 15
         scaleByQuantity: true
         ignoreResistances: true
         damage:
@@ -481,11 +482,22 @@
             Burn: -2
             Toxin: -5
             Brute: -2
+      - !type:HealthChange
+        conditions:
+        - !type:ReagentThreshold
+          reagent: Healium
+          min: 15
+        ignoreResistances: true
+        damage:
+          groups:
+            Burn: -12
+            Toxin: -25
+            Brute: -12
       - !type:PopupMessage
         conditions:
         - !type:ReagentThreshold
           reagent: Healium
-          min: 1.5
+          min: 4
         type: Local
         visualType: Medium
         messages: [ "effect-sleepy" ]
@@ -494,17 +506,17 @@
         conditions:
         - !type:ReagentThreshold
           reagent: Healium
-          min: 6
+          min: 8
         key: ForcedSleep
         component: ForcedSleeping
         time: 3
         type: Add
       - !type:Drunk
-        boozePower: 50
+        boozePower: 150
         conditions:
         - !type:ReagentThreshold
           reagent: Healium
-          min: 3
+          min: 4
     Medicine:
       effects:
       - !type:HealthChange


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Healium now has an upwards limit on how much it can heal, as well as increased booze power. At it's strongest, healium heals about as quickly as cryo does. You can also use slightly more before being forced asleep. 

## Why / Balance
Healium was too over-powered, allowing people to heal massive amounts of damage in a single a breath. It may still need some more tweaks, but very much needed to be nerfed. 

## Technical details
Changed some yaml properties

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None

**Changelog**
:cl:
- tweak: Added max heal rate to healium
- tweak: Increase healium booze power
- tweak: Increase healium minimum mols needed to force user asleep.