### PR TITLE
Gate, Loop, and Cluster Atmos Improvements

### DIFF
--- a/Resources/Maps/_Funkystation/cluster.yml
+++ b/Resources/Maps/_Funkystation/cluster.yml
@@ -4338,32 +4338,30 @@ entities:
             0: 65520
           10,-4:
             2: 8738
-            3: 8
-            4: 2048
+            3: 2056
           10,-3:
             2: 8738
-            4: 2056
+            3: 2056
           10,-2:
             2: 8738
-            5: 8
-            6: 2048
+            4: 8
+            5: 2048
           10,-5:
             2: 8750
-            4: 2048
+            3: 2048
           11,-4:
-            3: 3
-            4: 768
+            3: 771
             2: 34952
           11,-3:
-            4: 771
+            3: 771
             2: 34952
           11,-2:
-            5: 3
-            6: 768
+            4: 3
+            5: 768
             2: 34952
           11,-5:
             2: 34959
-            4: 768
+            3: 768
           12,-4:
             2: 12834
           12,-3:
@@ -4398,18 +4396,22 @@ entities:
             2: 7983
           8,-6:
             2: 61713
-            4: 204
+            3: 204
           9,-7:
-            2: 20263
+            2: 18223
           9,-6:
-            4: 17
-            2: 62660
+            3: 17
+            2: 62532
           10,-7:
-            2: 4369
+            2: 7
+            3: 65280
           10,-6:
-            2: 16145
+            3: 15
+            2: 61440
           11,-6:
-            2: 40704
+            2: 65024
+          11,-7:
+            2: 1
           12,-6:
             2: 256
           12,-5:
@@ -4601,7 +4603,7 @@ entities:
             0: 4352
           -1,16:
             2: 1
-            3: 128
+            6: 128
           -2,17:
             2: 8
           -1,17:
@@ -4672,25 +4674,6 @@ entities:
           - 0
           - 0
           - 0
-          - 6666.982
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-          - 0
-        - volume: 2500
-          temperature: 293.15
-          moles:
-          - 0
-          - 0
-          - 0
           - 0
           - 0
           - 0
@@ -4730,6 +4713,25 @@ entities:
           - 6666.982
           - 0
           - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 0
+          - 0
+          - 0
+          - 6666.982
           - 0
           - 0
           - 0
@@ -4761,6 +4763,7 @@ entities:
     - type: MovedGrids
     - type: Broadphase
     - type: OccluderTree
+    - type: LoadedMap
 - proto: AcousticGuitarInstrument
   entities:
   - uid: 3
@@ -6765,7 +6768,7 @@ entities:
       pos: 38.5,-1.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -1747.2501
+      secondsUntilStateChange: -1975.1908
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -23544,6 +23547,18 @@ entities:
     - type: Transform
       pos: 16.5,24.5
       parent: 2
+- proto: CartridgeRocket
+  entities:
+  - uid: 12775
+    components:
+    - type: Transform
+      pos: 25.288965,12.492906
+      parent: 2
+  - uid: 12776
+    components:
+    - type: Transform
+      pos: 25.600845,12.236063
+      parent: 2
 - proto: Catwalk
   entities:
   - uid: 3448
@@ -28203,6 +28218,13 @@ entities:
     - type: Transform
       pos: -16.593803,-4.1209826
       parent: 2
+- proto: ClothingEyesGlassesMercenary
+  entities:
+  - uid: 12778
+    components:
+    - type: Transform
+      pos: 16.32538,-29.603308
+      parent: 2
 - proto: ClothingHandsGlovesBoxingBlue
   entities:
   - uid: 4246
@@ -28407,6 +28429,13 @@ entities:
     - type: Transform
       pos: -22.500423,-8.478397
       parent: 2
+- proto: ClothingMaskGasMerc
+  entities:
+  - uid: 12777
+    components:
+    - type: Transform
+      pos: 16.490492,-29.254736
+      parent: 2
 - proto: ClothingMaskMime
   entities:
   - uid: 12758
@@ -28544,6 +28573,13 @@ entities:
       name: pilot's boots
     - type: Transform
       pos: -19.507818,-48.36427
+      parent: 2
+- proto: ClothingShoesBootsJackFilled
+  entities:
+  - uid: 12779
+    components:
+    - type: Transform
+      pos: 16.123575,-29.253181
       parent: 2
 - proto: ClothingShoesBootsMag
   entities:
@@ -81383,6 +81419,13 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 38.30525,10.607112
+      parent: 2
+- proto: WeaponLauncherRocket
+  entities:
+  - uid: 12774
+    components:
+    - type: Transform
+      pos: 25.509115,12.511251
       parent: 2
 - proto: WeaponPistolMk58
   entities:

--- a/Resources/Maps/loop.yml
+++ b/Resources/Maps/loop.yml
@@ -5014,9 +5014,17 @@ entities:
           - 0
           - 0
           - 0
+          - 0
+          - 0
+          - 0
+          - 0
         - volume: 2500
           temperature: 293.15
           moles:
+          - 0
+          - 0
+          - 0
+          - 0
           - 0
           - 0
           - 0
@@ -5044,6 +5052,10 @@ entities:
           - 0
           - 0
           - 0
+          - 0
+          - 0
+          - 0
+          - 0
         - volume: 2500
           temperature: 293.15
           moles:
@@ -5059,6 +5071,10 @@ entities:
           - 0
           - 0
           - 0
+          - 0
+          - 0
+          - 0
+          - 0
         - volume: 2500
           temperature: 293.15
           moles:
@@ -5074,10 +5090,18 @@ entities:
           - 0
           - 0
           - 0
+          - 0
+          - 0
+          - 0
+          - 0
         - volume: 2500
           temperature: 293.15
           moles:
           - 6666.982
+          - 0
+          - 0
+          - 0
+          - 0
           - 0
           - 0
           - 0
@@ -5104,11 +5128,19 @@ entities:
           - 0
           - 0
           - 0
+          - 0
+          - 0
+          - 0
+          - 0
         - volume: 2500
           temperature: 235
           moles:
           - 21.824879
           - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
           - 0
           - 0
           - 0
@@ -5134,11 +5166,19 @@ entities:
           - 0
           - 0
           - 0
+          - 0
+          - 0
+          - 0
+          - 0
         - volume: 2500
           temperature: 293.14902
           moles:
           - 21.824879
           - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
           - 0
           - 0
           - 0
@@ -5164,6 +5204,10 @@ entities:
           - 0
           - 0
           - 0
+          - 0
+          - 0
+          - 0
+          - 0
         - volume: 2500
           temperature: 293.14975
           moles:
@@ -5179,11 +5223,19 @@ entities:
           - 0
           - 0
           - 0
+          - 0
+          - 0
+          - 0
+          - 0
         - volume: 2500
           temperature: 293.15
           moles:
           - 21.6852
           - 81.57766
+          - 0
+          - 0
+          - 0
+          - 0
           - 0
           - 0
           - 0
@@ -7299,7 +7351,7 @@ entities:
       pos: -30.5,13.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -44351.34
+      secondsUntilStateChange: -44511.008
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -40162,7 +40214,7 @@ entities:
             - -0.25,0.48
           mask:
           - Impassable
-          - TableLayer
+          - MidImpassable
           - LowImpassable
           layer:
           - BulletImpassable
@@ -40470,7 +40522,7 @@ entities:
             - -0.25,0.48
           mask:
           - Impassable
-          - TableLayer
+          - MidImpassable
           - LowImpassable
           layer:
           - BulletImpassable
@@ -40501,7 +40553,7 @@ entities:
             - -0.25,0.48
           mask:
           - Impassable
-          - TableLayer
+          - MidImpassable
           - LowImpassable
           layer:
           - BulletImpassable
@@ -40532,7 +40584,7 @@ entities:
             - -0.25,0.48
           mask:
           - Impassable
-          - TableLayer
+          - MidImpassable
           - LowImpassable
           layer:
           - BulletImpassable
@@ -40568,7 +40620,7 @@ entities:
             - -0.25,0.48
           mask:
           - Impassable
-          - TableLayer
+          - MidImpassable
           - LowImpassable
           layer:
           - BulletImpassable
@@ -40609,7 +40661,7 @@ entities:
             - -0.25,0.48
           mask:
           - Impassable
-          - TableLayer
+          - MidImpassable
           - LowImpassable
           layer:
           - BulletImpassable
@@ -40650,7 +40702,7 @@ entities:
             - -0.25,0.48
           mask:
           - Impassable
-          - TableLayer
+          - MidImpassable
           - LowImpassable
           layer:
           - BulletImpassable
@@ -40686,7 +40738,7 @@ entities:
             - -0.25,0.48
           mask:
           - Impassable
-          - TableLayer
+          - MidImpassable
           - LowImpassable
           layer:
           - BulletImpassable
@@ -41405,8 +41457,11 @@ entities:
   - uid: 5014
     components:
     - type: Transform
-      pos: -15.579143,38.694138
+      pos: -15.346128,39.946465
       parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
 - proto: ClothingOuterSuitChicken
   entities:
   - uid: 14159
@@ -42439,6 +42494,10 @@ entities:
         - 0
         - 0
         - 0
+        - 0
+        - 0
+        - 0
+        - 0
     - type: ContainerContainer
       containers:
         entity_storage: !type:Container
@@ -42468,6 +42527,10 @@ entities:
         moles:
         - 1.7459903
         - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
         - 0
         - 0
         - 0
@@ -42517,6 +42580,10 @@ entities:
         - 0
         - 0
         - 0
+        - 0
+        - 0
+        - 0
+        - 0
     - type: ContainerContainer
       containers:
         entity_storage: !type:Container
@@ -42556,6 +42623,10 @@ entities:
         - 0
         - 0
         - 0
+        - 0
+        - 0
+        - 0
+        - 0
     - type: ContainerContainer
       containers:
         entity_storage: !type:Container
@@ -42585,6 +42656,10 @@ entities:
         moles:
         - 1.7459903
         - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
         - 0
         - 0
         - 0
@@ -42638,6 +42713,10 @@ entities:
         - 0
         - 0
         - 0
+        - 0
+        - 0
+        - 0
+        - 0
     - type: ContainerContainer
       containers:
         entity_storage: !type:Container
@@ -42667,6 +42746,10 @@ entities:
         moles:
         - 1.7459903
         - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
         - 0
         - 0
         - 0
@@ -42713,6 +42796,10 @@ entities:
         moles:
         - 1.7459903
         - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
         - 0
         - 0
         - 0
@@ -42902,6 +42989,10 @@ entities:
         - 0
         - 0
         - 0
+        - 0
+        - 0
+        - 0
+        - 0
     - type: ContainerContainer
       containers:
         entity_storage: !type:Container
@@ -42941,6 +43032,10 @@ entities:
         moles:
         - 1.8856695
         - 7.0937095
+        - 0
+        - 0
+        - 0
+        - 0
         - 0
         - 0
         - 0
@@ -43042,6 +43137,10 @@ entities:
         - 0
         - 0
         - 0
+        - 0
+        - 0
+        - 0
+        - 0
     - type: ContainerContainer
       containers:
         entity_storage: !type:Container
@@ -43088,6 +43187,10 @@ entities:
         moles:
         - 1.7459903
         - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
         - 0
         - 0
         - 0
@@ -43171,6 +43274,10 @@ entities:
         moles:
         - 1.7459903
         - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
         - 0
         - 0
         - 0
@@ -43388,7 +43495,7 @@ entities:
       pos: -9.5,51.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -292106.88
+      secondsUntilStateChange: -292266.53
       state: Opening
   - uid: 6747
     components:
@@ -43396,7 +43503,7 @@ entities:
       pos: -8.5,51.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -292107.6
+      secondsUntilStateChange: -292267.25
       state: Opening
   - uid: 6749
     components:
@@ -43404,7 +43511,7 @@ entities:
       pos: -6.5,51.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -292106.16
+      secondsUntilStateChange: -292265.8
       state: Opening
   - uid: 6750
     components:
@@ -43412,7 +43519,7 @@ entities:
       pos: -5.5,51.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -292105.53
+      secondsUntilStateChange: -292265.2
       state: Opening
 - proto: CyberPen
   entities:
@@ -48697,6 +48804,14 @@ entities:
     - type: Transform
       pos: -62.38587,9.986375
       parent: 2
+- proto: DungeonMasterCircuitBoard
+  entities:
+  - uid: 5329
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -28.627998,88.99103
+      parent: 2
 - proto: EmergencyLight
   entities:
   - uid: 1998
@@ -52706,14 +52821,6 @@ entities:
     - type: Transform
       pos: -53.45894,65.60686
       parent: 2
-- proto: DungeonMasterCircuitBoard
-  entities:
-  - uid: 5329
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -28.627998,88.99103
-      parent: 2
 - proto: GasAnalyzer
   entities:
   - uid: 5768
@@ -52752,6 +52859,14 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 15.5,15.5
       parent: 2
+- proto: GasMinerNitrousOxide
+  entities:
+  - uid: 17681
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,9.5
+      parent: 2
 - proto: GasMinerOxygenStation
   entities:
   - uid: 745
@@ -52759,6 +52874,14 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 15.5,17.5
+      parent: 2
+- proto: GasMinerPlasma
+  entities:
+  - uid: 17680
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 15.5,7.5
       parent: 2
 - proto: GasMinerWaterVapor
   entities:
@@ -74896,6 +75019,10 @@ entities:
         - 0
         - 0
         - 0
+        - 0
+        - 0
+        - 0
+        - 0
     - type: ContainerContainer
       containers:
         entity_storage: !type:Container
@@ -74942,6 +75069,10 @@ entities:
         - 0
         - 0
         - 0
+        - 0
+        - 0
+        - 0
+        - 0
 - proto: GunSafePistolMk58
   entities:
   - uid: 14055
@@ -74973,6 +75104,10 @@ entities:
         moles:
         - 1.7459903
         - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
         - 0
         - 0
         - 0
@@ -76083,6 +76218,20 @@ entities:
       parent: 16519
     - type: Physics
       canCollide: False
+- proto: LiquidNitrogenCanister
+  entities:
+  - uid: 1386
+    components:
+    - type: Transform
+      pos: 5.5,23.5
+      parent: 2
+- proto: LiquidOxygenCanister
+  entities:
+  - uid: 1388
+    components:
+    - type: Transform
+      pos: 4.5,23.5
+      parent: 2
 - proto: LiveLetLiveCircuitBoard
   entities:
   - uid: 5330
@@ -76435,6 +76584,13 @@ entities:
     - type: Transform
       pos: -41.5,5.5
       parent: 2
+- proto: LockerBrigmedicFilled
+  entities:
+  - uid: 5008
+    components:
+    - type: Transform
+      pos: -15.5,38.5
+      parent: 2
 - proto: LockerCaptainFilledNoLaser
   entities:
   - uid: 6601
@@ -76699,6 +76855,10 @@ entities:
         - 0
         - 0
         - 0
+        - 0
+        - 0
+        - 0
+        - 0
 - proto: LockerResearchDirectorFilled
   entities:
   - uid: 5867
@@ -76834,6 +76994,10 @@ entities:
         moles:
         - 1.7459903
         - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
         - 0
         - 0
         - 0
@@ -77806,11 +77970,6 @@ entities:
     - type: Transform
       pos: 16.5,15.5
       parent: 2
-  - uid: 1388
-    components:
-    - type: Transform
-      pos: 5.5,23.5
-      parent: 2
   - uid: 1389
     components:
     - type: Transform
@@ -77967,11 +78126,6 @@ entities:
     components:
     - type: Transform
       pos: 16.5,17.5
-      parent: 2
-  - uid: 1386
-    components:
-    - type: Transform
-      pos: 4.5,23.5
       parent: 2
   - uid: 1387
     components:
@@ -81968,12 +82122,6 @@ entities:
     components:
     - type: Transform
       pos: -62.5,33.5
-      parent: 2
-  - uid: 5008
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -15.5,38.5
       parent: 2
   - uid: 5493
     components:
@@ -92847,6 +92995,10 @@ entities:
         - 0
         - 0
         - 0
+        - 0
+        - 0
+        - 0
+        - 0
     - type: ContainerContainer
       containers:
         entity_storage: !type:Container
@@ -92903,6 +93055,10 @@ entities:
         - 0
         - 0
         - 0
+        - 0
+        - 0
+        - 0
+        - 0
     - type: ContainerContainer
       containers:
         entity_storage: !type:Container
@@ -92923,6 +93079,10 @@ entities:
         moles:
         - 1.7459903
         - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
         - 0
         - 0
         - 0
@@ -92963,6 +93123,10 @@ entities:
         - 0
         - 0
         - 0
+        - 0
+        - 0
+        - 0
+        - 0
     - type: ContainerContainer
       containers:
         entity_storage: !type:Container
@@ -92993,6 +93157,10 @@ entities:
         - 0
         - 0
         - 0
+        - 0
+        - 0
+        - 0
+        - 0
     - type: ContainerContainer
       containers:
         entity_storage: !type:Container
@@ -93013,6 +93181,10 @@ entities:
         moles:
         - 1.7459903
         - 6.568249
+        - 0
+        - 0
+        - 0
+        - 0
         - 0
         - 0
         - 0


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Gate station is now in pair with other stations in difficulty with setting up power,
updated loop atmos and fixed an error in cluster station atmos.
## Why / Balance
Gate is basically a death-sentence for the engineering department.

## Technical details
updated map files

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
🆑 
- add: plasma gas miner to loop
- tweak: gate station is now playable for engineering department
- fix: fixed storage chamber in cluster station atmos having round-start plasma
