### PR TITLE
Self-insert and Stowaway spawn removal

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
@@ -151,12 +151,6 @@
       prob: 0.10
       rolls: !type:RangeNumberSelector
         range: 1, 2
-    # Self-Insert Plushies
-    - !type:NestedSelector
-      tableId: AllSelfInsertPlushiesTable
-      prob: 0.05
-      rolls: !type:RangeNumberSelector
-        range: 1, 3
     # Stowaway Toys
     - !type:NestedSelector
       tableId: AllStowawayToysTable

--- a/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/misc.yml
@@ -151,12 +151,6 @@
       prob: 0.10
       rolls: !type:RangeNumberSelector
         range: 1, 2
-    # Stowaway Toys
-    - !type:NestedSelector
-      tableId: AllStowawayToysTable
-      prob: 0.05
-      rolls: !type:RangeNumberSelector
-        range: 1, 3
     # Weapons
     - !type:NestedSelector
       tableId: MaintWeaponTable


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Removes Self-insert plushies from Locker loot tables.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- remove: Self-insert and Stowaway brand plushies no longer spawn in lockers.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
