### PR TITLE
Add exact Blob Resource display on alert

### DIFF
--- a/Content.Server/_Goobstation/Blob/BlobCoreSystem.cs
+++ b/Content.Server/_Goobstation/Blob/BlobCoreSystem.cs
@@ -242,7 +242,8 @@ public sealed class BlobCoreSystem : EntitySystem
         // This one for points
         var pt = store.Balance.GetValueOrDefault(BlobMoney);
         var pointsSeverity = (short) Math.Clamp(Math.Round(pt.Float() / 10f), 0, 51);
-        _alerts.ShowAlert(component.Observer.Value, BlobResource, pointsSeverity);
+        string? pointsMessage = "Points: " + pt;
+        _alerts.ShowAlert(component.Observer.Value, BlobResource, pointsSeverity, dynamicMessage: pointsMessage);
 
         // And this one for health.
         if (!TryComp<DamageableComponent>(core.Owner, out var damageComp))


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Mousing over the alert Blob Resources alert will show you how many points you have

## Why / Balance
The current display method is evil and inaccurate, more integration of ported feature

## Technical details
<!-- Summary of code changes for easier review. -->

## Media

https://github.com/user-attachments/assets/02dce84a-7f52-435c-9e0e-90e3c957c80a

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl:
- add: The Blob can now see their exact resource total in real-time by mousing over the Blob Resources Alert on the right side of the screen.

