### PR TITLE
Minor blob changes

### DIFF
--- a/Content.Shared/_Goobstation/Blob/Components/BlobCoreComponent.cs
+++ b/Content.Shared/_Goobstation/Blob/Components/BlobCoreComponent.cs
@@ -132,7 +132,7 @@ public sealed partial class BlobCoreComponent : Component
     public int ResourceBlobsTotal;
 
     [DataField]
-    public FixedPoint2 AttackCost = 4;
+    public FixedPoint2 AttackCost = 1;
 
     [DataField]
     public BlobTileCosts BlobTileCosts = new()

--- a/Resources/Prototypes/_Goobstation/Blob/blob_mobs.yml
+++ b/Resources/Prototypes/_Goobstation/Blob/blob_mobs.yml
@@ -121,7 +121,7 @@
       description: ghost-role-information-blobbernaut-description
       rules: You are an antagonist, defend your blob core!
       raffle:
-        settings: default
+        settings: short
     - type: GhostTakeoverAvailable
     - type: Blobbernaut
     - type: Physics

--- a/Resources/Prototypes/_Goobstation/Blob/misc_blob.yml
+++ b/Resources/Prototypes/_Goobstation/Blob/misc_blob.yml
@@ -26,10 +26,10 @@
   id: BlobMob
 
 - type: entity
-  name: cancer mouse
-  description: Toxic. Squeak!
-  parent: MobMouseCancer
-  id: MobMouseCancerBlob
+  name: mouse
+  description: Squeak!
+  parent: MobMouse
+  id: MobMouseBlob
   suffix: Blob
   components:
   - type: BlobCarrier
@@ -41,7 +41,7 @@
   parent: BaseAntagSpawner
   components:
     - type: GhostRoleMobSpawner
-      prototype: MobMouseCancerBlob
+      prototype: MobMouseBlob
     - type: GhostRole
       makeSentient: true
       name: blob-carrier-role-name


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
* Blob attack costs 1 instead of 4
* Midround blob now spawns as a regular mouse
* Blobbernauts now have short raffles

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Hopefully making blob a little less painful to play and get set up

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
-->
:cl:
- tweak: Blob abilities tweaked & midround blob spawns as a regular mouse