### PR TITLE
The Salv Shuttle Computer Strikes Back

### DIFF
--- a/Resources/Locale/en-US/objectives/conditions/steal-target-groups.ftl
+++ b/Resources/Locale/en-US/objectives/conditions/steal-target-groups.ftl
@@ -36,6 +36,7 @@ steal-target-groups-fire-axe = fireaxe
 steal-target-groups-ame-part-flatpack =  AME flatpack
 steal-target-groups-salvage-expeditions-computer-circuitboard = salvage expeditions computer board
 steal-target-groups-cargo-shuttle-console-circuitboard = cargo shuttle console board
+steal-target-groups-salvage-shuttle-console-circuitboard = salvage shuttle console board
 steal-target-groups-clothing-eyes-hud-beer = beer goggles
 steal-target-groups-bible = bible
 steal-target-groups-clothing-neck-goldmedal = gold medal of crewmanship

--- a/Resources/Prototypes/Objectives/stealTargetGroups.yml
+++ b/Resources/Prototypes/Objectives/stealTargetGroups.yml
@@ -229,6 +229,13 @@
     state: cpuboard
 
 - type: stealTargetGroup
+  id: SalvageShuttleConsoleCircuitboard
+  name: salvage shuttle console board
+  sprite:
+    sprite: Objects/Misc/module.rsi
+    state: cpuboard
+
+- type: stealTargetGroup
   id: ClothingEyesHudBeer
   name: steal-target-groups-clothing-eyes-hud-beer
   sprite:

--- a/Resources/Prototypes/Objectives/stealTargetGroups.yml
+++ b/Resources/Prototypes/Objectives/stealTargetGroups.yml
@@ -230,7 +230,7 @@
 
 - type: stealTargetGroup
   id: SalvageShuttleConsoleCircuitboard
-  name: salvage shuttle console board
+  name: steal-target-groups-salvage-shuttle-console-circuitboard
   sprite:
     sprite: Objects/Misc/module.rsi
     state: cpuboard

--- a/Resources/Prototypes/Objectives/thief.yml
+++ b/Resources/Prototypes/Objectives/thief.yml
@@ -259,6 +259,17 @@
   - type: Objective
     difficulty: 0.7
 
+- type: entity
+  parent: BaseThiefStealObjective
+  id: SalvageShuttleCircuitboardStealObjective
+  components:
+  - type: NotJobRequirement
+    job: SalvageSpecialist
+  - type: StealCondition
+    stealGroup: SalvageShuttleConsoleCircuitboard
+  - type: Objective
+    difficulty: 0.7
+
 - type: entity                                      #Service subgroup
   parent: BaseThiefStealObjective
   id: ClothingEyesHudBeerStealObjective

--- a/Resources/migration.yml
+++ b/Resources/migration.yml
@@ -417,11 +417,6 @@ ClothingBeltSuspenders: ClothingBeltSuspendersRed
 # 2024-08-19
 ClothingNeckShockCollar: ClothingBackpackElectropack
 
-# 2024-08-22
-ComputerShuttleSalvage: null
-SalvageShuttleConsoleCircuitboard: null
-SalvageShuttleCircuitboardStealObjective: null
-
 # 2024-08-28
 ClothingBackpackDuffelSyndicateCostumeCentcom: null
 ClothingHeadsetAltCentComFake: null


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
This PR is licensed under MIT
## About the PR
<!-- What did you change? -->
In  a world long long ago, salvage was slayed with this PR https://github.com/space-wizards/space-station-14/pull/31333 While many battles have been fought to return them to their true power, we have fallen short. This PR brings us one step closer to greatness.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This PR should stop the removal of the salv shuttle console from maps happening automatically and returns the steal the salv shuttle console board back to the thief's list possible goals.
## Technical details
<!-- Summary of code changes for easier review. -->
Mostly just reverts of most of this PR https://github.com/space-wizards/space-station-14/pull/31333 I am not sure if this will auto re-add the console to maps, if it doesnt then a follow up PR can readd them without worry of them auto removing.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Stops the removal of the salv shuttle computer from maps