### PR TITLE
Syndicate bomb nerf!!

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/bombs.yml
@@ -123,7 +123,7 @@
       softness: 1
     - type: Explosive
       explosionType: HardBomb
-      totalIntensity: 4000.0
+      totalIntensity: 2500.0
       intensitySlope: 3
       maxIntensity: 400
 


### PR DESCRIPTION
## About the PR
Reduced totalIntensity of Syndicate Bombs from 4000 to 2500.

## Why / Balance
Syndicate bombs end shifts too often, mostly due to how debilitating the structural damage is to the station. Round ending behavior for these bombs refers to evacuation usually being called when a bomb goes off.

To reduce the sheer structural damage the bomb provides, I nearly halved the totalIntensity value for the syndicate bomb. This number is pretty much entirely a judgement call from me, but from the testing I did (media provided), the bomb appeared to still hold significant potential, even if its radius was diminished somewhat.

The goal of this change is to make it so that the crew has an easier time recovering after a syndicate bomb is planted rather than rushing to evacuate and end the shift.

## Technical details
one line yaml warrior...

## Media

Explosion UI for the existing 4000 intensity bomb
![explosionui_4000](https://github.com/user-attachments/assets/e4e1a3b4-930a-41d9-b8c2-196fd87ea972)

Explosion UI for the changed 2500 intensity bomb
![explosionui_2500](https://github.com/user-attachments/assets/1b7d2a4a-472e-46f1-8b59-778cac864878)

Control post; the dev map!
![devcontrol](https://github.com/user-attachments/assets/6127cd39-95c5-4490-ad04-d3695fc9beba)

Explosion for the existing 4000 intensity bomb
![explosion_4000](https://github.com/user-attachments/assets/0029a2d1-365c-4c84-a188-e91d30f16305)

Explosion for the changed 2500 intensity bomb
![explosion_2500](https://github.com/user-attachments/assets/a4f306cf-5c02-4a14-89b3-633162719dcd)

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A

**Changelog**
:cl:
- tweak: Syndicate bombs are weaker.
