### PR TITLE
Lower Heretic Player Req

### DIFF
--- a/Resources/Prototypes/_Goobstation/Heretic/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/GameRules/roundstart.yml
@@ -4,10 +4,7 @@
   components:
   - type: HereticRule
   - type: GameRule
-    minPlayers: 20
-    delay:
-      min: 30
-      max: 60
+    minPlayers: 8
   - type: AntagObjectives
     objectives:
     - HereticKnowledgeObjective
@@ -18,7 +15,7 @@
     definitions:
     - prefRoles: [ Heretic ]
       max: 2
-      playerRatio: 20
+      playerRatio: 25
       lateJoinAdditional: true
       mindRoles:
       - MindRoleHeretic


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
lowered heretic spawning from 20 to 8

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
lowpop mrp will be forced into extended if this isn't done, and it just so happens mrp is like 15 players half the time.
I also removed the wait time, it was basically useless anyways since it was literally just 30 seconds.

## Technical details
<!-- Summary of code changes for easier review. -->
 So this is basically a bandaid fix, im not messing around with gamerule stuff just to allow like 1 tot on a 8 pop server. Plus its quicker for me to do this so the mrp heads can actually enjoy the game.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Heretic can spawn on low pop
- fix: Fixes lowpop getting set to extended if the heretic player req isnt met
