### PR TITLE
Roboticist tweaks

### DIFF
--- a/Resources/Locale/en-US/job/job-description.ftl
+++ b/Resources/Locale/en-US/job/job-description.ftl
@@ -39,6 +39,7 @@ job-description-qm = Manage the supplies of the station & the cargo department, 
 job-description-rd = Manage the science department, unlocking technologies, acquiring & researching artifacts, and performing experiments.
 job-description-research-assistant = Learn the basics of how to research various artifacts, anomalies and robotics.
 job-description-reporter = Entertain & inform the crew with your vibrant journalism through wireless cameras, the radio and the news. Currently available on Bagel Station, Cog, Core, Train and Oasis.
+job-description-roboticist = Build and mantain the station's silicons, repair IPCs, and create mechs & various cybernetic enchancements for the crew.
 job-description-salvagespec = Use the salvage magnet to draw in detatched scraps & asteroids to loot and enrich the station, build a salvage ship and then travel to new planets, while fighting off any space fauna along the way.
 job-description-scientist = Research alien artifacts, unlock new technologies, build newer and better machines around the station, and make everything run more efficiently.
 job-description-security = Catch criminals and enemies of the station, enforce the law, and ensure that the station does not fall into disarray.

--- a/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
@@ -163,6 +163,7 @@
   - type: EncryptionKey
     channels:
     - Science
+    - Binary
     defaultChannel: Science
   - type: Sprite
     layers:

--- a/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/encryption_keys.yml
@@ -163,7 +163,6 @@
   - type: EncryptionKey
     channels:
     - Science
-    - Binary
     defaultChannel: Science
   - type: Sprite
     layers:


### PR DESCRIPTION
## About the PR
Roboticist now has a proper job description ~~and robotech encryption keys now have access to the binary channel.~~

**Changelog**
:cl:
- fix: Roboticist now has an actual job description.