### PR TITLE
Add (non hardsuit) Carp Costume to AutoDrobe

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/theater.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/theater.yml
@@ -10,6 +10,7 @@
     ClothingOuterWinterMime: 1
     ClothingOuterWinterMusician: 1
     ClothingMaskJoy: 2
+    ClothingOuterSuitCarp: 1
     ClothingHeadHatCardborg: 2
     ClothingOuterCardborg: 2
     ClothingHeadHatSombrero: 2


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This PR just adds the non hardsuit carp costume to the AutoDrobe, with only one in stock. From my memory, it was like this in Space Station 13, and also is like this on Delta V.

## Why / Balance
This is a very very simple change. All it does it add the original non-hardsuit carp costume to the AutoDrobe, this isn't meant as some kind of fix for meta gaming the suit or anything, I just really like how the carp suit looks and would like to see it as a easily accessible costume again, seeing as the AutoDrobe is meant for re-enactments and theater and such. Currently, the only other way to get a carp suit is either from an uplink or from The Grand Lottery, meaning its almost impossible, and very unlikely to come across one.

## Technical details
Changes \Resources\Prototypes\Catalog\VendingMachines\Inventories\theater.yml to add ClothingOuterSuitCarp as a option in the list, with only 1 inside the machine.

## Media
<!-- Attach media if the PR makes in game changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![SS14 Loader_sapWJFMxUJ](https://github.com/user-attachments/assets/ba00fab1-fc50-4090-9173-b9be0db5d986)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Nothing should break from this change, as it only adds one line to theater.yml, which is only used by the AutoDrobe. I genuinely cannot think of a way this could break anything.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Add non hardsuit carp costume to AutoDrobe