### PR TITLE
Adds the revolutionary flashbang

### DIFF
--- a/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/TriggerSystem.cs
@@ -33,6 +33,7 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Player;
 using Content.Shared.Coordinates;
+using Content.Shared.Revolutionary;
 using Robust.Shared.Utility;
 using Robust.Shared.Timing;
 
@@ -109,6 +110,8 @@ namespace Content.Server.Explosion.EntitySystems
             SubscribeLocalEvent<SoundOnTriggerComponent, TriggerEvent>(OnSoundTrigger);
             SubscribeLocalEvent<ShockOnTriggerComponent, TriggerEvent>(HandleShockTrigger);
             SubscribeLocalEvent<RattleComponent, TriggerEvent>(HandleRattleTrigger);
+
+            SubscribeLocalEvent<RevolutionaryFlashOnTriggerComponent, TriggerEvent>(HandleRevolutionaryFlashTrigger); // funkystation
         }
 
         private void OnSoundTrigger(EntityUid uid, SoundOnTriggerComponent component, TriggerEvent args)
@@ -177,6 +180,13 @@ namespace Content.Server.Explosion.EntitySystems
         {
             // TODO Make flash durations sane ffs.
             _flashSystem.FlashArea(uid, args.User, component.Range, component.Duration * 1000f, probability: component.Probability);
+            args.Handled = true;
+        }
+
+        // funkystation - no other clear way to do this
+        private void HandleRevolutionaryFlashTrigger(EntityUid uid, RevolutionaryFlashOnTriggerComponent comp, TriggerEvent args)
+        {
+            _flashSystem.RevolutionaryFlashArea(uid, args.User, comp.Range, comp.Duration * 1000f, probability: comp.Probability);
             args.Handled = true;
         }
 

--- a/Content.Server/Flash/FlashSystem.cs
+++ b/Content.Server/Flash/FlashSystem.cs
@@ -114,7 +114,8 @@ namespace Content.Server.Flash
             float slowTo,
             bool displayPopup = true,
             bool melee = false,
-            TimeSpan? stunDuration = null)
+            TimeSpan? stunDuration = null,
+            bool revFlash = false)
         {
             var attempt = new FlashAttemptEvent(target, user, used);
             RaiseLocalEvent(target, attempt, true);
@@ -142,7 +143,7 @@ namespace Content.Server.Flash
                     ("user", Identity.Entity(user.Value, EntityManager))), target, target);
             }
 
-            if (melee)
+            if (melee || revFlash)
             {
                 var ev = new AfterFlashedEvent(target, user, used);
                 if (user != null)
@@ -175,6 +176,35 @@ namespace Content.Server.Flash
 
                 // They shouldn't have flash removed in between right?
                 Flash(entity, user, source, duration, slowTo, displayPopup);
+            }
+
+            _audio.PlayPvs(sound, source, AudioParams.Default.WithVolume(1f).WithMaxDistance(3f));
+        }
+
+        // funkystation: copy and paste of above, cry about it
+        public void RevolutionaryFlashArea(Entity<FlashComponent?> source, EntityUid? user, float range, float duration, float slowTo = 0.8f, bool displayPopup = false, float probability = 1f, SoundSpecifier? sound = null)
+        {
+            var transform = Transform(source);
+            var mapPosition = _transform.GetMapCoordinates(transform);
+            var statusEffectsQuery = GetEntityQuery<StatusEffectsComponent>();
+            var damagedByFlashingQuery = GetEntityQuery<DamagedByFlashingComponent>();
+
+            foreach (var entity in _entityLookup.GetEntitiesInRange(transform.Coordinates, range))
+            {
+                if (!_random.Prob(probability))
+                    continue;
+
+                // Is the entity affected by the flash either through status effects or by taking damage?
+                if (!statusEffectsQuery.HasComponent(entity) && !damagedByFlashingQuery.HasComponent(entity))
+                    continue;
+
+                // Check for entites in view
+                // put damagedByFlashingComponent in the predicate because shadow anomalies block vision.
+                if (!_examine.InRangeUnOccluded(entity, mapPosition, range, predicate: (e) => damagedByFlashingQuery.HasComponent(e)))
+                    continue;
+
+                // They shouldn't have flash removed in between right?
+                Flash(entity, user, source, duration, slowTo, displayPopup, true, null, true);
             }
 
             _audio.PlayPvs(sound, source, AudioParams.Default.WithVolume(1f).WithMaxDistance(3f));

--- a/Content.Server/_Funkystation/Construction/Condition/RevolutionaryCrafterHasComponent.cs
+++ b/Content.Server/_Funkystation/Construction/Condition/RevolutionaryCrafterHasComponent.cs
@@ -1,0 +1,68 @@
+using Content.Shared.Construction;
+using Content.Shared.Examine;
+using Content.Shared.Mind;
+using JetBrains.Annotations;
+using Robust.Shared.Utility;
+using Content.Shared.Item;
+using Content.Shared.Revolutionary.Components;
+
+namespace Content.Server.Construction.Conditions;
+
+/// <summary>
+/// A graph condition to see if a crafter has a certain component. Useful if you want certain
+/// recipes only accessible by "knowledge" or some other mechanic. Only works if the item
+/// is parented to their character, which, I know, drawback.
+/// </summary>
+[UsedImplicitly]
+[DataDefinition]
+public sealed partial class RevolutionaryCrafterHasRecipeComponent : IGraphCondition
+{
+    [DataField]
+    public string? GuideText { get; private set; }
+    [DataField]
+    public SpriteSpecifier? GuideIcon { get; private set; }
+
+    public bool Condition(EntityUid uid, IEntityManager entityManager)
+    {
+        var minds = entityManager.System<SharedMindSystem>();
+        var transformComponent = entityManager.GetComponentOrNull<TransformComponent>(uid);
+
+        if (transformComponent == null)
+            return false;
+
+        if (!minds.TryGetMind(transformComponent.ParentUid, out _, out var mindComp))
+            return false;
+
+        if (mindComp.CurrentEntity == null)
+            return false;
+
+        var headRevComp = entityManager.GetComponentOrNull<HeadRevolutionaryComponent>(mindComp.CurrentEntity);
+
+        return headRevComp != null;
+    }
+
+    public bool DoExamine(ExaminedEvent args)
+    {
+        var entity = args.Examined;
+
+        var entMan = IoCManager.Resolve<IEntityManager>();
+
+        if (!entMan.TryGetComponent(entity, out ItemComponent? item)) return false;
+
+        args.PushMarkup("Something might happen if you use a screwdriver on it.");
+
+        return true;
+    }
+
+    public IEnumerable<ConstructionGuideEntry> GenerateGuideEntry()
+    {
+        if (GuideText == null)
+                yield break;
+
+        yield return new ConstructionGuideEntry()
+        {
+            Localization = GuideText,
+            Icon = GuideIcon,
+        };
+    }
+}

--- a/Content.Shared/_Funkystation/Revolutionary/RevolutionaryFlashOnTriggerComponent.cs
+++ b/Content.Shared/_Funkystation/Revolutionary/RevolutionaryFlashOnTriggerComponent.cs
@@ -1,0 +1,11 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Revolutionary;
+
+[RegisterComponent, NetworkedComponent]
+public sealed partial class RevolutionaryFlashOnTriggerComponent : Component
+{
+    [DataField] public float Range = 1.0f;
+    [DataField] public float Duration = 8.0f;
+    [DataField] public float Probability = 1.0f;
+}

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -80,7 +80,10 @@
   - type: GuideHelp
     guides:
     - Security
-    - Antagonists
+    - Antagonistsx
+  - type: Construction
+    graph: RevolutionaryFlashbangGraph
+    node: start
 
 - type: entity
   id: GrenadeFlashEffect

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/grenades.yml
@@ -80,7 +80,7 @@
   - type: GuideHelp
     guides:
     - Security
-    - Antagonistsx
+    - Antagonists
   - type: Construction
     graph: RevolutionaryFlashbangGraph
     node: start

--- a/Resources/Prototypes/_Funkystation/Entities/Weapons/revolutionary_flashbang.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Weapons/revolutionary_flashbang.yml
@@ -1,0 +1,24 @@
+- type: entity
+  name: revolutionary flashbang
+  description: Viva.
+  parent: [ GrenadeBase, BaseSyndicateContraband ]
+  id: GrenadeFlashBangRevolutionary
+  components:
+  - type: Sprite
+    sprite: Objects/Weapons/Grenades/flashbang.rsi
+  - type: RevolutionaryFlashOnTrigger
+    range: 7
+  - type: SoundOnTrigger
+    sound:
+      path: "/Audio/Effects/flash_bang.ogg"
+  - type: DeleteOnTrigger
+  - type: SpawnOnTrigger
+    proto: GrenadeFlashEffect
+  - type: Appearance
+  - type: TimerTriggerVisuals
+    primingSound:
+      path: /Audio/Effects/countdown.ogg
+  - type: GuideHelp
+    guides:
+    - Security
+    - Antagonists

--- a/Resources/Prototypes/_Funkystation/Recipes/Revolutionary/revolutionary_flashbang.yml
+++ b/Resources/Prototypes/_Funkystation/Recipes/Revolutionary/revolutionary_flashbang.yml
@@ -1,0 +1,21 @@
+- type: constructionGraph
+  id: RevolutionaryFlashbangGraph
+  start: start
+  graph:
+  - node: start
+    edges:
+    - to: revFlashbang
+      completed:
+      - !type:AdminLog
+        message: "A revolutionary flashbang was crafted"
+      - !type:SpawnPrototype
+        prototype: GrenadeFlashBangRevolutionary
+      - !type:DeleteEntity {}
+      conditions:
+      - !type:RevolutionaryCrafterHasRecipeComponent
+      steps:
+      - tool: Screwing
+        doAfter: 15
+
+  - node: revFlashbang
+    entity: GrenadeFlashBangRevolutionary


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Exactly what it sounds like. They can also be crafted by using a screwdriver on a flashbang, with a 15 second do after. Regular revolutionaries / non revs cannot craft them. Head revs are the only ones who can activate and use the flashbang like you would expect it to. Regular revolutionaries cannot.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Funny as hell (plus I felt it was missing)

## Technical details
<!-- Summary of code changes for easier review. -->
Adds a RevolutionaryFlashOnTrigger comp, as well as a RevolutionaryCrafterHasComponent construction condition. plus some more yamling

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
wizden changes

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
- add: The revolutionary flashbang, a new favorite for young revolutionaries.
