### PR TITLE
SmartFridge is now unanchorable, also takes Syringes

### DIFF
--- a/Content.Server/_Funkystation/Medical/SmartFridge/SmartFridgeSystem.cs
+++ b/Content.Server/_Funkystation/Medical/SmartFridge/SmartFridgeSystem.cs
@@ -1,5 +1,7 @@
-﻿using Content.Server.Power.EntitySystems;
+﻿using Content.Server.Interaction;
+using Content.Server.Power.EntitySystems;
 using Content.Shared._Funkystation.Medical.SmartFridge;
+using Content.Shared.Construction.EntitySystems;
 using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Interaction;
 using Content.Shared.Tag;
@@ -10,6 +12,8 @@ namespace Content.Server._Funkystation.Medical.SmartFridge;
 public sealed class SmartFridgeSystem : SharedSmartFridgeSystem
 {
     [Dependency] private readonly ItemSlotsSystem _itemSlotsSystem = default!;
+    [Dependency] private readonly AnchorableSystem _anchorable = default!;
+    [Dependency] private readonly IEntityManager _entityManager = default!;
     [Dependency] private readonly TagSystem _tags = default!;
     [Dependency] private readonly AudioSystem _audio = default!;
 
@@ -30,6 +34,19 @@ public sealed class SmartFridgeSystem : SharedSmartFridgeSystem
 
     private void OnInteractEvent(EntityUid entity, SmartFridgeComponent component, ref InteractUsingEvent ev)
     {
+        if (_tags.HasTag(ev.Used, "Wrench"))
+        {
+            _anchorable.TryToggleAnchor(entity, ev.User, ev.Used);
+
+            ev.Handled = true;
+        }
+
+        if (!_anchorable.IsPowered(entity, _entityManager))
+        {
+            ev.Handled = true;
+            return;
+        }
+
         if (component.StorageWhitelist != null)
         {
             if (!_tags.HasAnyTag(ev.Used, component.StorageWhitelist.Tags!.ToArray()))

--- a/Resources/Prototypes/Entities/Structures/Machines/smartfridge.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/smartfridge.yml
@@ -8,9 +8,11 @@
     storageWhitelist:
       tags:
       - PillCanister
-      - Meat
+      - MeatF
+      - Cooked
       - ChemDispensable
       - Bottle
+      - Syringe
   - type: ActivatableUI
     key: enum.SmartFridgeUiKey.Key
   - type: ActivatableUIRequiresPower
@@ -33,7 +35,10 @@
       map: ["enum.StorageVisualLayers.Door"]
       shader: unshaded
   - type: ApcPowerReceiver
-    powerLoad: 0
+    powerLoad: 100
+  - type: ExtensionCableReceiver
+  - type: LightningTarget
+    priority: 1
   - type: EntityStorageVisuals
     stateBaseClosed: smartfridge
     stateDoorOpen: smartfridge_open
@@ -46,7 +51,7 @@
     bodyType: Static
   - type: Transform
     noRot: true
-    anchored: True
+    anchored: true
   - type: Fixtures
     fixtures:
       fix1:

--- a/Resources/Prototypes/Entities/Structures/Machines/smartfridge.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/smartfridge.yml
@@ -8,7 +8,7 @@
     storageWhitelist:
       tags:
       - PillCanister
-      - MeatF
+      - Meat
       - Cooked
       - ChemDispensable
       - Bottle


### PR DESCRIPTION
## About the PR
Title

## Why / Balance
good

## Technical details
adds a component and now checks for a Wrench tag on OnInteractEvent

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: SmartFridge can now store syringes.
- fix: SmartFridge can now be unanchored.
