### PR TITLE
Revs: Evac shuttle doesn't arrive when HRevs are alive

### DIFF
--- a/Content.Server/GameTicking/Rules/Components/RevolutionaryRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/RevolutionaryRuleComponent.cs
@@ -27,10 +27,18 @@ public sealed partial class RevolutionaryRuleComponent : Component
     /// The time it takes after the last head is killed for the shuttle to arrive.
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public TimeSpan ShuttleCallTime = TimeSpan.FromMinutes(5);
+    public TimeSpan ShuttleCallTime = TimeSpan.FromSeconds(20);
 
     // goob edit start
     [DataField] public bool HasAnnouncementPlayed = false;
     [DataField] public bool HasRevAnnouncementPlayed = false;
     // gobo edit end
+
+    // funky station
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public TimeSpan? RevVictoryEndTime;
+
+    // funky station
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public TimeSpan RevVictoryEndDelay = TimeSpan.FromMinutes(2);
 }

--- a/Content.Server/GameTicking/Rules/Components/RevolutionaryRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/RevolutionaryRuleComponent.cs
@@ -27,7 +27,7 @@ public sealed partial class RevolutionaryRuleComponent : Component
     /// The time it takes after the last head is killed for the shuttle to arrive.
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public TimeSpan ShuttleCallTime = TimeSpan.FromSeconds(20);
+    public TimeSpan ShuttleCallTime = TimeSpan.FromMinutes(3);
 
     // goob edit start
     [DataField] public bool HasAnnouncementPlayed = false;

--- a/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
@@ -36,7 +36,6 @@ using Content.Shared.Chat;
 using Content.Server.Chat.Systems;
 using Content.Shared.Changeling;
 using Content.Shared.Heretic;
-using Timer = Robust.Shared.Timing.Timer;
 
 namespace Content.Server.GameTicking.Rules;
 

--- a/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
@@ -66,8 +66,6 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
     public readonly ProtoId<NpcFactionPrototype> RevolutionaryNpcFaction = "Revolutionary";
     public readonly ProtoId<NpcFactionPrototype> RevPrototypeId = "Rev";
 
-    private CancellationTokenSource? _cancellationTokenSource;
-
     public override void Initialize()
     {
         base.Initialize();

--- a/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
@@ -267,7 +267,7 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
     /// <summary>
     /// Checks if all the Head Revs are dead and if so will deconvert all regular revs.
     /// </summary>
-    public bool CheckRevsLose(bool deconvertRevs = true) // this should have been just a simple check w no logic
+    private bool CheckRevsLose(bool deconvertRevs = true) // this should have been just a simple check w no logic
     {
         var stunTime = TimeSpan.FromSeconds(4);
         var headRevList = new List<EntityUid>();

--- a/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
+++ b/Content.Server/Shuttles/Systems/EmergencyShuttleSystem.cs
@@ -428,6 +428,23 @@ public sealed partial class EmergencyShuttleSystem : EntitySystem
     /// </remarks>
     public void DockEmergencyShuttle()
     {
+        // funky station
+        // fires an event that the emergency shuttle is trying to dock.
+        var query = AllEntityQuery<StationEmergencyShuttleComponent>();
+
+        var ev = new ShuttleDockAttemptEvent();
+        RaiseLocalEvent(ref ev); // 💔
+
+        if (ev.Cancelled)
+        {
+            while (query.MoveNext(out var uid, out _))
+            {
+                _chatSystem.DispatchStationAnnouncement(uid, ev.CancelMessage);
+            }
+
+            return;
+        }
+
         if (EmergencyShuttleArrived)
             return;
 
@@ -439,8 +456,6 @@ public sealed partial class EmergencyShuttleSystem : EntitySystem
 
         _consoleAccumulator = _configManager.GetCVar(CCVars.EmergencyShuttleDockTime);
         EmergencyShuttleArrived = true;
-
-        var query = AllEntityQuery<StationEmergencyShuttleComponent>();
 
         var dockResults = new List<ShuttleDockResult>();
 
@@ -737,4 +752,12 @@ public sealed partial class EmergencyShuttleSystem : EntitySystem
         /// </summary>
         GoodLuck,
     }
+}
+
+// funky station
+[ByRefEvent]
+public record struct ShuttleDockAttemptEvent()
+{
+    public bool Cancelled = false;
+    public string CancelMessage = string.Empty;
 }

--- a/Resources/Locale/en-US/_Funkystation/shuttle/fail_reasons.ftl
+++ b/Resources/Locale/en-US/_Funkystation/shuttle/fail_reasons.ftl
@@ -1,0 +1,1 @@
+shuttle-dock-fail-revs = Central Command has received reports of unusual activity on the station. The shuttle has been returned to base as a precaution, and will not be usable until the situation has been resolved.

--- a/Resources/Locale/en-US/_Goobstation/game-ticking/game-presets/presets-revolutionaries.ftl
+++ b/Resources/Locale/en-US/_Goobstation/game-ticking/game-presets/presets-revolutionaries.ftl
@@ -10,5 +10,5 @@ revolutionaries-win-announcement =
 
     Viva la revolución!
 
-revolutionaries-win-sender = Taipan Communications
+revolutionaries-win-sender = Yucatan Communications
 revolutionaries-sender-cc = Central Command


### PR DESCRIPTION
# This PR is part of a larger Revolutionaries rework.
Any PR with this as the header is considered a part of the larger revs rework at Funky Station.

## About the PR
When Command calls the evac shuttle, after the wait period ends, the evac shuttle doesn't arrive. Instead, a message is broadcast that the evac shuttle could not dock because of strange activity on the station. Also with this change, when all of command is dead, the round just ends. (We understand that rounds with no command will just auto-end, too bad too sad.)

This PR also changes `revolutionaries-win-sender` to Yucatan Communications, to be more in-line with Funky lore.

## Why / Balance
Too many half measures and half baked features make revs terrible to play on Goob down-streams. Having the communications console just not be able to call evac makes the game-mode so easy to meta. The terror and panic (or wonder and excitement!) that ensues when you realize that your station is full of revolutionaries is what makes this game-mode good. This should also allow rounds to end nicer and more gracefully, as there is a 2 minute cool-down to the round ending when revs win.

Also, revs going to centcomm is stupid asf idc what anyone says.

We also hope that this encourages HRevs to play things safer, and to stop charging into security with no armor expecting a different outcome other than being gunned down immediately.

## Technical details
Adds a new event to `EmergencyShuttleSystem` called  `ShuttleDockAttemptEvent`, which quite frankly was missing on upstream. Should be obvious when this is called in-game (when the evac shuttle... attempts to dock lol)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
idk lol

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl: taydeo, Rainbeon
- tweak: The Evacuation Shuttle no longer Docks when HRevs are still alive
- tweak: The game now auto-ends when revolutionaries win.
- tweak: The Evacuation shuttle is now auto-called when HRevs die.
