### PR TITLE
[port] [goob #1057] disables ashing

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/base.yml
@@ -68,21 +68,22 @@
         damage: 400
       behaviors:
       - !type:GibBehavior { }
-    - trigger:
-        !type:DamageTypeTrigger
-        damageType: Heat
-        damage: 1500
-      behaviors:
-      - !type:SpawnEntitiesBehavior
-        spawnInContainer: true
-        spawn:
-          Ash:
-            min: 1
-            max: 1
-      - !type:BurnBodyBehavior { }
-      - !type:PlaySoundBehavior
-        sound:
-          collection: MeatLaserImpact
+    # GoobStation: Disabled ashing until husking is added
+    #- trigger:
+    #    !type:DamageTypeTrigger
+    #    damageType: Heat
+    #    damage: 1500
+    #  behaviors:
+    #  - !type:SpawnEntitiesBehavior
+    #    spawnInContainer: true
+    #    spawn:
+    #      Ash:
+    #        min: 1
+    #        max: 1
+    #  - !type:BurnBodyBehavior { }
+    #  - !type:PlaySoundBehavior
+    #    sound:
+    #      collection: MeatLaserImpact
   - type: RadiationReceiver
   - type: Stamina
   - type: MobState


### PR DESCRIPTION
(cherry picked from commit 53c9543cd6edf96ff9576d94cd7967b9f2918294)
https://github.com/Goob-Station/Goob-Station/pull/1057 - thanks deltanedas

**Why**
Ashing is broken as hell with Shitmed and results in unrevivable bodies with no organs

**Changelog**
:cl: deltanedas
- remove: Extreme heat no longer turns people to ash.
