### PR TITLE
Flash & Baton buff

### DIFF
--- a/Content.Shared/Flash/Components/FlashComponent.cs
+++ b/Content.Shared/Flash/Components/FlashComponent.cs
@@ -17,7 +17,7 @@ namespace Content.Shared.Flash.Components
         /// If null, melee flashes will not stun at all
         /// </summary>
         [DataField]
-        public TimeSpan? MeleeStunDuration = TimeSpan.FromSeconds(1.5);
+        public TimeSpan? MeleeStunDuration = TimeSpan.FromSeconds(3);
 
         [DataField("range")]
         [ViewVariables(VVAccess.ReadWrite)]

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/stunprod.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/stunprod.yml
@@ -39,10 +39,10 @@
     angle: 60
     animation: WeaponArcThrust
   - type: StaminaDamageOnHit
-    damage: 35
+    damage: 40
     sound: /Audio/Weapons/egloves.ogg
   - type: StaminaDamageOnCollide
-    damage: 35
+    damage: 40
     sound: /Audio/Weapons/egloves.ogg
   - type: LandAtCursor # it deals stamina damage when thrown
   - type: Battery

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -45,10 +45,10 @@
     soundHit:
       collection: MetalThud #fs - Thwack
   - type: StaminaDamageOnHit
-    damage: 35
+    damage: 40 #fs - Stunbaton 2-hit stun
     sound: /Audio/Weapons/egloves.ogg
   - type: StaminaDamageOnCollide
-    damage: 35
+    damage: 40 #fs - Stunbaton 2-hit stun
     sound: /Audio/Weapons/egloves.ogg
   - type: LandAtCursor # it deals stamina damage when thrown
   - type: Battery


### PR DESCRIPTION
Stun batons are now a 2 hit stamcrit if timed well, and flashes now stun for double duration (1.5s -> 3s), allowing a flash cuff if timed quickly enough.

Why?
Sec equipment kinda sucks ATM. Buffing Sec equipment can lead to more fun antag equipment down the road so everyone has better tools to deal with everything without admin intervention.

:cl:
- tweak: Stun batons now stamina-crit in two hits rather than three
- tweak: Flash stun duration doubled to 3 seconds