### PR TITLE
Adds holy to damage modifiers, buffs zombies, nerfs skeletons

### DIFF
--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -171,7 +171,7 @@
     Piercing: 0.8
     Cold: 0.8
     Heat: 0.2
-#   Holy: 3 If we ever get some holy or magic sort of damage type they should be vulnerable
+    Holy: 2.0 #funkystation
   flatReductions:
     Heat: 3
 
@@ -202,28 +202,28 @@
 - type: damageModifierSet
   id: Zombie #Blunt resistant and immune to biological threats, but can be hacked apart and burned
   coefficients:
-    Blunt: 0.6
-    Piercing: 0.8
+    Blunt: 0.5 #funkystation
+    Piercing: 0.5 #funkystation
     Cold: 0.3
-    Heat: 1.25
+    Heat: 0.6 #funkystation
     Poison: 0.0
     Radiation: 0.0
+    Holy: 1.5 #funkystation`
 
 # immune to everything except physical and heat damage
 - type: damageModifierSet
   id: Skeleton
   coefficients:
-    Blunt: 1.1
+    Blunt: 1.5 #funkystation
     Slash: 0.8
     Piercing: 0.6
+    Holy: 1.5 #funkystation
     Cold: 0.0
     Poison: 0.0
     Radiation: 0.0
     Asphyxiation: 0.0
     Bloodloss: 0.0
     Cellular: 0.0
-  flatReductions:
-    Blunt: 5
 
 # hurt a lot by blunt, immune to a good amount of other stuff because they're a cookie
 - type: damageModifierSet
@@ -273,6 +273,7 @@
     Radiation: 0.0
     Shock: 0.8
     Bloodloss: 0.4
+    Holy: 2.0 #funkystation
 
 - type: damageModifierSet
   id: Cockroach

--- a/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/skeleton.yml
@@ -18,7 +18,7 @@
     requiredLegs: 2
     gibSound: /Audio/Effects/bone_rattle.ogg
   - type: Damageable
-    damageContainer: Biological
+    damageContainer: BiologicalMetaphysical
     damageModifierSet: Skeleton
   - type: DamageVisuals
     damageOverlayGroups:


### PR DESCRIPTION
Title

Silver ammo might prove useful now.

Zombies still don't take holy damage (they can't unless I modified the damage container which I can't figure out how to do)

:cl: Mish
- tweak: Skeletons now take twice as much brute and holy damage.
- tweak: Zombies take less damage from most sources besides holy.
- tweak: Holy damage real?
