### PR TITLE
Remove train from rotation

### DIFF
--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -18,7 +18,7 @@
   - Packed
   #- Reach # funkystation - operation revive lrp
   - roid_outpost
-  - Train
+  #- Train unpopular map
   - FlandHighPop
   - OasisHighPop
   #- Barratry # Goobstation - Re-add barratry - Funkystation - Barratrauma


### PR DESCRIPTION

## About the PR
Removed train from rotation

## Why / Balance
Too many people despise it



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->



**Changelog**

:cl:

- remove: Removed train from map rotation (can still be admemed in)

-->
