### PR TITLE
Roll antags before job

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -640,6 +640,8 @@ namespace Content.Client.Lobby.UI
                 ("humanoid-profile-editor-antag-preference-no-button", 1)
             };
 
+            AntagList.AddChild(new Label { Text = Loc.GetString("humanoid-profile-editor-antag-roll-before-jobs") }); // Goobstation
+
             foreach (var antag in _prototypeManager.EnumeratePrototypes<AntagPrototype>().OrderBy(a => Loc.GetString(a.Name)))
             {
                 if (!antag.SetPreference)

--- a/Content.Server/Antag/Components/AntagSelectionComponent.cs
+++ b/Content.Server/Antag/Components/AntagSelectionComponent.cs
@@ -185,6 +185,13 @@ public partial struct AntagSelectionDefinition()
     /// </remarks>
     [DataField]
     public EntProtoId? SpawnerPrototype;
+
+    /// <summary>
+    /// Goobstation
+    /// Does this antag role roll before job
+    /// </summary>
+    [DataField]
+    public bool RollBeforeJob = true;
 }
 
 /// <summary>

--- a/Content.Server/Station/Systems/StationJobsSystem.Roundstart.cs
+++ b/Content.Server/Station/Systems/StationJobsSystem.Roundstart.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using Content.Server._Goobstation.PendingAntag;
 using Content.Server.Administration.Managers;
 using Content.Server.Players.PlayTimeTracking;
 using Content.Server.Station.Components;
@@ -17,6 +18,7 @@ public sealed partial class StationJobsSystem
 {
     [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
     [Dependency] private readonly IBanManager _banManager = default!;
+    [Dependency] private readonly PendingAntagSystem _pendingAntag = default!; // Goobstation
 
     private Dictionary<int, HashSet<string>> _jobsByWeight = default!;
     private List<int> _orderedWeights = default!;
@@ -290,7 +292,8 @@ public sealed partial class StationJobsSystem
             }
 
             var profile = profiles[player];
-            if (profile.PreferenceUnavailable != PreferenceUnavailableMode.SpawnAsOverflow)
+            if (profile.PreferenceUnavailable != PreferenceUnavailableMode.SpawnAsOverflow &&
+                !_pendingAntag.PendingAntags.ContainsKey(player)) // Goob edit - spawn as overflow if rolled antag
             {
                 assignedJobs.Add(player, (null, EntityUid.Invalid));
                 continue;
@@ -351,6 +354,8 @@ public sealed partial class StationJobsSystem
 
             List<string>? availableJobs = null;
 
+            var pendingAntag = _pendingAntag.PendingAntags.ContainsKey(player); // Goobstation
+
             foreach (var jobId in profileJobs)
             {
                 var priority = profile.JobPriorities[jobId];
@@ -359,6 +364,9 @@ public sealed partial class StationJobsSystem
                     continue;
 
                 if (!_prototypeManager.TryIndex(jobId, out var job))
+                    continue;
+
+                if (!job.CanBeAntag && pendingAntag) // Goobstation
                     continue;
 
                 if (weight is not null && job.Weight != weight.Value)

--- a/Content.Server/_Goobstation/PendingAntag/PendingAntagSystem.cs
+++ b/Content.Server/_Goobstation/PendingAntag/PendingAntagSystem.cs
@@ -1,0 +1,44 @@
+using Content.Server.Antag;
+using Content.Server.Antag.Components;
+using Content.Server.GameTicking;
+using Content.Shared.GameTicking;
+using Content.Shared.Roles;
+using Robust.Shared.Network;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._Goobstation.PendingAntag;
+
+public sealed class PendingAntagSystem : EntitySystem
+{
+    [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+    [Dependency] private readonly AntagSelectionSystem _selection = default!;
+
+    public Dictionary<NetUserId, (AntagSelectionDefinition, Entity<AntagSelectionComponent>)> PendingAntags = new();
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<RoundRestartCleanupEvent>(OnRoundRestart);
+        SubscribeLocalEvent<PlayerSpawnCompleteEvent>(OnPlayerSpawned);
+    }
+
+    private void OnPlayerSpawned(PlayerSpawnCompleteEvent ev)
+    {
+        if (ev.LateJoin)
+            return;
+
+        if (ev.JobId == null || !_prototypeManager.Index<JobPrototype>(ev.JobId).CanBeAntag)
+            return;
+
+        if (!PendingAntags.Remove(ev.Player.UserId, out var pendingAntag))
+            return;
+
+        _selection.TryMakeAntag(pendingAntag.Item2, ev.Player, pendingAntag.Item1, true);
+    }
+
+    private void OnRoundRestart(RoundRestartCleanupEvent ev)
+    {
+        PendingAntags.Clear();
+    }
+}

--- a/Content.Shared/Antag/AntagAcceptability.cs
+++ b/Content.Shared/Antag/AntagAcceptability.cs
@@ -29,6 +29,12 @@ public enum AntagSelectionTime : byte
     PrePlayerSpawn,
 
     /// <summary>
+    /// Goobstation
+    /// Antag roles are assigned before jobs are assigned and during midround when player latejoins.
+    /// </summary>
+    BeforeJobs,
+
+    /// <summary>
     /// Antag roles get assigned after players have been assigned jobs and have spawned in.
     /// </summary>
     PostPlayerSpawn

--- a/Resources/Locale/en-US/_Goobstation/preferences/ui/humanoid-profile-editor.ftl
+++ b/Resources/Locale/en-US/_Goobstation/preferences/ui/humanoid-profile-editor.ftl
@@ -1,1 +1,2 @@
-humanoid-profile-editor-borgname-label = Preferred Borg Name: 
+humanoid-profile-editor-borgname-label = Preferred Borg Name:
+humanoid-profile-editor-antag-roll-before-jobs = Keep in mind that all antags except for initial infected and sleeper agent are rolled before jobs.

--- a/Resources/Prototypes/GameRules/midround.yml
+++ b/Resources/Prototypes/GameRules/midround.yml
@@ -15,6 +15,7 @@
       maxPicks: 10
     maxDifficulty: 2.5
   - type: AntagSelection
+    selectionTime: BeforeJobs # Goobstation
     agentName: thief-round-end-agent-name
     definitions:
     - prefRoles: [ Thief ]

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -170,10 +170,8 @@
   components:
   - type: GameRule
     minPlayers: 5
-    delay:
-      min: 240
-      max: 420
   - type: AntagSelection
+    selectionTime: BeforeJobs # Goobstation
     definitions:
     - prefRoles: [ Traitor ]
       max: 8
@@ -192,6 +190,7 @@
   components:
   - type: TraitorRule
   - type: AntagSelection
+    selectionTime: PostPlayerSpawn # Goobstation
     definitions:
     - prefRoles: [ Traitor ]
       mindRoles:
@@ -205,6 +204,7 @@
     minPlayers: 15
   - type: RevolutionaryRule
   - type: AntagSelection
+    selectionTime: BeforeJobs # Goobstation
     definitions:
     - prefRoles: [ HeadRev ]
       max: 3

--- a/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
@@ -11,7 +11,6 @@
   startingGear: TechnicalAssistantGear
   icon: "JobIconTechnicalAssistant"
   supervisors: job-supervisors-engineering
-  canBeAntag: false
   access:
   - Maintenance
   - Engineering

--- a/Resources/Prototypes/Roles/Jobs/Medical/medical_intern.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/medical_intern.yml
@@ -1,4 +1,4 @@
-﻿- type: job
+- type: job
   id: MedicalIntern
   name: job-name-intern
   description: job-description-intern
@@ -11,7 +11,6 @@
   startingGear: MedicalInternGear
   icon: "JobIconMedicalIntern"
   supervisors: job-supervisors-medicine
-  canBeAntag: false
   access:
   - Medical
   - Maintenance

--- a/Resources/Prototypes/Roles/Jobs/Science/research_assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_assistant.yml
@@ -1,4 +1,4 @@
-﻿- type: job
+- type: job
   id: ResearchAssistant
   name: job-name-research-assistant
   description: job-description-research-assistant
@@ -11,7 +11,6 @@
   startingGear: ResearchAssistantGear
   icon: "JobIconResearchAssistant"
   supervisors: job-supervisors-science
-  canBeAntag: false
   access:
   - Research
   - Maintenance

--- a/Resources/Prototypes/_Goobstation/GameRules/Dynamic/midround.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/Dynamic/midround.yml
@@ -9,7 +9,7 @@
   components:
   - type: DynamicRuleset
     nameLoc: dynamic-gamerule-midround-traitor-title
-    weight: 30 
+    weight: 30
     cost: 9 # Lmao at 3 cost, the average game has 10-30 midgame pretty often
   - type: StationEvent
     earliestStart: 30
@@ -21,6 +21,8 @@
     duration: null
     occursDuringRoundEnd: false
   - type: AlertLevelInterceptionRule
+  - type: AntagSelection
+    selectionTime: PostPlayerSpawn
 
 # Midround Changelings
 - type: entity
@@ -30,7 +32,7 @@
   - type: DynamicRuleset
     nameLoc: dynamic-gamerule-midround-changeling-title
     weight: 15
-    cost: 12 
+    cost: 12
   - type: StationEvent
     earliestStart: 20
     weight: 3
@@ -41,6 +43,8 @@
     duration: null
     occursDuringRoundEnd: false
   - type: AlertLevelInterceptionRule
+  - type: AntagSelection
+    selectionTime: PostPlayerSpawn
 
 # Midround Heretics
 - type: entity
@@ -52,8 +56,8 @@
     weight: 15
     cost: 15
   - type: StationEvent
-    earliestStart: 20 
-    weight: 3 
+    earliestStart: 20
+    weight: 3
     minimumPlayers: 30
     startAnnouncement: station-event-communication-interception
     startAudio:
@@ -61,6 +65,8 @@
     duration: null
     occursDuringRoundEnd: false
   - type: AlertLevelInterceptionRule
+  - type: AntagSelection
+    selectionTime: PostPlayerSpawn
 
 # Midround Revolutionaries
 - type: entity
@@ -73,12 +79,14 @@
     cost: 30
     highImpact: true
   - type: StationEvent
-    earliestStart: 20 
-    weight: 3 
+    earliestStart: 20
+    weight: 3
     minimumPlayers: 30
     maxOccurrences: 1
     duration: null
     occursDuringRoundEnd: false
+  - type: AntagSelection
+    selectionTime: PostPlayerSpawn
 
 # Skeleton Spawn
 - type: entity
@@ -262,6 +270,7 @@
   - type: NukeopsRule
     warDeclarationMinOps: 1 # challenge mode
   - type: AntagSelection
+    selectionTime: PostPlayerSpawn
     definitions:
     - spawnerPrototype: SpawnPointNukeopsCommander
       min: 1

--- a/Resources/Prototypes/_Goobstation/GameRules/Dynamic/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/Dynamic/roundstart.yml
@@ -23,6 +23,7 @@
   - type: GameRule
     minPlayers: 45 # when the difference between low/med/high actually changes antag count
   - type: AntagSelection
+    selectionTime: BeforeJobs
     definitions:
     - prefRoles: [ Traitor ]
       max: 2
@@ -44,6 +45,7 @@
     cost: 16
     scalingCost: 18
   - type: AntagSelection
+    selectionTime: BeforeJobs
     definitions:
     - prefRoles: [ Traitor ]
       max: 4
@@ -67,6 +69,7 @@
   - type: GameRule
     minPlayers: 30
   - type: AntagSelection
+    selectionTime: BeforeJobs
     definitions:
     - prefRoles: [ Traitor ]
       max: 6
@@ -101,6 +104,7 @@
       maxPicks: 10
     maxDifficulty: 2.5
   - type: AntagSelection
+    selectionTime: BeforeJobs
     agentName: thief-round-end-agent-name
     definitions:
     - prefRoles: [ Thief ]
@@ -134,6 +138,7 @@
     - EscapeIdentityObjective
     - ChangelingSurviveObjective
   - type: AntagSelection
+    selectionTime: BeforeJobs
     agentName: changeling-roundend-name
     definitions:
     - prefRoles: [ Changeling ]
@@ -166,6 +171,7 @@
     - EscapeIdentityObjective
     - ChangelingSurviveObjective
   - type: AntagSelection
+    selectionTime: BeforeJobs
     agentName: changeling-roundend-name
     definitions:
     - prefRoles: [ Changeling ]
@@ -194,6 +200,7 @@
   - type: GameRule
     minPlayers: 40
   - type: AntagSelection
+    selectionTime: BeforeJobs
     agentName: heretic-roundend-name
     definitions:
     - prefRoles: [ Heretic ]
@@ -224,6 +231,7 @@
   - type: GameRule
     minPlayers: 20
   - type: AntagSelection
+    selectionTime: BeforeJobs
     agentName: heretic-roundend-name
     definitions:
     - prefRoles: [ Heretic ]
@@ -255,6 +263,7 @@
   - type: GameRule
     minPlayers: 20
   - type: AntagSelection
+    selectionTime: BeforeJobs
     definitions:
     - prefRoles: [ HeadRev ]
       max: 3
@@ -289,7 +298,7 @@
   - type: LoadMapRule
     mapPath: /Maps/_Goobstation/Nonstations/nukieplanet.yml
   - type: AntagSelection
-    #selectionTime: PrePlayerSpawn
+    selectionTime: PrePlayerSpawn
     definitions:
     - prefRoles: [ NukeopsCommander ]
       fallbackRoles: [ Nukeops, NukeopsMedic ]

--- a/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/GameRules/roundstart.yml
@@ -14,6 +14,7 @@
     - EscapeIdentityObjective
     - ChangelingSurviveObjective
   - type: AntagSelection
+    selectionTime: BeforeJobs
     agentName: changeling-roundend-name
     definitions:
     - prefRoles: [ Changeling ]
@@ -33,6 +34,7 @@
       min: 240
       max: 420
   - type: AntagSelection
+    selectionTime: BeforeJobs
     definitions:
     - prefRoles: [ Traitor ]
       max: 4
@@ -55,6 +57,7 @@
       min: 30
       max: 60
   - type: AntagSelection
+    selectionTime: BeforeJobs
     agentName: changeling-roundend-name
     definitions:
     - prefRoles: [ Changeling ]
@@ -131,6 +134,7 @@
     minPlayers: 30
   - type: RevolutionaryRule
   - type: AntagSelection
+    selectionTime: BeforeJobs
     definitions:
     - prefRoles: [ HeadRev ]
       max: 2

--- a/Resources/Prototypes/_Goobstation/Heretic/GameRules/roundstart.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/GameRules/roundstart.yml
@@ -11,6 +11,7 @@
     - HereticSacrificeObjective
     - HereticSacrificeHeadObjective
   - type: AntagSelection
+    selectionTime: BeforeJobs
     agentName: heretic-roundend-name
     definitions:
     - prefRoles: [ Heretic ]
@@ -31,6 +32,7 @@
       min: 30
       max: 60
   - type: AntagSelection
+    selectionTime: BeforeJobs
     agentName: heretic-roundend-name
     definitions:
     - prefRoles: [ Heretic ]


### PR DESCRIPTION
https://github.com/Goob-Station/Goob-Station/pull/1012#issue-2705214193

> ## About the PR
> Now all antags except initial infected (there must be a delay for them so no zombies roundstart) are not delayed and are rolled before jobs. So you can pick a sec officer and you can still roll antag (your job will be different though). Made that all intern roles can roll antag because why not.
> 
> Hopefully nothing breaks.
> 
> ## Why / Balance
> People asked for it.
> 
> ## Technical details
> ## Media
>  antag.mp4 (pretend this is a video)
> ## Requirements
> * [x]  I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
> * [x]  I have added media to this PR or it does not require an ingame showcase.
**Changelog**
 🆑 Aviu
 - add: Now antags are rolled roundstart and before jobs except for initial infected.
 - add: Intern roles can be antags except for cadet obviously.
