### PR TITLE
ATMOS Resin changes

### DIFF
--- a/Content.Server/Atmos/Components/AtmosResinDespawnComponent.cs
+++ b/Content.Server/Atmos/Components/AtmosResinDespawnComponent.cs
@@ -1,0 +1,12 @@
+using Content.Server.Atmos.EntitySystems;
+
+namespace Content.Server.Atmos.Components;
+
+/// <summary>
+/// Assmos - Extinguisher Nozzle
+/// When a <c>TimedDespawnComponent"</c> despawns, another one will be spawned in its place.
+/// </summary>
+[RegisterComponent, Access(typeof(AtmosResinDespawnSystem))]
+public sealed partial class AtmosResinDespawnComponent : Component
+{
+}

--- a/Content.Server/Atmos/EntitySystems/AtmosResinDespawnSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosResinDespawnSystem.cs
@@ -1,0 +1,44 @@
+using Content.Server.Atmos.Components;
+using Robust.Shared.Spawners;
+using Content.Shared.Atmos;
+using Content.Server.Atmos.EntitySystems;
+
+namespace Content.Server.Atmos.EntitySystems;
+
+
+/// <summary>
+/// Assmos - Extinguisher Nozzle
+/// Sets atmospheric temperature to 20C and removes all toxins. 
+/// </summary>
+public sealed class AtmosResinDespawnSystem : EntitySystem
+{
+    [Dependency] private readonly AtmosphereSystem _atmo = default!;
+    [Dependency] private readonly GasTileOverlaySystem _gasOverlaySystem = default!;
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<AtmosResinDespawnComponent, TimedDespawnEvent>(OnDespawn);
+    }
+
+    private void OnDespawn(EntityUid uid, AtmosResinDespawnComponent comp, ref TimedDespawnEvent args)
+    {
+        if (!TryComp(uid, out TransformComponent? xform))
+            return;
+
+        var mix = _atmo.GetContainingMixture(uid, true);
+
+        if (mix is null) return;
+        mix.AdjustMoles(Gas.CarbonDioxide, -mix.GetMoles(Gas.CarbonDioxide));
+        mix.AdjustMoles(Gas.Plasma, -mix.GetMoles(Gas.Plasma));
+        mix.AdjustMoles(Gas.Tritium, -mix.GetMoles(Gas.Tritium));
+        mix.AdjustMoles(Gas.Ammonia, -mix.GetMoles(Gas.Ammonia));
+        mix.AdjustMoles(Gas.NitrousOxide, -mix.GetMoles(Gas.NitrousOxide));
+        mix.AdjustMoles(Gas.Frezon, -mix.GetMoles(Gas.Frezon));
+        mix.AdjustMoles(Gas.BZ, -mix.GetMoles(Gas.BZ));
+        mix.AdjustMoles(Gas.Healium, -mix.GetMoles(Gas.Healium));
+        mix.AdjustMoles(Gas.Nitrium, -mix.GetMoles(Gas.Nitrium));
+        mix.Temperature = Atmospherics.T20C;
+        _gasOverlaySystem.UpdateSessions();
+    }
+}

--- a/Content.Server/Explosion/EntitySystems/SmokeOnTriggerSystem.cs
+++ b/Content.Server/Explosion/EntitySystems/SmokeOnTriggerSystem.cs
@@ -50,7 +50,6 @@ public sealed class SmokeOnTriggerSystem : SharedSmokeOnTriggerSystem
             return;
         }
 
-        _smoke.StartSmoke(ent, comp.Solution, comp.Duration, comp.SpreadAmount, comp.IsResin, smoke); // Assmos - Extinguisher Nozzle
-        //_smoke.StartSmoke(ent, comp.Solution, comp.Duration, comp.SpreadAmount, smoke); 
+        _smoke.StartSmoke(ent, comp.Solution, comp.Duration, comp.SpreadAmount, smoke); 
     }
 }

--- a/Content.Server/Fluids/EntitySystems/SmokeSystem.cs
+++ b/Content.Server/Fluids/EntitySystems/SmokeSystem.cs
@@ -24,8 +24,6 @@ using System.Linq;
 using Content.Server.Nutrition.Components;
 using Content.Shared.Inventory;
 using TimedDespawnComponent = Robust.Shared.Spawners.TimedDespawnComponent;
-using Content.Shared.Atmos; // Assmos - Extinguisher Nozzle
-using Content.Server.Atmos.EntitySystems; // Assmos - Extinguisher Nozzle
 
 namespace Content.Server.Fluids.EntitySystems;
 
@@ -48,8 +46,6 @@ public sealed class SmokeSystem : EntitySystem
     [Dependency] private readonly SharedPhysicsSystem _physics = default!;
     [Dependency] private readonly SharedSolutionContainerSystem _solutionContainerSystem = default!;
     [Dependency] private readonly InventorySystem _inventory = default!; // Goobstation
-    [Dependency] private readonly AtmosphereSystem _atmo = default!; // Assmos - Extinguisher Nozzle
-    [Dependency] private readonly GasTileOverlaySystem _gasOverlaySystem = default!; // Assmos - Extinguisher Nozzle
 
     private EntityQuery<SmokeComponent> _smokeQuery;
     private EntityQuery<SmokeAffectedComponent> _smokeAffectedQuery;
@@ -155,8 +151,7 @@ public sealed class SmokeSystem : EntitySystem
             var spreadAmount = Math.Max(0, smokePerSpread);
             entity.Comp.SpreadAmount -= args.NeighborFreeTiles.Count;
 
-            StartSmoke(ent, solution.Clone(), timer?.Lifetime ?? entity.Comp.Duration, spreadAmount, entity.Comp.IsResin); // Assmos - Extinguisher Nozzle
-            //StartSmoke(ent, solution.Clone(), timer?.Lifetime ?? entity.Comp.Duration, spreadAmount);
+            StartSmoke(ent, solution.Clone(), timer?.Lifetime ?? entity.Comp.Duration, spreadAmount);
 
             if (entity.Comp.SpreadAmount == 0)
             {
@@ -218,15 +213,10 @@ public sealed class SmokeSystem : EntitySystem
     /// <summary>
     /// Sets up a smoke component for spreading.
     /// </summary>
-    public void StartSmoke(EntityUid uid, Solution solution, float duration, int spreadAmount, bool isResin = false, SmokeComponent? component = null)
+    public void StartSmoke(EntityUid uid, Solution solution, float duration, int spreadAmount, SmokeComponent? component = null)
     {
         if (!Resolve(uid, ref component))
             return;
-
-        // Assmos - Extinguisher Nozzle
-        component.IsResin = isResin;
-        if (component.IsResin) UpdateAtmosphere(uid);
-        // Assmos end
 
         component.SpreadAmount = spreadAmount;
         component.Duration = duration;
@@ -365,27 +355,5 @@ public sealed class SmokeSystem : EntitySystem
 
         var color = solution.GetColor(_prototype);
         _appearance.SetData(smoke.Owner, SmokeVisuals.Color, color, smoke.Comp2);
-    }
-
-    /// <summary>
-    /// Used for ATMOS Resin. Assmos - Extinguisher Nozzle. 
-    /// This only deals with the resin's effect on the atmosphere. Should eventually be moved to an atmopsheric system and component and made less rigid. 
-    /// </summary>
-    private void UpdateAtmosphere(EntityUid uid)
-    {
-        var mix = _atmo.GetContainingMixture(uid, true);
-
-        if (mix is null) return;
-        mix.AdjustMoles(Gas.CarbonDioxide, -mix.GetMoles(Gas.CarbonDioxide));
-        mix.AdjustMoles(Gas.Plasma, -mix.GetMoles(Gas.Plasma));
-        mix.AdjustMoles(Gas.Tritium, -mix.GetMoles(Gas.Tritium));
-        mix.AdjustMoles(Gas.Ammonia, -mix.GetMoles(Gas.Ammonia));
-        mix.AdjustMoles(Gas.NitrousOxide, -mix.GetMoles(Gas.NitrousOxide));
-        mix.AdjustMoles(Gas.Frezon, -mix.GetMoles(Gas.Frezon));
-        mix.AdjustMoles(Gas.BZ, -mix.GetMoles(Gas.BZ));
-        mix.AdjustMoles(Gas.Healium, -mix.GetMoles(Gas.Healium));
-        mix.AdjustMoles(Gas.Nitrium, -mix.GetMoles(Gas.Nitrium));
-        mix.Temperature = Atmospherics.T20C;
-        _gasOverlaySystem.UpdateSessions();
     }
 }

--- a/Content.Shared/Chemistry/Components/SmokeComponent.cs
+++ b/Content.Shared/Chemistry/Components/SmokeComponent.cs
@@ -37,11 +37,4 @@ public sealed partial class SmokeComponent : Component
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite), AutoNetworkedField]
     public float Duration = 10;
-
-    /// <summary>
-    /// Assmos - Extinguisher Nozzle. 
-    /// </summary>
-    [DataField]
-    public bool IsResin = false;
-
 }

--- a/Content.Shared/Explosion/Components/OnTrigger/SmokeOnTriggerComponent.cs
+++ b/Content.Shared/Explosion/Components/OnTrigger/SmokeOnTriggerComponent.cs
@@ -39,10 +39,4 @@ public sealed partial class SmokeOnTriggerComponent : Component
     /// </remarks>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public Solution Solution = new();
-
-    /// <remarks>
-    /// Assmos - Extinguisher Nozzle.
-    /// </remarks>
-    [DataField]
-    public bool IsResin = false;
 }

--- a/Resources/Prototypes/Entities/Clothing/Back/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/specific.yml
@@ -84,14 +84,14 @@
   - type: SolutionAmmoProvider
     solutionId: tank
     proto: AtmosResin
-    fireCost: 50
+    fireCost: 40
   - type: SolutionContainerManager
     solutions:
       tank:
-        maxVol: 1250
+        maxVol: 1200
         reagents:
         - ReagentId: Water
-          Quantity: 1250
+          Quantity: 1200
   - type: SolutionTransfer
     transferAmount: 50
     maxTransferAmount: 100

--- a/Resources/Prototypes/Entities/Effects/chemistry_effects.yml
+++ b/Resources/Prototypes/Entities/Effects/chemistry_effects.yml
@@ -267,3 +267,4 @@
   - type: FoamVisuals
     animationTime: 0.6
     animationState: resin-dissolve
+  - type: AtmosResinDespawn

--- a/Resources/Prototypes/Entities/Objects/Tools/firefightingnozzle.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/firefightingnozzle.yml
@@ -61,7 +61,6 @@
     sprite: Objects/Weapons/Grenades/frozen-smoke-capsule.rsi
     state: icon
   - type: SmokeOnTrigger
-    isResin: true
     duration: 12
     spreadAmount: 1000
     smokePrototype: Resin

--- a/Resources/Prototypes/Entities/Objects/Tools/firefightingnozzle.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/firefightingnozzle.yml
@@ -1,4 +1,5 @@
-﻿- type: entity
+﻿# Assmos - Extinguisher Nozzle
+- type: entity
   id: FirefighterNozzle
   parent: BaseItem
   name: firefighter nozzle
@@ -61,10 +62,10 @@
     state: icon
   - type: SmokeOnTrigger
     isResin: true
-    duration: 5
+    duration: 12
     spreadAmount: 1000
     smokePrototype: Resin
   - type: ActiveTimerTrigger
     timeRemaining: 0.3
   - type: DeleteOnTrigger
-        
+  


### PR DESCRIPTION
## About the PR
ATMOS resin has been changed to remove toxins and normalize temperatures on dissipation rather than on initial tile spread, making ATMOS resin much stronger. Duration, and therefore spread, of ATMOS resin has also been increased, making it capable of effecting much larger rooms. Cost of firing resin has been reduced from 50 to 40, and the firefighting backpack capacity has been lowered from 1250 to 1200. 

## Why / Balance
The old system was built into SmokeSystem and needed to be moved to it's own atmospheric system and component. Having resin only clean the tiles on initial spread scaled poorly with duration and spread properties. 

## Technical details
- Reverted SmokeSystem, SmokeComponent, and SmokeOnTriggerComponent to their originals
- Made a AtmosResinDespawnComponent and AtmosResinDespawnSystem to handle temperature normalization and toxin removal

## Media
None

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None

**Changelog**
:cl: 
- tweak: ATMOS Resin cleans air on despawn