### PR TITLE
Removes Antag scheduler from Blob gamemode

### DIFF
--- a/Resources/Prototypes/_Goobstation/game_presets.yml
+++ b/Resources/Prototypes/_Goobstation/game_presets.yml
@@ -103,6 +103,5 @@
   rules:
   - BlobGameMode
   - BasicStationEventScheduler
-  - AntagStationEventScheduler
   - BasicRoundstartVariation
   - SubGamemodesRule


### PR DESCRIPTION

## Why
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Now in-line with the rest of the gamemodes so events aren't firing double what they should be
## Technical details
<!-- Summary of code changes for easier review. -->
Removed a line