### PR TITLE
added station beacons to kettle

### DIFF
--- a/Resources/Maps/_Funkystation/kettle.yml
+++ b/Resources/Maps/_Funkystation/kettle.yml
@@ -10274,6 +10274,7 @@ entities:
     - type: MovedGrids
     - type: Broadphase
     - type: OccluderTree
+    - type: LoadedMap
 - proto: AccordionInstrument
   entities:
   - uid: 21533
@@ -68630,6 +68631,352 @@ entities:
     - type: Transform
       pos: 20.5,-91.5
       parent: 82
+- proto: DefaultStationBeaconAME
+  entities:
+  - uid: 26414
+    components:
+    - type: Transform
+      pos: -12.5,50.5
+      parent: 82
+- proto: DefaultStationBeaconAnchor
+  entities:
+  - uid: 26415
+    components:
+    - type: Transform
+      pos: 0.5,61.5
+      parent: 82
+- proto: DefaultStationBeaconAnomalyGenerator
+  entities:
+  - uid: 26416
+    components:
+    - type: Transform
+      pos: 15.5,73.5
+      parent: 82
+- proto: DefaultStationBeaconArmory
+  entities:
+  - uid: 26417
+    components:
+    - type: Transform
+      pos: 50.5,-15.5
+      parent: 82
+- proto: DefaultStationBeaconArtifactLab
+  entities:
+  - uid: 26418
+    components:
+    - type: Transform
+      pos: 28.5,75.5
+      parent: 82
+- proto: DefaultStationBeaconAtmospherics
+  entities:
+  - uid: 26419
+    components:
+    - type: Transform
+      pos: 6.5,15.5
+      parent: 82
+- proto: DefaultStationBeaconBar
+  entities:
+  - uid: 26420
+    components:
+    - type: Transform
+      pos: -23.5,-15.5
+      parent: 82
+- proto: DefaultStationBeaconBotany
+  entities:
+  - uid: 26421
+    components:
+    - type: Transform
+      pos: -33.5,-20.5
+      parent: 82
+- proto: DefaultStationBeaconBridge
+  entities:
+  - uid: 26413
+    components:
+    - type: Transform
+      pos: 8.5,-11.5
+      parent: 82
+- proto: DefaultStationBeaconBrig
+  entities:
+  - uid: 26426
+    components:
+    - type: Transform
+      pos: 41.5,-16.5
+      parent: 82
+- proto: DefaultStationBeaconCaptainsQuarters
+  entities:
+  - uid: 26427
+    components:
+    - type: Transform
+      pos: 12.5,-15.5
+      parent: 82
+- proto: DefaultStationBeaconCERoom
+  entities:
+  - uid: 26425
+    components:
+    - type: Transform
+      pos: -8.5,34.5
+      parent: 82
+- proto: DefaultStationBeaconChapel
+  entities:
+  - uid: 26451
+    components:
+    - type: Transform
+      pos: -14.5,16.5
+      parent: 82
+- proto: DefaultStationBeaconChemistry
+  entities:
+  - uid: 26447
+    components:
+    - type: Transform
+      pos: -32.5,-27.5
+      parent: 82
+- proto: DefaultStationBeaconCMORoom
+  entities:
+  - uid: 26428
+    components:
+    - type: Transform
+      pos: -43.5,-35.5
+      parent: 82
+- proto: DefaultStationBeaconCourtroom
+  entities:
+  - uid: 26429
+    components:
+    - type: Transform
+      pos: 29.5,-20.5
+      parent: 82
+- proto: DefaultStationBeaconCryosleep
+  entities:
+  - uid: 26459
+    components:
+    - type: Transform
+      pos: 16.5,-44.5
+      parent: 82
+- proto: DefaultStationBeaconDetectiveRoom
+  entities:
+  - uid: 26460
+    components:
+    - type: Transform
+      pos: -53.5,0.5
+      parent: 82
+- proto: DefaultStationBeaconDorms
+  entities:
+  - uid: 26450
+    components:
+    - type: Transform
+      pos: 8.5,-35.5
+      parent: 82
+- proto: DefaultStationBeaconEngineering
+  entities:
+  - uid: 26424
+    components:
+    - type: Transform
+      pos: -14.5,37.5
+      parent: 82
+- proto: DefaultStationBeaconEvac
+  entities:
+  - uid: 26423
+    components:
+    - type: Transform
+      pos: -62.5,42.5
+      parent: 82
+- proto: DefaultStationBeaconEVAStorage
+  entities:
+  - uid: 26461
+    components:
+    - type: Transform
+      pos: -38.5,26.5
+      parent: 82
+- proto: DefaultStationBeaconGravGen
+  entities:
+  - uid: 26439
+    components:
+    - type: Transform
+      pos: 0.5,57.5
+      parent: 82
+- proto: DefaultStationBeaconHOPOffice
+  entities:
+  - uid: 26440
+    components:
+    - type: Transform
+      pos: -5.5,2.5
+      parent: 82
+- proto: DefaultStationBeaconHOSRoom
+  entities:
+  - uid: 26441
+    components:
+    - type: Transform
+      pos: 61.5,-15.5
+      parent: 82
+- proto: DefaultStationBeaconJanitorsCloset
+  entities:
+  - uid: 26442
+    components:
+    - type: Transform
+      pos: -0.5,36.5
+      parent: 82
+- proto: DefaultStationBeaconKitchen
+  entities:
+  - uid: 26422
+    components:
+    - type: Transform
+      pos: -33.5,-12.5
+      parent: 82
+- proto: DefaultStationBeaconLawOffice
+  entities:
+  - uid: 26443
+    components:
+    - type: Transform
+      pos: 28.5,-27.5
+      parent: 82
+- proto: DefaultStationBeaconMedbay
+  entities:
+  - uid: 26444
+    components:
+    - type: Transform
+      pos: -34.5,-37.5
+      parent: 82
+- proto: DefaultStationBeaconMedical
+  entities:
+  - uid: 26445
+    components:
+    - type: Transform
+      pos: -25.5,-28.5
+      parent: 82
+- proto: DefaultStationBeaconMorgue
+  entities:
+  - uid: 26446
+    components:
+    - type: Transform
+      pos: -55.5,-27.5
+      parent: 82
+- proto: DefaultStationBeaconPermaBrig
+  entities:
+  - uid: 26430
+    components:
+    - type: Transform
+      pos: 51.5,-41.5
+      parent: 82
+- proto: DefaultStationBeaconPowerBank
+  entities:
+  - uid: 26448
+    components:
+    - type: Transform
+      pos: -25.5,43.5
+      parent: 82
+- proto: DefaultStationBeaconQMRoom
+  entities:
+  - uid: 26452
+    components:
+    - type: Transform
+      pos: 46.5,14.5
+      parent: 82
+- proto: DefaultStationBeaconRDRoom
+  entities:
+  - uid: 26455
+    components:
+    - type: Transform
+      pos: 27.5,65.5
+      parent: 82
+- proto: DefaultStationBeaconRND
+  entities:
+  - uid: 26458
+    components:
+    - type: Transform
+      pos: 24.5,59.5
+      parent: 82
+- proto: DefaultStationBeaconRobotics
+  entities:
+  - uid: 26456
+    components:
+    - type: Transform
+      pos: 14.5,55.5
+      parent: 82
+- proto: DefaultStationBeaconSalvage
+  entities:
+  - uid: 26453
+    components:
+    - type: Transform
+      pos: 44.5,34.5
+      parent: 82
+- proto: DefaultStationBeaconSecurity
+  entities:
+  - uid: 26431
+    components:
+    - type: Transform
+      pos: 45.5,-3.5
+      parent: 82
+- proto: DefaultStationBeaconServerRoom
+  entities:
+  - uid: 26457
+    components:
+    - type: Transform
+      pos: 12.5,64.5
+      parent: 82
+- proto: DefaultStationBeaconSingularity
+  entities:
+  - uid: 26449
+    components:
+    - type: Transform
+      pos: -26.5,56.5
+      parent: 82
+- proto: DefaultStationBeaconSolars
+  entities:
+  - uid: 26432
+    components:
+    - type: Transform
+      pos: -41.5,-50.5
+      parent: 82
+  - uid: 26433
+    components:
+    - type: Transform
+      pos: -64.5,-25.5
+      parent: 82
+  - uid: 26434
+    components:
+    - type: Transform
+      pos: -52.5,11.5
+      parent: 82
+- proto: DefaultStationBeaconSupply
+  entities:
+  - uid: 26454
+    components:
+    - type: Transform
+      pos: 44.5,26.5
+      parent: 82
+- proto: DefaultStationBeaconTechVault
+  entities:
+  - uid: 26438
+    components:
+    - type: Transform
+      pos: 9.5,35.5
+      parent: 82
+- proto: DefaultStationBeaconTelecoms
+  entities:
+  - uid: 26462
+    components:
+    - type: Transform
+      pos: -31.5,18.5
+      parent: 82
+- proto: DefaultStationBeaconToolRoom
+  entities:
+  - uid: 26437
+    components:
+    - type: Transform
+      pos: -26.5,3.5
+      parent: 82
+- proto: DefaultStationBeaconVault
+  entities:
+  - uid: 26436
+    components:
+    - type: Transform
+      pos: -11.5,-7.5
+      parent: 82
+- proto: DefaultStationBeaconWardensOffice
+  entities:
+  - uid: 26435
+    components:
+    - type: Transform
+      pos: 41.5,-8.5
+      parent: 82
 - proto: DefibrillatorCabinetFilled
   entities:
   - uid: 2849
@@ -76791,6 +77138,30 @@ entities:
     components:
     - type: Transform
       pos: -13.484442,-43.490257
+      parent: 82
+- proto: DrinkWhiskeyBottleFull
+  entities:
+  - uid: 26463
+    components:
+    - type: Transform
+      pos: -7.270398,34.718456
+      parent: 82
+- proto: DrinkWhiskeyColaGlass
+  entities:
+  - uid: 26464
+    components:
+    - type: Transform
+      pos: -9.778774,34.48408
+      parent: 82
+  - uid: 26465
+    components:
+    - type: Transform
+      pos: -9.474087,34.437206
+      parent: 82
+  - uid: 26466
+    components:
+    - type: Transform
+      pos: -9.239712,34.636425
       parent: 82
 - proto: DrinkWineBottleFull
   entities:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
I added station beacons to kettle for players to see more clearly the departments around the station.

## Why / Balance
It was changed so players can find their way about more.

## Technical details

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- Added Whisky to Chief Engineer's office in Kettle.
- Added beacons across the station inside kettle station.
