### PR TITLE
Revs: Revolution fails if HRevs abandon station for >1 minute.

### DIFF
--- a/Content.Server/GameTicking/Rules/Components/RevolutionaryRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/RevolutionaryRuleComponent.cs
@@ -41,4 +41,16 @@ public sealed partial class RevolutionaryRuleComponent : Component
     // funky station
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public TimeSpan RevVictoryEndDelay = TimeSpan.FromMinutes(2);
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public TimeSpan? RevLoseTime;
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public TimeSpan OffStationTimer = TimeSpan.FromMinutes(1);
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public bool RevLossTimerActive = false;
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public bool RevForceLose = false;
 }

--- a/Resources/Locale/en-US/game-ticking/game-presets/preset-revolutionary.ftl
+++ b/Resources/Locale/en-US/game-ticking/game-presets/preset-revolutionary.ftl
@@ -71,3 +71,7 @@ rev-deconverted-text =
 
     You are no longer a revolutionary, so be nice.
 rev-deconverted-confirm = Confirm
+
+rev-headrev-must-return = The Revolution is leaderless. We must return to the station within a minute!
+rev-headrev-returned = A Head Revolutionary has returned to the station, the Revolution continues!
+rev-headrev-abandoned = You have disgraced the revolution by abandoning your station. The Revolution is over.


### PR DESCRIPTION
# This PR is part of a larger Revolutionaries rework.
Any PR with this as the header is considered a part of the larger revs rework at Funky Station.

## About the PR
If there are still alive Head Revolutionaries, but none of them are on station, they will prompted to return to the station within 1 minute, or else they lose. Upon atleast one returning to the station, all Head Revs will be notified that the Revolution is no longer at risk, and the timer will stop. 

The timer will reset to its full length and activate if this condition is triggered again.

## Why / Balance
Prevent ATS/shuttle camping and round stalling. Just like Command has to be on station to progress the round, so do Head Revs.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl:
- tweak: If all alive Head Revolutionaries abandon the station, a 1 minute timer will now start that counts down until a Head Revolutionary returns. If no Head Revolutionaries return, the game will consider this as the Revolution failing, and all Revs will be de-converted + the shuttle called on the next check. If a single Head Revolutionary returns, the timer will stop, and the game will continue as normal.
