### PR TITLE
Port Dynamic Message Alerts + add to Borg Battery Alert

### DIFF
--- a/Content.Client/Actions/UI/ActionAlertTooltip.cs
+++ b/Content.Client/Actions/UI/ActionAlertTooltip.cs
@@ -14,12 +14,14 @@ namespace Content.Client.Actions.UI
         private const float TooltipTextMaxWidth = 350;
 
         private readonly RichTextLabel _cooldownLabel;
+        private readonly RichTextLabel _dynamicMessageLabel;
         private readonly IGameTiming _gameTiming;
 
         /// <summary>
         /// Current cooldown displayed in this tooltip. Set to null to show no cooldown.
         /// </summary>
         public (TimeSpan Start, TimeSpan End)? Cooldown { get; set; }
+        public string? DynamicMessage { get; set; }
 
         public ActionAlertTooltip(FormattedMessage name, FormattedMessage? desc, string? requires = null, FormattedMessage? charges = null)
         {
@@ -70,6 +72,13 @@ namespace Content.Client.Actions.UI
                 Visible = false
             });
 
+            vbox.AddChild(_dynamicMessageLabel = new RichTextLabel
+            {
+                MaxWidth = TooltipTextMaxWidth,
+                StyleClasses = {StyleNano.StyleClassTooltipActionDynamicMessage},
+                Visible = false
+            });
+
             if (!string.IsNullOrWhiteSpace(requires))
             {
                 var requiresLabel = new RichTextLabel
@@ -93,23 +102,33 @@ namespace Content.Client.Actions.UI
             if (!Cooldown.HasValue)
             {
                 _cooldownLabel.Visible = false;
-                return;
-            }
-
-            var timeLeft = Cooldown.Value.End - _gameTiming.CurTime;
-            if (timeLeft > TimeSpan.Zero)
-            {
-                var duration = Cooldown.Value.End - Cooldown.Value.Start;
-
-                if (!FormattedMessage.TryFromMarkup(Loc.GetString("ui-actionslot-duration", ("duration", (int)duration.TotalSeconds), ("timeLeft", (int)timeLeft.TotalSeconds + 1)), out var markup))
-                    return;
-
-                _cooldownLabel.SetMessage(markup);
-                _cooldownLabel.Visible = true;
             }
             else
             {
-                _cooldownLabel.Visible = false;
+                var timeLeft = Cooldown.Value.End - _gameTiming.CurTime;
+                if (timeLeft > TimeSpan.Zero)
+                {
+                    var duration = Cooldown.Value.End - Cooldown.Value.Start;
+
+                    if (FormattedMessage.TryFromMarkup($"[color=#a10505]{(int) duration.TotalSeconds} sec cooldown ({(int) timeLeft.TotalSeconds + 1} sec remaining)[/color]", out var markup)){
+                        _cooldownLabel.SetMessage(markup);
+                        _cooldownLabel.Visible = true;
+                    }
+                }
+                else
+                {
+                    _cooldownLabel.Visible = false;
+                }
+            }
+
+            if (string.IsNullOrWhiteSpace(DynamicMessage))
+            {
+                _dynamicMessageLabel.Visible = false;
+            }
+            else if (FormattedMessage.TryFromMarkup($"[color=#ffffff]{DynamicMessage}[/color]", out var dynamicMarkup))
+            {
+                _dynamicMessageLabel.SetMessage(dynamicMarkup);
+                _dynamicMessageLabel.Visible = true;
             }
         }
     }

--- a/Content.Client/Stylesheets/StyleNano.cs
+++ b/Content.Client/Stylesheets/StyleNano.cs
@@ -57,6 +57,7 @@ namespace Content.Client.Stylesheets
         public const string StyleClassTooltipActionTitle = "tooltipActionTitle";
         public const string StyleClassTooltipActionDescription = "tooltipActionDesc";
         public const string StyleClassTooltipActionCooldown = "tooltipActionCooldown";
+        public const string StyleClassTooltipActionDynamicMessage = "tooltipActionDynamicMessage";
         public const string StyleClassTooltipActionRequirements = "tooltipActionCooldown";
         public const string StyleClassTooltipActionCharges = "tooltipActionCharges";
         public const string StyleClassHotbarSlotNumber = "hotbarSlotNumber";
@@ -1001,6 +1002,10 @@ namespace Content.Client.Stylesheets
                     new StyleProperty("font", notoSans15)
                 }),
                 new StyleRule(new SelectorElement(typeof(RichTextLabel), new[] {StyleClassTooltipActionCooldown}, null, null), new[]
+                {
+                    new StyleProperty("font", notoSans15)
+                }),
+                new StyleRule(new SelectorElement(typeof(RichTextLabel), new[] {StyleClassTooltipActionDynamicMessage}, null, null), new[]
                 {
                     new StyleProperty("font", notoSans15)
                 }),

--- a/Content.Client/UserInterface/Systems/Alerts/Controls/AlertControl.cs
+++ b/Content.Client/UserInterface/Systems/Alerts/Controls/AlertControl.cs
@@ -30,7 +30,21 @@ namespace Content.Client.UserInterface.Systems.Alerts.Controls
             }
         }
 
+        public string? DynamicMessage
+        {
+            get => _dynamicMessage;
+            set
+            {
+                _dynamicMessage = value;
+                if (SuppliedTooltip is ActionAlertTooltip actionAlertTooltip)
+                {
+                    actionAlertTooltip.DynamicMessage = value;
+                }
+            }
+        }
+
         private (TimeSpan Start, TimeSpan End)? _cooldown;
+        private string? _dynamicMessage;
 
         private short? _severity;
         private readonly IGameTiming _gameTiming;
@@ -71,7 +85,7 @@ namespace Content.Client.UserInterface.Systems.Alerts.Controls
         {
             var msg = FormattedMessage.FromMarkupOrThrow(Loc.GetString(Alert.Name));
             var desc = FormattedMessage.FromMarkupOrThrow(Loc.GetString(Alert.Description));
-            return new ActionAlertTooltip(msg, desc) {Cooldown = Cooldown};
+            return new ActionAlertTooltip(msg, desc) {Cooldown = Cooldown, DynamicMessage = DynamicMessage};
         }
 
         /// <summary>

--- a/Content.Client/UserInterface/Systems/Alerts/Widgets/AlertsUI.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Alerts/Widgets/AlertsUI.xaml.cs
@@ -98,6 +98,7 @@ public sealed partial class AlertsUI : UIWidget
                 existingAlertControl.SetSeverity(alertState.Severity);
                 if (alertState.ShowCooldown)
                     existingAlertControl.Cooldown = alertState.Cooldown;
+                existingAlertControl.DynamicMessage = alertState.DynamicMessage;
             }
             else
             {
@@ -143,9 +144,12 @@ public sealed partial class AlertsUI : UIWidget
         if (alertState.ShowCooldown)
             cooldown = alertState.Cooldown;
 
+        string? dynamicMessage = alertState.DynamicMessage;
+
         var alertControl = new AlertControl(alert, alertState.Severity)
         {
-            Cooldown = cooldown
+            Cooldown = cooldown,
+            DynamicMessage = dynamicMessage,
         };
         alertControl.OnPressed += AlertControlPressed;
         return alertControl;

--- a/Content.Server/Silicons/Borgs/BorgSystem.cs
+++ b/Content.Server/Silicons/Borgs/BorgSystem.cs
@@ -284,8 +284,10 @@ public sealed partial class BorgSystem : SharedBorgSystem
             chargePercent = 1;
         }
 
+        string? chargeMessage = Loc.GetString("borg-ui-charge-label", ("charge", (int) MathF.Round(battery.CurrentCharge / battery.MaxCharge * 100f)));
+
         _alerts.ClearAlert(ent, ent.Comp.NoBatteryAlert);
-        _alerts.ShowAlert(ent, ent.Comp.BatteryAlert, chargePercent);
+        _alerts.ShowAlert(ent, ent.Comp.BatteryAlert, chargePercent, dynamicMessage: chargeMessage);
     }
 
     /// <summary>

--- a/Content.Shared/Alert/AlertState.cs
+++ b/Content.Shared/Alert/AlertState.cs
@@ -8,6 +8,7 @@ public struct AlertState
 {
     public short? Severity;
     public (TimeSpan, TimeSpan)? Cooldown;
+    public string? DynamicMessage;
     public bool AutoRemove;
     public bool ShowCooldown;
     public ProtoId<AlertPrototype> Type;

--- a/Content.Shared/Alert/AlertsSystem.cs
+++ b/Content.Shared/Alert/AlertsSystem.cs
@@ -78,7 +78,8 @@ public abstract class AlertsSystem : EntitySystem
     ///     be erased if there is currently a cooldown for the alert)</param>
     /// <param name="autoRemove">if true, the alert will be removed at the end of the cooldown</param>
     /// <param name="showCooldown">if true, the cooldown will be visibly shown over the alert icon</param>
-    public void ShowAlert(EntityUid euid, ProtoId<AlertPrototype> alertType, short? severity = null, (TimeSpan, TimeSpan)? cooldown = null, bool autoRemove = false, bool showCooldown = true )
+    /// <param name="dynamicMessage">a custom message that can be dynamically updated or edited</param>
+    public void ShowAlert(EntityUid euid, ProtoId<AlertPrototype> alertType, short? severity = null, (TimeSpan, TimeSpan)? cooldown = null, bool autoRemove = false, bool showCooldown = true, string? dynamicMessage = null )
     {
         // This should be handled as part of networking.
         if (_timing.ApplyingState)
@@ -96,7 +97,8 @@ public abstract class AlertsSystem : EntitySystem
                 alertStateCallback.Severity == severity &&
                 alertStateCallback.Cooldown == cooldown &&
                 alertStateCallback.AutoRemove == autoRemove &&
-                alertStateCallback.ShowCooldown == showCooldown)
+                alertStateCallback.ShowCooldown == showCooldown &&
+                alertStateCallback.DynamicMessage == dynamicMessage)
             {
                 return;
             }
@@ -105,7 +107,7 @@ public abstract class AlertsSystem : EntitySystem
             alertsComponent.Alerts.Remove(alert.AlertKey);
 
             var state = new AlertState
-                { Cooldown = cooldown, Severity = severity, Type = alertType, AutoRemove = autoRemove, ShowCooldown = showCooldown};
+                { Cooldown = cooldown, Severity = severity, Type = alertType, AutoRemove = autoRemove, ShowCooldown = showCooldown, DynamicMessage = dynamicMessage};
             alertsComponent.Alerts[alert.AlertKey] = state;
 
             // Keeping a list of AutoRemove alerts, so Update() doesn't need to check every alert


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Ports my Dynamic Message Alert support from RMC14 at https://github.com/RMC-14/RMC-14/pull/4150, adds it to the Borg Battery alert so it functions in real-time

## Why / Balance
Cool generically useful feature

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
Video Demonstration

https://github.com/user-attachments/assets/819e8d97-9b1a-483e-bd5e-7740e652e213



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl:
- add: Added the ability for Alerts to show dynamically updating text in real-time.
- add: The Cyborg's Battery Alert on the sidebar will now show your charge percentage in real-time when you hover over it with your mouse.


