### PR TITLE
Revolutionary Balance Changes

### DIFF
--- a/Content.Shared/Implants/Components/ImplanterComponent.cs
+++ b/Content.Shared/Implants/Components/ImplanterComponent.cs
@@ -49,7 +49,7 @@ public sealed partial class ImplanterComponent : Component
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField]
-    public float DrawTime = 60f;
+    public float DrawTime = 20f; // funkystation ^ yeah fucking right lmao
 
     /// <summary>
     /// Good for single-use injectors

--- a/Resources/Prototypes/Catalog/Fills/Crates/medical.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/medical.yml
@@ -46,12 +46,12 @@
   id: CrateMindShieldImplants
   parent: CrateMedical
   name: MindShield implant crate
-  description: Crate filled with 3 MindShield implants.
+  description: Crate filled with 6 MindShield implants. # funkystation
   components:
   - type: StorageFill
     contents:
       - id: MindShieldImplanter
-        amount: 3
+        amount: 6 # funkystation - revs balance
 
 - type: entity
   id: CrateMedicalSurgery

--- a/Resources/Prototypes/Recipes/Lathes/medical.yml
+++ b/Resources/Prototypes/Recipes/Lathes/medical.yml
@@ -116,8 +116,8 @@
   result: Implanter
   completetime: 1
   materials:
-    Glass: 500
-    Steel: 500
+    Glass: 200 # funkystation - implanters are cheaper
+    Steel: 200
 
 - type: latheRecipe
   id: Defibrillator


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
I'm not doing 3 prs for simple yaml changes.

* Reduces implant remover time by 40 seconds.
* Doubles the amount of mindshields in a crate.
* Implanters are now cheaper, only costing 2 glass and 2 steel. 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Rev's should be encouraged to find alternative ways to do a successful revolution, and in a way that's also lore friendly. Capturing command should be made easier, and removing the implants of security should also be made easier. Mindshields also need to be more plentiful, as it makes it easier for command to respond to a rev threat.

## Technical details
<!-- Summary of code changes for easier review. -->
yaml

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Mindshields come in crates of 6 now.
- tweak: Implanters now cost 2 glass and 2 steel.
- tweak: Implanters can now remove implants in 20 seconds now.
