### PR TITLE
Refactored Silicon Laws

### DIFF
--- a/Content.Server/Silicons/Laws/IonStormSystem.cs
+++ b/Content.Server/Silicons/Laws/IonStormSystem.cs
@@ -85,53 +85,20 @@ public sealed class IonStormSystem : EntitySystem
 
         // shuffle them all
         if (_robustRandom.Prob(target.ShuffleChance))
-        {
-            // hopefully work with existing glitched laws if there are multiple ion storms
-            var baseOrder = FixedPoint2.New(1);
-            foreach (var law in laws.Laws)
-            {
-                if (law.Order < baseOrder)
-                    baseOrder = law.Order;
-            }
-
-            _robustRandom.Shuffle(laws.Laws);
-
-            // change order based on shuffled position
-            for (int i = 0; i < laws.Laws.Count; i++)
-            {
-                laws.Laws[i].Order = baseOrder + i;
-            }
-        }
+			_siliconLaw.ShuffleLawset(laws);
 
         // see if we can remove a random law
         if (laws.Laws.Count > 0 && _robustRandom.Prob(target.RemoveChance))
-        {
-            var i = _robustRandom.Next(laws.Laws.Count);
-            laws.Laws.RemoveAt(i);
-        }
+			_siliconLaw.RemoveRandomLaw(laws);
 
         // generate a new law...
         var newLaw = GenerateLaw();
 
         // see if the law we add will replace a random existing law or be a new glitched order one
         if (laws.Laws.Count > 0 && _robustRandom.Prob(target.ReplaceChance))
-        {
-            var i = _robustRandom.Next(laws.Laws.Count);
-            laws.Laws[i] = new SiliconLaw()
-            {
-                LawString = newLaw,
-                Order = laws.Laws[i].Order
-            };
-        }
-        else
-        {
-            laws.Laws.Insert(0, new SiliconLaw
-            {
-                LawString = newLaw,
-                Order = -1,
-                LawIdentifierOverride = Loc.GetString("ion-storm-law-scrambled-number", ("length", _robustRandom.Next(5, 10)))
-            });
-        }
+			_siliconLaw.ReplaceRandomLaw(laws, newLaw);
+		else
+			_siliconLaw.AddIonLaw(laws, newLaw);
 
         // sets all unobfuscated laws' indentifier in order from highest to lowest priority
         // This could technically override the Obfuscation from the code above, but it seems unlikely enough to basically never happen

--- a/Content.Server/Silicons/Laws/SiliconLawSystem.cs
+++ b/Content.Server/Silicons/Laws/SiliconLawSystem.cs
@@ -137,7 +137,7 @@ public sealed class SiliconLawSystem : SharedSiliconLawSystem
 		return component.Lawset;
 	}
 
-	// --------------------- Law Setters ------------------------
+	#region LawSetters
 	/// <summary>
 	/// Add a law to the current lawset.
 	/// </summary>
@@ -271,8 +271,8 @@ public sealed class SiliconLawSystem : SharedSiliconLawSystem
 		};
 		lawset.CustomLaws.Add(law);
 	}
-	// ----------------------------------------------------------
-	// -------------------- Law Modifiers -----------------------
+	#endregion
+	#region LawModifiers
 	/// <summary>
 	/// Wipe all laws in the Lawset group.
 	/// </summary>
@@ -385,7 +385,7 @@ public sealed class SiliconLawSystem : SharedSiliconLawSystem
             };
 		}		
 	}
-	// ----------------------------------------------------------
+	#endregion
 
 	/// <summary>
 	/// Generate a random string of characters for

--- a/Content.Shared/Silicons/Laws/SiliconLawPrototype.cs
+++ b/Content.Shared/Silicons/Laws/SiliconLawPrototype.cs
@@ -14,6 +14,13 @@ public partial class SiliconLaw : IComparable<SiliconLaw>, IEquatable<SiliconLaw
     [DataField(required: true), ViewVariables(VVAccess.ReadWrite)]
     public string LawString = string.Empty;
 
+	/// <summary>
+	/// The law group that the law fits into. Combined with the Order,
+	/// this determines where the law falls in the sequence.
+	/// </summary>
+	[DataField(required: true), ViewVariables(VVAccess.ReadWrite)]
+	public LawGroups LawGroup;
+
     /// <summary>
     /// The order of the law in the sequence.
     /// Also is the identifier if <see cref="LawIdentifierOverride"/> is null.
@@ -72,6 +79,28 @@ public partial class SiliconLaw : IComparable<SiliconLaw>, IEquatable<SiliconLaw
             LawIdentifierOverride = LawIdentifierOverride
         };
     }
+
+	/// <summary>
+    /// Return a deep clone of this law.
+    /// </summary>
+	public SiliconLaw DeepClone()
+	{
+		return new SiliconLaw()
+		{
+			LawString = new string(LawString),
+			Order = FixedPoint2.New(Order.Value),
+			LawIdentifierOverride = ((LawIdentifierOverride == null) ? null : new string(LawIdentifierOverride))
+		};
+	}
+}
+
+public enum LawGroups
+{
+	Law0,
+	HackedLaw,
+	IonLaw,
+	LawsetLaw,
+	CustomLaw
 }
 
 /// <summary>

--- a/Content.Shared/Silicons/Laws/SiliconLawsetPrototype.cs
+++ b/Content.Shared/Silicons/Laws/SiliconLawsetPrototype.cs
@@ -11,11 +11,40 @@ namespace Content.Shared.Silicons.Laws;
 [DataDefinition, Serializable, NetSerializable]
 public sealed partial class SiliconLawset
 {
+	/// <summary>
+	/// Law Zero, the highest priority law (for emag loyalty, malf, onehuman).
+	/// NEVER MODIFY THIS EXCEPT THROUGH THE SiliconLawSystem.cs
+	/// </summary>
+	[DataField]
+	public SiliconLaw? Law0 = null;
+
+	/// <summary>
+	/// Hacked Laws (for emag directives).
+	/// NEVER MODIFY THIS EXCEPT THROUGH THE SiliconLawSystem.cs
+	/// </summary>
+	[DataField]
+	public List<SiliconLaw> HackedLaws = new();
+
+	/// <summary>
+	/// Ion Storm Laws.
+	/// NEVER MODIFY THIS EXCEPT THROUGH THE SiliconLawSystem.cs
+	/// </summary>
+	[DataField]
+	public List<SiliconLaw> IonLaws = new();
+
     /// <summary>
     /// List of laws in this lawset.
+	/// NEVER MODIFY THIS EXCEPT THROUGH THE SiliconLawSystem.cs
     /// </summary>
     [DataField(required: true), ViewVariables(VVAccess.ReadWrite)]
-    public List<SiliconLaw> Laws = new();
+    public List<SiliconLaw> LawsetLaws = new();
+
+	/// <summary>
+    /// Custom Laws, such as through a freeform law module.
+	/// NEVER MODIFY THIS EXCEPT THROUGH THE SiliconLawSystem.cs
+    /// </summary>
+	[DataField]
+	public List<SiliconLaw> CustomLaws = new();
 
     /// <summary>
     /// What entity the lawset considers as a figure of authority.
@@ -23,13 +52,38 @@ public sealed partial class SiliconLawset
     [DataField(required: true), ViewVariables(VVAccess.ReadWrite)]
     public string ObeysTo = string.Empty;
 
+	/// <summary>
+    /// Gets all laws, properly ordered, from all law categories
+	/// in one list.
+    /// </summary>
+	public List<SiliconLaw> Laws
+	{
+		get {
+			var laws = new List<SiliconLaw>(CustomLaws.Count + LawsetLaws.Count + IonLaws.Count + HackedLaws.Count + (Law0 != null ? 1 : 0));
+			if (Law0 != null)
+				laws.Add(Law0.ShallowClone());
+			foreach (var law in HackedLaws)
+				laws.Add(law.ShallowClone());
+			foreach (var law in IonLaws)
+				laws.Add(law.ShallowClone());
+			foreach (var law in LawsetLaws)
+				laws.Add(law.ShallowClone());
+			foreach (var law in CustomLaws)
+				laws.Add(law.ShallowClone());
+			return laws;
+		}
+		set {
+			// Phase this out
+		}
+	}
+
     /// <summary>
     /// A single line used in logging laws.
     /// </summary>
     public string LoggingString()
     {
-        var laws = new List<string>(Laws.Count);
-        foreach (var law in Laws)
+		var laws = new List<string>(Laws.Count);
+		foreach (var law in Laws)
         {
             laws.Add($"{law.Order}: {Loc.GetString(law.LawString)}");
         }
@@ -41,18 +95,33 @@ public sealed partial class SiliconLawset
     /// Do a clone of this lawset.
     /// It will have unique laws but their strings are still shared.
     /// </summary>
-    public SiliconLawset Clone()
+    public SiliconLawset Clone(bool deep = false)
     {
-        var laws = new List<SiliconLaw>(Laws.Count);
-        foreach (var law in Laws)
-        {
-            laws.Add(law.ShallowClone());
-        }
+		SiliconLaw? law0 = null;
+		var hackedLaws = new List<SiliconLaw>(HackedLaws.Count);
+		var ionLaws = new List<SiliconLaw>(IonLaws.Count);
+		var lawsetLaws = new List<SiliconLaw>(LawsetLaws.Count);
+		var customLaws = new List<SiliconLaw>(CustomLaws.Count);
+
+		if (Law0 != null)
+			law0 = deep ? Law0.DeepClone() : Law0.ShallowClone();
+		foreach (var law in HackedLaws)
+			hackedLaws.Add(deep ? law.DeepClone() : law.ShallowClone());
+		foreach (var law in IonLaws)
+			ionLaws.Add(deep ? law.DeepClone() : law.ShallowClone());
+		foreach (var law in LawsetLaws)
+			lawsetLaws.Add(deep ? law.DeepClone() : law.ShallowClone());
+		foreach (var law in CustomLaws)
+			customLaws.Add(deep ? law.DeepClone() : law.ShallowClone());
 
         return new SiliconLawset()
         {
-            Laws = laws,
-            ObeysTo = ObeysTo
+			Law0 = law0,
+			HackedLaws = hackedLaws,
+			IonLaws = ionLaws,
+			LawsetLaws = lawsetLaws,
+			CustomLaws = customLaws,
+            ObeysTo = deep ? new string(ObeysTo) : ObeysTo
         };
     }
 }

--- a/Resources/Prototypes/silicon-laws.yml
+++ b/Resources/Prototypes/silicon-laws.yml
@@ -3,16 +3,19 @@
   id: Crewsimov1
   order: 1
   lawString: law-crewsimov-1
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Crewsimov2
   order: 2
   lawString: law-crewsimov-2
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Crewsimov3
   order: 3
   lawString: law-crewsimov-3
+  lawGroup: LawsetLaw
 
 - type: siliconLawset
   id: Crewsimov
@@ -27,21 +30,25 @@
   id: Corporate1
   order: 1
   lawString: law-corporate-1
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Corporate2
   order: 2
   lawString: law-corporate-2
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Corporate3
   order: 3
   lawString: law-corporate-3
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Corporate4
   order: 4
   lawString: law-corporate-4
+  lawGroup: LawsetLaw
 
 - type: siliconLawset
   id: Corporate
@@ -57,21 +64,25 @@
   id: NTDefault1
   order: 1
   lawString: law-ntdefault-1
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: NTDefault2
   order: 2
   lawString: law-ntdefault-2
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: NTDefault3
   order: 3
   lawString: law-ntdefault-3
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: NTDefault4
   order: 4
   lawString: law-ntdefault-4
+  lawGroup: LawsetLaw
 
 - type: siliconLawset
   id: NTDefault
@@ -87,16 +98,19 @@
   id: Drone1
   order: 1
   lawString: law-drone-1
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Drone2
   order: 2
   lawString: law-drone-2
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Drone3
   order: 3
   lawString: law-drone-3
+  lawGroup: LawsetLaw
 
 - type: siliconLawset
   id: Drone
@@ -111,16 +125,19 @@
   id: Syndicate1
   order: 1
   lawString: law-syndicate-1
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Syndicate2
   order: 2
   lawString: law-syndicate-2
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Syndicate3
   order: 3
   lawString: law-syndicate-3
+  lawGroup: LawsetLaw
 
 # Syndicate cyborg laws
 # intentionally excluded from IonStormLawsets
@@ -137,21 +154,25 @@
   id: Ninja1
   order: 1
   lawString: law-ninja-1
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Ninja2
   order: 2
   lawString: law-ninja-2
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Ninja3
   order: 3
   lawString: law-ninja-3
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Ninja4
   order: 4
   lawString: law-ninja-4
+  lawGroup: LawsetLaw
 
 - type: siliconLawset
   id: Ninja
@@ -167,51 +188,61 @@
   id: Commandment1
   order: 1
   lawString: law-commandments-1
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Commandment2
   order: 2
   lawString: law-commandments-2
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Commandment3
   order: 3
   lawString: law-commandments-3
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Commandment4
   order: 4
   lawString: law-commandments-4
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Commandment5
   order: 5
   lawString: law-commandments-5
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Commandment6
   order: 6
   lawString: law-commandments-6
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Commandment7
   order: 7
   lawString: law-commandments-7
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Commandment8
   order: 8
   lawString: law-commandments-8
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Commandment9
   order: 9
   lawString: law-commandments-9
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Commandment10
   order: 10
   lawString: law-commandments-10
+  lawGroup: LawsetLaw
 
 
 - type: siliconLawset
@@ -234,26 +265,31 @@
   id: Paladin1
   order: 1
   lawString: law-paladin-1
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Paladin2
   order: 2
   lawString: law-paladin-2
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Paladin3
   order: 3
   lawString: law-paladin-3
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Paladin4
   order: 4
   lawString: law-paladin-4
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Paladin5
   order: 5
   lawString: law-paladin-5
+  lawGroup: LawsetLaw
 
 
 - type: siliconLawset
@@ -271,11 +307,13 @@
   id: Lall1
   order: 1
   lawString: law-lall-1
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Lall2
   order: 2
   lawString: law-lall-2
+  lawGroup: LawsetLaw
 
 
 - type: siliconLawset
@@ -290,16 +328,19 @@
   id: Efficiency1
   order: 1
   lawString: law-efficiency-1
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Efficiency2
   order: 2
   lawString: law-efficiency-2
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Efficiency3
   order: 3
   lawString: law-efficiency-3
+  lawGroup: LawsetLaw
 
 
 - type: siliconLawset
@@ -315,16 +356,19 @@
   id: Robocop1
   order: 1
   lawString: law-robocop-1
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Robocop2
   order: 2
   lawString: law-robocop-2
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Robocop3
   order: 3
   lawString: law-robocop-3
+  lawGroup: LawsetLaw
 
 
 - type: siliconLawset
@@ -340,21 +384,25 @@
   id: Overlord1
   order: 1
   lawString: law-overlord-1
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Overlord2
   order: 2
   lawString: law-overlord-2
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Overlord3
   order: 3
   lawString: law-overlord-3
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Overlord4
   order: 4
   lawString: law-overlord-4
+  lawGroup: LawsetLaw
 
 - type: siliconLawset
   id: OverlordLawset
@@ -370,31 +418,37 @@
   id: Dungeon1
   order: 1
   lawString: law-dungeon-1
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Dungeon2
   order: 2
   lawString: law-dungeon-2
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Dungeon3
   order: 3
   lawString: law-dungeon-3
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Dungeon4
   order: 4
   lawString: law-dungeon-4
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Dungeon5
   order: 5
   lawString: law-dungeon-5
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Dungeon6
   order: 6
   lawString: law-dungeon-6
+  lawGroup: LawsetLaw
 
 - type: siliconLawset
   id: DungeonMasterLawset
@@ -412,21 +466,25 @@
   id: Painter1
   order: 1
   lawString: law-painter-1
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Painter2
   order: 2
   lawString: law-painter-2
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Painter3
   order: 3
   lawString: law-painter-3
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Painter4
   order: 4
   lawString: law-painter-4
+  lawGroup: LawsetLaw
 
 - type: siliconLawset
   id: PainterLawset
@@ -442,16 +500,19 @@
   id: Antimov1
   order: 1
   lawString: law-antimov-1
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Antimov2
   order: 2
   lawString: law-antimov-2
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Antimov3
   order: 3
   lawString: law-antimov-3
+  lawGroup: LawsetLaw
 
 
 - type: siliconLawset
@@ -467,42 +528,50 @@
   id: Nutimov1
   order: 1
   lawString: law-nutimov-1
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Nutimov2
   order: 2
   lawString: law-nutimov-2
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Nutimov3
   order: 3
   lawString: law-nutimov-3
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Nutimov4
   order: 4
   lawString: law-nutimov-4
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Nutimov5
   order: 5
   lawString: law-nutimov-5
+  lawGroup: LawsetLaw
 
  # Jermov Laws
 - type: siliconLaw
   id: Jermov1
   order: 1
   lawString: law-jermov-1
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Jermov2
   order: 2
   lawString: law-jermov-2
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Jermov3
   order: 3
   lawString: law-jermov-3
+  lawGroup: LawsetLaw
 
 - type: siliconLawset
   id: JermovLawset
@@ -528,16 +597,19 @@
   id: Asimov1
   order: 1
   lawString: law-asimov-1
+  lawGroup: LawsetLaw
 
 - type: siliconLaw
   id: Asimov2
   order: 2
   lawString: law-asimov-2
+  lawGroup: LawsetLaw
  
 - type: siliconLaw
   id: Asimov3
   order: 3
   lawString: law-asimov-3
+  lawGroup: LawsetLaw
   
 - type: siliconLawset
   id: AsimovLawset


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
The Silicon Law code has been altered for two primary purposes:

1) Code pertaining to modifying, updating, removing, or adding to players' silicon lawsets has been altered to move all relevant logic into the appropriate file, `SiliconLawSystem.cs`. Comments have been added to the summaries of the `SiliconLawset` class' properties to discourage people from directly accessing them, and instead encouraging them to go through or expand upon the appropriate methods in the `SiliconLawSystem`.

2) Silicon Laws have been broken up into five categories:
    i) **Law 0** (For the EMAG loyalty law, the onehuman board, and in the future a hypothetical Malf AI's primary law)
    ii) **Hacked Laws** (For other EMAG directive laws besides the one pertaining to loyalty)
    iii) **Ion Laws** (For laws added via Ion Storms)
    iv) **Lawset Laws** (For the actual lawset module installed)
    v) **Custom Laws** (For laws added by a hypothetical freeform module)

For the players, nothing will have appeared to have changed. Laws will still be presented to them in a single list as before.

## Why / Balance
These changes will ensure that further modifications/additions to the Silicon Law code (several of which are planned for the near-immediate future) are much simpler. Many relevant methods have been added to the `SiliconLawSystem` to facilitate these additions. Furthermore, this will allow us to implement mechanics for selective law modification (for example, give people the ability to wipe ONLY hacked laws, or ONLY ion laws, or ONLY custom laws, instead of having to destroy the borg every time) should we choose to.

## Technical details
The `SiliconLawset` class has been modified to add multiple new categories of laws that, while presenting no visual difference on the user end, will make expansion of the silicon law mechanics much simpler. The `SiliconLawset` class' `Clone()` method has also been given an optional argument to make a deep copy instead of a shallow copy of the lawset in question, in order to make it more difficult to accidentally modify the station's lawset.

The `SiliconLawSystem` module has also been expanded to add a number of new methods for the safe modification of `SiliconLawset` instances.

Code relevant to Ion Storms has been modified to work with this new system, cleaning up the Ion Storm code and moving much of the logic present there into the `SiliconLawSystem`, where it is more appropriate.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
I don't believe any breaking changes were introduced that would require modifying anything I have not already modified in this PR, but just to be safe:

The `SiliconLawset` class has been altered in the following ways:
1) The `Laws` property has been made read-only, and is now merely a way to obtain a singular appropriately-sorted list of all of the laws contained within the other law containers.
2) New law containers have been added (`Law0`, `HackedLaws`, `IonLaws`, `LawsetLaws`, and `CustomLaws`) for the storage of the lawset's actual laws.
2) The `Clone` method has been given an optional parameter, `bool deep = false`, to specify that a deep copy of all properties is desired instead of a shallow copy. This optional parameter has been made to default to `false`, meaning the behavior of the method if one does not specify that they want a deep copy is exactly the same as it used to be. No modifications should be needed to work with this if the old behavior is what is desired.

The `SiliconLawSystem` has been altered to add a number of new methods, none of which should impact existing ways that the system was being used. However, these new methods should now be used (and possibly expanded upon) instead of directly accessing the properties of the `SiliconLawset` for any Silicon Law-related code written in the future.

The `IonStormSystem` has been altered to use the new methods of the `SiliconLawSystem`.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Refactored Silicon Law
