### PR TITLE
Nerfed the Medical Multitool's doAfter Speed

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
@@ -445,25 +445,25 @@
     startSound:
       path: /Audio/_Shitmed/Medical/Surgery/saw.ogg
   - type: Hemostat
-    speed: 0.75
+    speed: 0.75  # funkystation
   - type: Scalpel
-    speed: 0.75
+    speed: 0.75  # funkystation
   - type: Drill
-    speed: 0.75
+    speed: 0.75  # funkystation
   - type: BoneSetter
-    speed: 0.75
+    speed: 0.75  # funkystation
   - type: Retractor
-    speed: 0.75
+    speed: 0.75  # funkystation
   - type: Cautery
-    speed: 0.75
+    speed: 0.75  # funkystation
   - type: BoneGel
-    speed: 0.75
+    speed: 0.75  # funkystation
   - type: BoneSaw
-    speed: 0.75
+    speed: 0.75  # funkystation
   - type: Tweezers
-    speed: 0.75
+    speed: 0.75  # funkystation
   - type: Tending
-    speed: 0.75
+    speed: 0.75  # funkystation
 
 - type: entity
   parent: [ OmnimedTool, BaseSyndicateContraband ]

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/surgery.yml
@@ -445,25 +445,25 @@
     startSound:
       path: /Audio/_Shitmed/Medical/Surgery/saw.ogg
   - type: Hemostat
-    speed: 2
+    speed: 0.75
   - type: Scalpel
-    speed: 2
+    speed: 0.75
   - type: Drill
-    speed: 2
+    speed: 0.75
   - type: BoneSetter
-    speed: 2
+    speed: 0.75
   - type: Retractor
-    speed: 2
+    speed: 0.75
   - type: Cautery
-    speed: 2
+    speed: 0.75
   - type: BoneGel
-    speed: 2
+    speed: 0.75
   - type: BoneSaw
-    speed: 2
+    speed: 0.75
   - type: Tweezers
-    speed: 2
+    speed: 0.75
   - type: Tending
-    speed: 2
+    speed: 0.75
 
 - type: entity
   parent: [ OmnimedTool, BaseSyndicateContraband ]


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
The Medical Multitool's doAfter speed (the speed at which the loading bar progresses) has been changed from 2x the normal tool speed to 0.75x the normal tool speed.

Credit to Cthyga on the Funky Station Discord for the original idea for this nerf.

## Why / Balance
If the normal tools are considered the baseline of speed, then there are only two ways they could be improved. One could either:
1) Increase the speed of the loading bar (shorter doAfter speeds), shortening the amount of time it takes to complete a single step
or
2) Combine multiple surgical tools into one object, decreasing the time it takes for you to move from one step to the next.

Going beyond the basic surgery tools, a set of upgraded tools already exists that accomplishes the first possibility (the Advanced Retractor, the Energy Scalpel, the Searing Tool, etc). These tools are specialized, but perform their surgeries much faster than their basic counterparts.

The Surgical Multitool is an object that should accomplish the second possibility. By combining every surgical tool into one, you will save _enormous_ amounts of time that would otherwise be spent juggling objects around, closing and re-opening menus, etc. The Surgical Multitool eliminates all that and makes every surgery a matter of clicking one button after the next.

It does not make sense that the Surgical Multitool, an item that accomplishes the second possibility extremely well and already saves tons of time on that point alone, should also not only have shorter doAfter times than the normal surgical tools, but also **shorter doAfter times than the highly specialized, UPGRADED surgical tools.**

If the upgraded surgical tools exist for the purpose of allowing a surgeon to perform those specific tasks at very high speeds, then the Surgical Multitool should not be allowed to make them redundant. This nerf ensures that the Surgical Multitool remains highly valuable as a one-size-fits-all problem solver that still simplifies all surgeries down to clicking a series of buttons, while simultaneously ensuring that the more specialized, upgraded surgical tools still have a reason to exist.

## Technical details
Changed some numbers.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Reduced Surgical Multitool doAfter time.
