### PR TITLE
atmospheric gas pricing rebalance

### DIFF
--- a/Resources/Prototypes/Atmospherics/gases.yml
+++ b/Resources/Prototypes/Atmospherics/gases.yml
@@ -50,7 +50,7 @@
   gasOverlayState: tritium
   color: 13FF4B
   reagent: Tritium
-  pricePerMole: 0.4
+  pricePerMole: 0.4 #funkystation
 
 - type: gas
   id: 5
@@ -99,7 +99,7 @@
   gasMolesVisible: 0.6
   color: 3a758c
   reagent: Frezon
-  pricePerMole: 1.2
+  pricePerMole: 1.2 #funkystation
 
 # Assmos - /tg/ gases
 
@@ -111,7 +111,7 @@
   molarMass: 12
   color: 9370db
   reagent: BZ
-  pricePerMole: 1.2
+  pricePerMole: 1.2 #funkystation
 
 - type: gas
   id: 10
@@ -123,7 +123,7 @@
   gasOverlayState: healium
   color: fa8072
   reagent: Healium
-  pricePerMole: 2.7
+  pricePerMole: 2.7 #funkystation
 
 - type: gas
   id: 11

--- a/Resources/Prototypes/Atmospherics/gases.yml
+++ b/Resources/Prototypes/Atmospherics/gases.yml
@@ -50,7 +50,7 @@
   gasOverlayState: tritium
   color: 13FF4B
   reagent: Tritium
-  pricePerMole: 1.4
+  pricePerMole: 0.4
 
 - type: gas
   id: 5
@@ -99,7 +99,7 @@
   gasMolesVisible: 0.6
   color: 3a758c
   reagent: Frezon
-  pricePerMole: 0.5
+  pricePerMole: 1.2
 
 # Assmos - /tg/ gases
 
@@ -111,7 +111,7 @@
   molarMass: 12
   color: 9370db
   reagent: BZ
-  pricePerMole: 1
+  pricePerMole: 1.2
 
 - type: gas
   id: 10
@@ -123,7 +123,7 @@
   gasOverlayState: healium
   color: fa8072
   reagent: Healium
-  pricePerMole: 2.5
+  pricePerMole: 2.7
 
 - type: gas
   id: 11


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changed the following prices of atmospheric gases:
Tritium 1.4 -> 0.4
Frezon 0.5 -> 1.2
BZ 1.0 -> 1.2
Healium 2.5 -> 2.7

## Why / Balance
With current Atmospheric setups that are becoming slowly more common knowledge, it is possible to produce canisters of 1,000,000 spesos with only thirty or so minutes of waiting. Said canister consists of only Tritium being sold at 1.4 spesos per mole. Honestly this has grown a bit boring and I have been settling to do more work for less money (Making healium cans only worth 20,000ish after two hours of work). I think a change in prices can lead newer atmos players to want to learn the hard setups and make actually doing hard setups worthwhile. 

This only really changes the experience inside atmospherics as cargo is going to get rich no matter what.

## Technical details
changed gases.yml

## Media

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- tweak: rebalanced prices of atmospheric gases

