### PR TITLE
Ling biomass change + Headslug buff

### DIFF
--- a/Content.Server/_Goobstation/Changeling/ChangelingSystem.Abilities.cs
+++ b/Content.Server/_Goobstation/Changeling/ChangelingSystem.Abilities.cs
@@ -601,6 +601,14 @@ public sealed partial class ChangelingSystem : EntitySystem
         if (!TryUseAbility(uid, comp, args))
             return;
 
+        if (TryComp<CuffableComponent>(uid, out var cuffs) && cuffs.Container.ContainedEntities.Count > 0)
+        {
+            var cuff = cuffs.LastAddedCuffs;
+
+            _cuffs.Uncuff(uid, cuffs.LastAddedCuffs, cuff);
+            QueueDel(cuff);
+        }
+
         comp.IsInLastResort = true;
 
         var newUid = TransformEntity(

--- a/Content.Server/_Goobstation/Changeling/ChangelingSystem.cs
+++ b/Content.Server/_Goobstation/Changeling/ChangelingSystem.cs
@@ -180,7 +180,7 @@ public sealed partial class ChangelingSystem : EntitySystem
     }
     private void UpdateBiomass(EntityUid uid, ChangelingComponent comp, float? amount = null)
     {
-        comp.Biomass += amount ?? -1;
+        comp.Biomass += amount ?? -0.5f; // #funkystation, nerfs the drain to half
         comp.Biomass = Math.Clamp(comp.Biomass, 0, comp.MaxBiomass);
         Dirty(uid, comp);
         _alerts.ShowAlert(uid, "ChangelingBiomass");
@@ -200,7 +200,7 @@ public sealed partial class ChangelingSystem : EntitySystem
         }
         else if (comp.Biomass <= comp.MaxBiomass / 3)
         {
-            // vomit blood
+            // vomit (funkystation) VOMIT LIKE ITS A HUGE GIVEAWAY IF ITS BLOOD VRO LIKE WTF???
             if (random == 1)
             {
                 if (TryComp<StatusEffectsComponent>(uid, out var status))
@@ -208,9 +208,8 @@ public sealed partial class ChangelingSystem : EntitySystem
 
                 var solution = new Solution();
 
-                var vomitAmount = 15f;
-                _blood.TryModifyBloodLevel(uid, -vomitAmount);
-                solution.AddReagent("Blood", vomitAmount);
+                var vomitAmount = 10f;
+                solution.AddReagent("Vomit", vomitAmount);
 
                 _puddle.TrySplashSpillAt(uid, Transform(uid).Coordinates, solution, out _);
 

--- a/Resources/Prototypes/_Goobstation/Changeling/Entities/Mobs/headcrab.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/Entities/Mobs/headcrab.yml
@@ -5,7 +5,7 @@
   description: You don't want to touch it.
   components:
   - type: Sprite
-    drawdepth: Mobs
+    drawdepth: SmallMobs
     layers:
     - map: ["enum.DamageStateVisualLayers.Base"]
       state: headcrab
@@ -29,3 +29,14 @@
     baseSprintSpeed: 7
   - type: ExplosionResistance
     damageCoefficient: 0
+  - type: Fixtures
+    fixtures:
+      fix1:
+        shape:
+          !type:PhysShapeCircle
+          radius: 0.2
+        density: 15
+        mask:
+        - SmallMobMask
+        layer:
+        - SmallMobLayer


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Ling biomass drain is halfed, vomiting blood is changed with normal vomit, and the headslug can go through doors and tables (and can be used while cuffed)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Headslug was so terrible it needed a huge buff, despite being a last resort you literally can never use it at all since it would get stuck on doors or you were cuffed and couldn't use it.

Biomass drains too much, so you'd need to kill every 20 minutes so you wouldnt puke blood

Vomiting blood was a dead giveaway. It's just complete bullshit just walking around and then suddenly you've got a full clip of lead in your head cuz you forgot to eat a clown.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Changed biomass drain and vomit
- tweak: Changed headslug to work in cuffs and to move under doors
