### PR TITLE
Fix absurd amount of midround antags (#1010)

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -273,6 +273,21 @@
       - !type:NestedSelector
         tableId: BasicCalmEventsTable
       - !type:NestedSelector
+        tableId: BasicAntagEventsTable
+      - !type:NestedSelector
+        tableId: CargoGiftsTable
+      - !type:NestedSelector
+        tableId: CalmPestEventsTable
+      - !type:NestedSelector
+        tableId: SpicyPestEventsTable
+
+- type: entityTable
+  id: BasicGameRulesTableNoAntag
+  table: !type:AllSelector
+    children:
+      - !type:NestedSelector
+        tableId: BasicCalmEventsTable
+      - !type:NestedSelector
         tableId: CargoGiftsTable
       - !type:NestedSelector
         tableId: CalmPestEventsTable
@@ -284,7 +299,7 @@
   table: !type:AllSelector
     children:
     - !type:NestedSelector
-      tableId: BasicGameRulesTable
+      tableId: BasicGameRulesTableNoAntag
     - !type:NestedSelector
       tableId: BasicAntagEventsTable
 
@@ -321,7 +336,15 @@
   components:
   - type: RampingStationEventScheduler
     scheduledGameRules: !type:NestedSelector
-      tableId: AllGameRulesTable
+      tableId: BasicGameRulesTable
+
+- type: entity
+  id: BasicStationEventSchedulerNoAntag
+  parent: BaseGameRule
+  components:
+  - type: BasicStationEventScheduler
+    scheduledGameRules: !type:NestedSelector
+      tableId: BasicGameRulesTableNoAntag
 # goob edit end
 
 - type: entity

--- a/Resources/Prototypes/_Goobstation/GameRules/Dynamic/dynamic.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/Dynamic/dynamic.yml
@@ -82,7 +82,7 @@
   showInVote: true
   rules:
     - Dynamic
-    - BasicStationEventScheduler
+    - BasicStationEventSchedulerNoAntag
     - DynamicStationEventScheduler
     #- MeteorSwarmScheduler Goobstation - nuh uh
     - SpaceTrafficControlEventScheduler
@@ -100,7 +100,7 @@
   showInVote: false # admeme only
   rules:
     - DynamicUnforgiving
-    - BasicStationEventScheduler
+    - BasicStationEventSchedulerNoAntag
     - DynamicStationEventScheduler
     - MeteorSwarmScheduler
     - SpaceTrafficControlEventScheduler

--- a/Resources/Prototypes/_Goobstation/game_presets.yml
+++ b/Resources/Prototypes/_Goobstation/game_presets.yml
@@ -11,7 +11,6 @@
     - Changeling
     - SubGamemodesRule
     - BasicStationEventScheduler
-    - AntagStationEventScheduler
     #- MeteorSwarmScheduler Goobstation - nuh uh
     - BasicRoundstartVariation
 
@@ -28,7 +27,6 @@
     - CalmTraitor
     - SubGamemodesRule
     - BasicStationEventScheduler
-    - AntagStationEventScheduler
     #- MeteorSwarmScheduler Goobstation - nuh uh
     - BasicRoundstartVariation
 
@@ -45,7 +43,6 @@
     - Calmops
     - CalmTraitor
     - BasicStationEventScheduler
-    - AntagStationEventScheduler
     #- MeteorSwarmScheduler Goobstation - nuh uh
     - BasicRoundstartVariation
 
@@ -61,7 +58,6 @@
     - Calmops
     - CalmLing
     - BasicStationEventScheduler
-    - AntagStationEventScheduler
     #- MeteorSwarmScheduler Goobstation - nuh uh
     - BasicRoundstartVariation
 
@@ -78,7 +74,6 @@
     - CalmRevs
     - CalmTraitor
     - BasicStationEventScheduler
-    - AntagStationEventScheduler
     #- MeteorSwarmScheduler Goobstation - nuh uh
 
 - type: gamePreset
@@ -94,7 +89,6 @@
     - CalmLing
     - SubGamemodesRule
     - BasicStationEventScheduler
-    - AntagStationEventScheduler
     #- MeteorSwarmScheduler Goobstation - nuh uh
     - BasicRoundstartVariation
     - BasicRoundstartVariation

--- a/Resources/Prototypes/game_presets.yml
+++ b/Resources/Prototypes/game_presets.yml
@@ -1,6 +1,3 @@
-# goob edit - separated antag and basic event schedulers
-# if you see a AntagStationEventScheduler it's from goobstation
-
 - type: gamePreset
   id: Survival
   alias:
@@ -161,7 +158,6 @@
     - Traitor
     - SubGamemodesRule
     - BasicStationEventScheduler
-    - AntagStationEventScheduler
   #  - MeteorSwarmScheduler Goobstation - nuh uh
     - SpaceTrafficControlEventScheduler
     - BasicRoundstartVariation
@@ -190,7 +186,6 @@
     - Nukeops
     - SubGamemodesRule
     - BasicStationEventScheduler
-    - AntagStationEventScheduler
   #  - MeteorSwarmScheduler Goobstation - nuh uh
     - SpaceTrafficControlEventScheduler
     - BasicRoundstartVariation
@@ -208,7 +203,6 @@
     - Revolutionary
     - SubGamemodesRule
     - BasicStationEventScheduler
-    - AntagStationEventScheduler
   #  - MeteorSwarmScheduler Goobstation - nuh uh
     - SpaceTrafficControlEventScheduler
     - BasicRoundstartVariation
@@ -227,7 +221,6 @@
   rules:
   - Zombie
   - BasicStationEventScheduler
-  - AntagStationEventScheduler
 #  - MeteorSwarmScheduler Goobstation - nuh uh
   - SpaceTrafficControlEventScheduler
   - BasicRoundstartVariation
@@ -244,7 +237,6 @@
   rules:
   - Zombie
   - BasicStationEventScheduler
-  - AntagStationEventScheduler
   - KesslerSyndromeScheduler
   - SpaceTrafficControlEventScheduler
   - BasicRoundstartVariation


### PR DESCRIPTION
(cherry picked from commit 66fea4fcf191f27bd084a50b17ae119fc405b1e2 https://github.com/Goob-Station/Goob-Station/pull/1010)

https://github.com/Goob-Station/Goob-Station/pull/1010#issue-2704797573

> ## About the PR
> Now there will be much less midround antags, no ninja, lone ops, multiple skeletons and rat kings every shift. Also added heretic to all at once gamemode.
> 
> ## Why / Balance
> ## Technical details
> ![2024-11-29-135838_1920x1080_scrot](https://private-user-images.githubusercontent.com/93730715/391065191-4a119f8b-7c63-4e78-abc3-16779a15dcad.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MzU4NzY5MzIsIm5iZiI6MTczNTg3NjYzMiwicGF0aCI6Ii85MzczMDcxNS8zOTEwNjUxOTEtNGExMTlmOGItN2M2My00ZTc4LWFiYzMtMTY3NzlhMTVkY2FkLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNTAxMDMlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjUwMTAzVDAzNTcxMlomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWZjMTExNDg0MDJkYjU5Njc3NWM0ODI0OGQ4ZjNkN2U2YzA0ZGM2MzQwN2U2ZGY2ZWVkMWE0ZWFlN2U5MGQzMDYmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.NS8tgWP3FZBFDcOckhqOhG4JKYfgIWQhlmRhaSPC1R4)
> 
> ## Media
> ## Requirements
> * [x]  I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
> * [x]  I have added media to this PR or it does not require an ingame showcase.
> 
> ## Breaking changes
> **Changelog**
> 
🆑 Aviu
 - fix: Fix absurd amount of midround antags spawning every shift.

