### PR TITLE
clean up /tg/ gas code

### DIFF
--- a/Resources/Locale/en-US/reagents/meta/gases.ftl
+++ b/Resources/Locale/en-US/reagents/meta/gases.ftl
@@ -26,4 +26,4 @@ reagent-name-healium = healium
 reagent-desc-healium = A powerful sleeping agent with regenerative properties.
 
 reagent-name-nitrium = nitrium
-reagent-desc-nitrium = A strong stimulant that will improve reflexes and stamina.
+reagent-desc-nitrium = An experimental performance enhancing gas. Nitrium can have amplified effects as more of it gets into your bloodstream.

--- a/Resources/Prototypes/Atmospherics/gases.yml
+++ b/Resources/Prototypes/Atmospherics/gases.yml
@@ -107,7 +107,7 @@
   id: 9
   name: gases-bz
   specificHeat: 20
-  heatCapacityRatio: 1.4
+  heatCapacityRatio: 1.6
   molarMass: 12
   color: 9370db
   reagent: BZ
@@ -116,13 +116,12 @@
 - type: gas
   id: 10
   name: gases-healium
-  specificHeat: 20
+  specificHeat: 10
   heatCapacityRatio: 1.4
   molarMass: 15
   gasOverlaySprite: /Textures/Effects/atmospherics.rsi
   gasOverlayState: healium
-  gasMolesVisible: 2
-  color: 8b0000
+  color: fa8072
   reagent: Healium
   pricePerMole: 5
 
@@ -133,8 +132,7 @@
   heatCapacityRatio: 1.4
   gasOverlaySprite: /Textures/Effects/atmospherics.rsi
   gasOverlayState: nitrium
-  gasMolesVisible: 0.6
   molarMass: 8
-  color: b76f0e
+  color: a52a2a
   reagent: Nitrium
   pricePerMole: 6

--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -482,7 +482,7 @@
   name: reagent-name-healium
   desc: reagent-desc-healium
   physicalDesc: reagent-physical-desc-gaseous
-  flavor: rubbery
+  flavor: strange
   color: "#90560b"
   metabolisms:
     Gas:
@@ -570,7 +570,7 @@
   name: reagent-name-nitrium
   desc: reagent-desc-nitrium
   physicalDesc: reagent-physical-desc-gaseous
-  flavor: burning
+  flavor: sour
   color: "#90560B"
   metabolisms:
     Gas:

--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -409,7 +409,7 @@
         key: SeeingRainbows
         component: SeeingRainbows
         type: Add
-        time: 10
+        time: 150
         refresh: false
       - !type:Emote
         conditions:
@@ -482,8 +482,8 @@
   name: reagent-name-healium
   desc: reagent-desc-healium
   physicalDesc: reagent-physical-desc-gaseous
-  flavor: sweet
-  color: "#8b0000"
+  flavor: rubbery
+  color: "#90560b"
   metabolisms:
     Gas:
       effects:
@@ -532,7 +532,7 @@
           max: 0.01
         key: ForcedSleep
         component: ForcedSleeping
-        time: 3
+        time: 1
         type: Add
       - !type:Drunk
         boozePower: 50
@@ -570,8 +570,8 @@
   name: reagent-name-nitrium
   desc: reagent-desc-nitrium
   physicalDesc: reagent-physical-desc-gaseous
-  flavor: sour
-  color: "#b76f0e"
+  flavor: burning
+  color: "#90560B"
   metabolisms:
     Gas:
       effects:

--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -483,8 +483,8 @@
   group: Narcotics
   desc: reagent-desc-nitrosyl-plasmide
   physicalDesc: reagent-physical-desc-translucent
-  flavor: sour
-  color: "#b76f0e"
+  flavor: sourness
+  color: "#e1a116"
   metabolisms:
     Gas:
       effects:
@@ -509,6 +509,10 @@
         key: ForcedSleep
         type: Remove
         time: 10
+      - !type:HealthChange
+        damage:
+          types:
+            Poison: 0.1
     Medicine:
       effects:
       - !type:ResetNarcolepsy

--- a/Resources/Prototypes/Reagents/narcotics.yml
+++ b/Resources/Prototypes/Reagents/narcotics.yml
@@ -483,7 +483,7 @@
   group: Narcotics
   desc: reagent-desc-nitrosyl-plasmide
   physicalDesc: reagent-physical-desc-translucent
-  flavor: sourness
+  flavor: sour
   color: "#e1a116"
   metabolisms:
     Gas:


### PR DESCRIPTION
## About the PR
Makes small changes to tg gases. Reagent colors have been changed to match original hex values. BZ effects have been tweaked so that it actually does something when you inhale it. Nitrosyl plasmide slowly deals poison damage. Some reagent descriptions have been slightly changed. 

## Why / Balance
Mostly cleaning up placeholder values and descriptions. Most changes are very minor, however this does include a fix for BZ's seeing rainbows effect. Nitrosyl plasmide has also been changed to deal 0.1 poison damage as it metabolizes. 

## Technical details
None

## Media
None

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None

**Changelog**
:cl:
- tweak: Added poison damage to nitrosyl plasmide
- fix: Fixed BZ rainbow effects
