### PR TITLE
kettle atmos and station beacon fix

### DIFF
--- a/Resources/Maps/_Funkystation/kettle.yml
+++ b/Resources/Maps/_Funkystation/kettle.yml
@@ -7322,7 +7322,7 @@ entities:
           -1,3:
             0: 65535
           -1,4:
-            0: 255
+            0: 1791
             1: 61440
           0,0:
             1: 240
@@ -10540,7 +10540,6 @@ entities:
     - type: DeviceList
       devices:
       - 1002
-      - 10060
       - 1000
   - uid: 11165
     components:
@@ -11760,6 +11759,18 @@ entities:
       parent: 82
 - proto: AirlockAtmosphericsGlassLocked
   entities:
+  - uid: 795
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,18.5
+      parent: 82
+  - uid: 812
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,18.5
+      parent: 82
   - uid: 1165
     components:
     - type: Transform
@@ -14239,11 +14250,6 @@ entities:
     components:
     - type: Transform
       pos: 28.5,-3.5
-      parent: 82
-  - uid: 10060
-    components:
-    - type: Transform
-      pos: 7.5,12.5
       parent: 82
   - uid: 10622
     components:
@@ -17250,6 +17256,18 @@ entities:
       rot: 3.141592653589793 rad
       pos: 77.5,16.5
       parent: 82
+  - uid: 797
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,18.5
+      parent: 82
+  - uid: 824
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -1.5,18.5
+      parent: 82
   - uid: 3771
     components:
     - type: Transform
@@ -19595,6 +19613,126 @@ entities:
       parent: 82
 - proto: CableApcExtension
   entities:
+  - uid: 373
+    components:
+    - type: Transform
+      pos: 2.5,9.5
+      parent: 82
+  - uid: 419
+    components:
+    - type: Transform
+      pos: 6.5,9.5
+      parent: 82
+  - uid: 428
+    components:
+    - type: Transform
+      pos: 4.5,9.5
+      parent: 82
+  - uid: 429
+    components:
+    - type: Transform
+      pos: 3.5,9.5
+      parent: 82
+  - uid: 430
+    components:
+    - type: Transform
+      pos: 8.5,9.5
+      parent: 82
+  - uid: 432
+    components:
+    - type: Transform
+      pos: 7.5,9.5
+      parent: 82
+  - uid: 565
+    components:
+    - type: Transform
+      pos: 5.5,9.5
+      parent: 82
+  - uid: 672
+    components:
+    - type: Transform
+      pos: 1.5,9.5
+      parent: 82
+  - uid: 673
+    components:
+    - type: Transform
+      pos: 0.5,9.5
+      parent: 82
+  - uid: 674
+    components:
+    - type: Transform
+      pos: -0.5,9.5
+      parent: 82
+  - uid: 675
+    components:
+    - type: Transform
+      pos: -1.5,9.5
+      parent: 82
+  - uid: 676
+    components:
+    - type: Transform
+      pos: -1.5,8.5
+      parent: 82
+  - uid: 714
+    components:
+    - type: Transform
+      pos: 14.5,9.5
+      parent: 82
+  - uid: 718
+    components:
+    - type: Transform
+      pos: 12.5,9.5
+      parent: 82
+  - uid: 723
+    components:
+    - type: Transform
+      pos: 11.5,9.5
+      parent: 82
+  - uid: 724
+    components:
+    - type: Transform
+      pos: 10.5,9.5
+      parent: 82
+  - uid: 726
+    components:
+    - type: Transform
+      pos: 13.5,9.5
+      parent: 82
+  - uid: 727
+    components:
+    - type: Transform
+      pos: 15.5,9.5
+      parent: 82
+  - uid: 728
+    components:
+    - type: Transform
+      pos: 16.5,8.5
+      parent: 82
+  - uid: 729
+    components:
+    - type: Transform
+      pos: 9.5,9.5
+      parent: 82
+  - uid: 754
+    components:
+    - type: Transform
+      pos: -2.5,16.5
+      parent: 82
+  - uid: 755
+    components:
+    - type: Transform
+      pos: -1.5,16.5
+      parent: 82
+  - uid: 758
+    components:
+    - type: Transform
+      pos: -2.5,17.5
+      parent: 82
+  - uid: 759
+    components:
+    - type: Transform
+      pos: -2.5,18.5
+      parent: 82
   - uid: 1127
     components:
     - type: Transform
@@ -24565,46 +24703,6 @@ entities:
     - type: Transform
       pos: -1.5,12.5
       parent: 82
-  - uid: 15782
-    components:
-    - type: Transform
-      pos: -0.5,12.5
-      parent: 82
-  - uid: 15783
-    components:
-    - type: Transform
-      pos: 0.5,12.5
-      parent: 82
-  - uid: 15784
-    components:
-    - type: Transform
-      pos: 1.5,12.5
-      parent: 82
-  - uid: 15785
-    components:
-    - type: Transform
-      pos: 2.5,12.5
-      parent: 82
-  - uid: 15786
-    components:
-    - type: Transform
-      pos: 3.5,12.5
-      parent: 82
-  - uid: 15787
-    components:
-    - type: Transform
-      pos: 4.5,12.5
-      parent: 82
-  - uid: 15788
-    components:
-    - type: Transform
-      pos: 5.5,12.5
-      parent: 82
-  - uid: 15789
-    components:
-    - type: Transform
-      pos: 6.5,12.5
-      parent: 82
   - uid: 15790
     components:
     - type: Transform
@@ -24614,61 +24712,6 @@ entities:
     components:
     - type: Transform
       pos: -3.5,16.5
-      parent: 82
-  - uid: 15792
-    components:
-    - type: Transform
-      pos: -2.5,16.5
-      parent: 82
-  - uid: 15793
-    components:
-    - type: Transform
-      pos: -1.5,16.5
-      parent: 82
-  - uid: 15794
-    components:
-    - type: Transform
-      pos: -0.5,16.5
-      parent: 82
-  - uid: 15795
-    components:
-    - type: Transform
-      pos: 0.5,16.5
-      parent: 82
-  - uid: 15796
-    components:
-    - type: Transform
-      pos: 1.5,16.5
-      parent: 82
-  - uid: 15797
-    components:
-    - type: Transform
-      pos: 2.5,16.5
-      parent: 82
-  - uid: 15798
-    components:
-    - type: Transform
-      pos: 3.5,16.5
-      parent: 82
-  - uid: 15799
-    components:
-    - type: Transform
-      pos: 4.5,16.5
-      parent: 82
-  - uid: 15800
-    components:
-    - type: Transform
-      pos: 5.5,16.5
-      parent: 82
-  - uid: 15801
-    components:
-    - type: Transform
-      pos: 6.5,16.5
-      parent: 82
-  - uid: 15802
-    components:
-    - type: Transform
-      pos: -1.5,17.5
       parent: 82
   - uid: 15803
     components:
@@ -24935,46 +24978,6 @@ entities:
     - type: Transform
       pos: 8.5,25.5
       parent: 82
-  - uid: 15856
-    components:
-    - type: Transform
-      pos: 8.5,12.5
-      parent: 82
-  - uid: 15857
-    components:
-    - type: Transform
-      pos: 9.5,12.5
-      parent: 82
-  - uid: 15858
-    components:
-    - type: Transform
-      pos: 10.5,12.5
-      parent: 82
-  - uid: 15859
-    components:
-    - type: Transform
-      pos: 11.5,12.5
-      parent: 82
-  - uid: 15860
-    components:
-    - type: Transform
-      pos: 12.5,12.5
-      parent: 82
-  - uid: 15861
-    components:
-    - type: Transform
-      pos: 13.5,12.5
-      parent: 82
-  - uid: 15862
-    components:
-    - type: Transform
-      pos: 14.5,12.5
-      parent: 82
-  - uid: 15863
-    components:
-    - type: Transform
-      pos: 15.5,12.5
-      parent: 82
   - uid: 15864
     components:
     - type: Transform
@@ -25009,46 +25012,6 @@ entities:
     components:
     - type: Transform
       pos: 22.5,12.5
-      parent: 82
-  - uid: 15871
-    components:
-    - type: Transform
-      pos: 8.5,16.5
-      parent: 82
-  - uid: 15872
-    components:
-    - type: Transform
-      pos: 9.5,16.5
-      parent: 82
-  - uid: 15873
-    components:
-    - type: Transform
-      pos: 10.5,16.5
-      parent: 82
-  - uid: 15874
-    components:
-    - type: Transform
-      pos: 11.5,16.5
-      parent: 82
-  - uid: 15875
-    components:
-    - type: Transform
-      pos: 12.5,16.5
-      parent: 82
-  - uid: 15876
-    components:
-    - type: Transform
-      pos: 13.5,16.5
-      parent: 82
-  - uid: 15877
-    components:
-    - type: Transform
-      pos: 14.5,16.5
-      parent: 82
-  - uid: 15878
-    components:
-    - type: Transform
-      pos: 15.5,16.5
       parent: 82
   - uid: 15879
     components:
@@ -53522,6 +53485,18 @@ entities:
       parent: 82
 - proto: Catwalk
   entities:
+  - uid: 796
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,17.5
+      parent: 82
+  - uid: 864
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,16.5
+      parent: 82
   - uid: 911
     components:
     - type: Transform
@@ -53587,18 +53562,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,16.5
-      parent: 82
-  - uid: 923
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,17.5
-      parent: 82
-  - uid: 924
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,16.5
       parent: 82
   - uid: 925
     components:
@@ -53935,51 +53898,6 @@ entities:
     components:
     - type: Transform
       pos: 44.5,39.5
-      parent: 82
-  - uid: 1859
-    components:
-    - type: Transform
-      pos: 1.5,12.5
-      parent: 82
-  - uid: 1860
-    components:
-    - type: Transform
-      pos: 0.5,12.5
-      parent: 82
-  - uid: 1862
-    components:
-    - type: Transform
-      pos: 8.5,12.5
-      parent: 82
-  - uid: 1863
-    components:
-    - type: Transform
-      pos: 6.5,12.5
-      parent: 82
-  - uid: 1864
-    components:
-    - type: Transform
-      pos: 13.5,12.5
-      parent: 82
-  - uid: 1870
-    components:
-    - type: Transform
-      pos: 2.5,12.5
-      parent: 82
-  - uid: 1871
-    components:
-    - type: Transform
-      pos: 14.5,12.5
-      parent: 82
-  - uid: 1876
-    components:
-    - type: Transform
-      pos: 12.5,12.5
-      parent: 82
-  - uid: 1877
-    components:
-    - type: Transform
-      pos: 7.5,12.5
       parent: 82
   - uid: 1992
     components:
@@ -68592,6 +68510,13 @@ entities:
     - type: Transform
       pos: -19.032625,-19.430998
       parent: 82
+- proto: DefaultStationBeaconAI
+  entities:
+  - uid: 876
+    components:
+    - type: Transform
+      pos: 20.5,-92.5
+      parent: 82
 - proto: DefaultStationBeaconAICore
   entities:
   - uid: 24135
@@ -68605,6 +68530,420 @@ entities:
     components:
     - type: Transform
       pos: 20.5,-91.5
+      parent: 82
+- proto: DefaultStationBeaconAME
+  entities:
+  - uid: 877
+    components:
+    - type: Transform
+      pos: -11.5,48.5
+      parent: 82
+- proto: DefaultStationBeaconAnchor
+  entities:
+  - uid: 878
+    components:
+    - type: Transform
+      pos: 1.5,56.5
+      parent: 82
+- proto: DefaultStationBeaconAnomalyGenerator
+  entities:
+  - uid: 879
+    components:
+    - type: Transform
+      pos: 15.5,73.5
+      parent: 82
+- proto: DefaultStationBeaconArmory
+  entities:
+  - uid: 880
+    components:
+    - type: Transform
+      pos: 50.5,-19.5
+      parent: 82
+- proto: DefaultStationBeaconArrivals
+  entities:
+  - uid: 881
+    components:
+    - type: Transform
+      pos: 79.5,2.5
+      parent: 82
+- proto: DefaultStationBeaconArtifactLab
+  entities:
+  - uid: 882
+    components:
+    - type: Transform
+      pos: 26.5,74.5
+      parent: 82
+- proto: DefaultStationBeaconAtmospherics
+  entities:
+  - uid: 883
+    components:
+    - type: Transform
+      pos: 7.5,10.5
+      parent: 82
+- proto: DefaultStationBeaconBar
+  entities:
+  - uid: 791
+    components:
+    - type: Transform
+      pos: -23.5,-11.5
+      parent: 82
+- proto: DefaultStationBeaconBotany
+  entities:
+  - uid: 813
+    components:
+    - type: Transform
+      pos: -33.5,-20.5
+      parent: 82
+- proto: DefaultStationBeaconBridge
+  entities:
+  - uid: 798
+    components:
+    - type: Transform
+      pos: 7.5,-12.5
+      parent: 82
+- proto: DefaultStationBeaconBrig
+  entities:
+  - uid: 817
+    components:
+    - type: Transform
+      pos: 41.5,-14.5
+      parent: 82
+- proto: DefaultStationBeaconCaptainsQuarters
+  entities:
+  - uid: 829
+    components:
+    - type: Transform
+      pos: 11.5,-17.5
+      parent: 82
+- proto: DefaultStationBeaconCargoBay
+  entities:
+  - uid: 753
+    components:
+    - type: Transform
+      pos: 44.5,22.5
+      parent: 82
+- proto: DefaultStationBeaconCargoReception
+  entities:
+  - uid: 811
+    components:
+    - type: Transform
+      pos: 39.5,29.5
+      parent: 82
+- proto: DefaultStationBeaconCERoom
+  entities:
+  - uid: 828
+    components:
+    - type: Transform
+      pos: -8.5,33.5
+      parent: 82
+- proto: DefaultStationBeaconChapel
+  entities:
+  - uid: 792
+    components:
+    - type: Transform
+      pos: -14.5,19.5
+      parent: 82
+- proto: DefaultStationBeaconChemistry
+  entities:
+  - uid: 799
+    components:
+    - type: Transform
+      pos: -33.5,-26.5
+      parent: 82
+- proto: DefaultStationBeaconCMORoom
+  entities:
+  - uid: 816
+    components:
+    - type: Transform
+      pos: -42.5,-35.5
+      parent: 82
+- proto: DefaultStationBeaconCourtroom
+  entities:
+  - uid: 752
+    components:
+    - type: Transform
+      pos: 24.5,-17.5
+      parent: 82
+- proto: DefaultStationBeaconCryonics
+  entities:
+  - uid: 815
+    components:
+    - type: Transform
+      pos: -42.5,-39.5
+      parent: 82
+- proto: DefaultStationBeaconCryosleep
+  entities:
+  - uid: 818
+    components:
+    - type: Transform
+      pos: 16.5,-41.5
+      parent: 82
+- proto: DefaultStationBeaconDetectiveRoom
+  entities:
+  - uid: 827
+    components:
+    - type: Transform
+      pos: -53.5,0.5
+      parent: 82
+- proto: DefaultStationBeaconDisposals
+  entities:
+  - uid: 794
+    components:
+    - type: Transform
+      pos: -63.5,-35.5
+      parent: 82
+- proto: DefaultStationBeaconDorms
+  entities:
+  - uid: 749
+    components:
+    - type: Transform
+      pos: 7.5,-35.5
+      parent: 82
+- proto: DefaultStationBeaconEngineering
+  entities:
+  - uid: 800
+    components:
+    - type: Transform
+      pos: -19.5,44.5
+      parent: 82
+- proto: DefaultStationBeaconEvac
+  entities:
+  - uid: 826
+    components:
+    - type: Transform
+      pos: -61.5,43.5
+      parent: 82
+- proto: DefaultStationBeaconEVAStorage
+  entities:
+  - uid: 810
+    components:
+    - type: Transform
+      pos: -38.5,26.5
+      parent: 82
+- proto: DefaultStationBeaconGravGen
+  entities:
+  - uid: 746
+    components:
+    - type: Transform
+      pos: 0.5,56.5
+      parent: 82
+- proto: DefaultStationBeaconHOPOffice
+  entities:
+  - uid: 734
+    components:
+    - type: Transform
+      pos: -7.5,2.5
+      parent: 82
+- proto: DefaultStationBeaconHOSRoom
+  entities:
+  - uid: 747
+    components:
+    - type: Transform
+      pos: 60.5,-14.5
+      parent: 82
+- proto: DefaultStationBeaconJanitorsCloset
+  entities:
+  - uid: 751
+    components:
+    - type: Transform
+      pos: -0.5,36.5
+      parent: 82
+- proto: DefaultStationBeaconKitchen
+  entities:
+  - uid: 764
+    components:
+    - type: Transform
+      pos: -32.5,-13.5
+      parent: 82
+- proto: DefaultStationBeaconLawOffice
+  entities:
+  - uid: 801
+    components:
+    - type: Transform
+      pos: 29.5,-27.5
+      parent: 82
+- proto: DefaultStationBeaconLibrary
+  entities:
+  - uid: 750
+    components:
+    - type: Transform
+      pos: 26.5,26.5
+      parent: 82
+- proto: DefaultStationBeaconMedbay
+  entities:
+  - uid: 793
+    components:
+    - type: Transform
+      pos: -34.5,-37.5
+      parent: 82
+- proto: DefaultStationBeaconMedical
+  entities:
+  - uid: 830
+    components:
+    - type: Transform
+      pos: -24.5,-29.5
+      parent: 82
+- proto: DefaultStationBeaconMorgue
+  entities:
+  - uid: 809
+    components:
+    - type: Transform
+      pos: -55.5,-26.5
+      parent: 82
+- proto: DefaultStationBeaconPermaBrig
+  entities:
+  - uid: 867
+    components:
+    - type: Transform
+      pos: 51.5,-42.5
+      parent: 82
+- proto: DefaultStationBeaconPowerBank
+  entities:
+  - uid: 710
+    components:
+    - type: Transform
+      pos: -24.5,45.5
+      parent: 82
+- proto: DefaultStationBeaconQMRoom
+  entities:
+  - uid: 874
+    components:
+    - type: Transform
+      pos: 47.5,14.5
+      parent: 82
+- proto: DefaultStationBeaconRDRoom
+  entities:
+  - uid: 706
+    components:
+    - type: Transform
+      pos: 28.5,64.5
+      parent: 82
+- proto: DefaultStationBeaconRND
+  entities:
+  - uid: 708
+    components:
+    - type: Transform
+      pos: 27.5,59.5
+      parent: 82
+- proto: DefaultStationBeaconRobotics
+  entities:
+  - uid: 709
+    components:
+    - type: Transform
+      pos: 11.5,56.5
+      parent: 82
+- proto: DefaultStationBeaconSalvage
+  entities:
+  - uid: 617
+    components:
+    - type: Transform
+      pos: 41.5,33.5
+      parent: 82
+- proto: DefaultStationBeaconScience
+  entities:
+  - uid: 653
+    components:
+    - type: Transform
+      pos: 19.5,61.5
+      parent: 82
+- proto: DefaultStationBeaconSecurity
+  entities:
+  - uid: 657
+    components:
+    - type: Transform
+      pos: 40.5,-2.5
+      parent: 82
+- proto: DefaultStationBeaconSecurityCheckpoint
+  entities:
+  - uid: 654
+    components:
+    - type: Transform
+      pos: -28.5,26.5
+      parent: 82
+  - uid: 656
+    components:
+    - type: Transform
+      pos: -61.5,50.5
+      parent: 82
+- proto: DefaultStationBeaconServerRoom
+  entities:
+  - uid: 707
+    components:
+    - type: Transform
+      pos: 12.5,64.5
+      parent: 82
+- proto: DefaultStationBeaconService
+  entities:
+  - uid: 671
+    components:
+    - type: Transform
+      pos: 27.5,-35.5
+      parent: 82
+- proto: DefaultStationBeaconSingularity
+  entities:
+  - uid: 825
+    components:
+    - type: Transform
+      pos: -26.5,53.5
+      parent: 82
+- proto: DefaultStationBeaconSolars
+  entities:
+  - uid: 658
+    components:
+    - type: Transform
+      pos: -51.5,11.5
+      parent: 82
+  - uid: 669
+    components:
+    - type: Transform
+      pos: -62.5,-25.5
+      parent: 82
+  - uid: 875
+    components:
+    - type: Transform
+      pos: -41.5,-50.5
+      parent: 82
+- proto: DefaultStationBeaconSupply
+  entities:
+  - uid: 670
+    components:
+    - type: Transform
+      pos: 36.5,26.5
+      parent: 82
+- proto: DefaultStationBeaconSurgery
+  entities:
+  - uid: 680
+    components:
+    - type: Transform
+      pos: -34.5,-44.5
+      parent: 82
+- proto: DefaultStationBeaconTelecoms
+  entities:
+  - uid: 683
+    components:
+    - type: Transform
+      pos: -33.5,17.5
+      parent: 82
+- proto: DefaultStationBeaconToolRoom
+  entities:
+  - uid: 705
+    components:
+    - type: Transform
+      pos: 26.5,-8.5
+      parent: 82
+- proto: DefaultStationBeaconVault
+  entities:
+  - uid: 730
+    components:
+    - type: Transform
+      pos: -11.5,-6.5
+      parent: 82
+- proto: DefaultStationBeaconWardensOffice
+  entities:
+  - uid: 736
+    components:
+    - type: Transform
+      pos: 41.5,-8.5
       parent: 82
 - proto: DefibrillatorCabinetFilled
   entities:
@@ -81790,52 +82129,60 @@ entities:
       color: '#03FCD3FF'
 - proto: GasFilterFlipped
   entities:
-  - uid: 729
+  - uid: 375
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 0.5,16.5
+      pos: 0.5,17.5
       parent: 82
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 730
+      color: '#DB48CFFF'
+  - uid: 677
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 2.5,16.5
+      pos: 6.5,17.5
       parent: 82
-  - uid: 731
+    - type: AtmosPipeColor
+      color: '#A114DEFF'
+  - uid: 678
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 4.5,16.5
+      pos: 4.5,17.5
       parent: 82
+  - uid: 679
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 2.5,17.5
+      parent: 82
+    - type: AtmosPipeColor
+      color: '#C4C0C1FF'
   - uid: 732
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 6.5,16.5
-      parent: 82
-  - uid: 733
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 8.5,16.5
-      parent: 82
-  - uid: 734
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 10.5,16.5
-      parent: 82
-  - uid: 735
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 12.5,16.5
+      pos: 12.5,17.5
       parent: 82
     - type: AtmosPipeColor
-      color: '#990000FF'
+      color: '#F7526AFF'
+  - uid: 740
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 10.5,17.5
+      parent: 82
+    - type: AtmosPipeColor
+      color: '#52D1F7FF'
+  - uid: 744
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,17.5
+      parent: 82
+    - type: AtmosPipeColor
+      color: '#262426FF'
   - uid: 22571
     components:
     - type: Transform
@@ -81878,44 +82225,6 @@ entities:
       parent: 82
 - proto: GasMixer
   entities:
-  - uid: 718
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 9.5,14.5
-      parent: 82
-  - uid: 725
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 7.5,14.5
-      parent: 82
-  - uid: 726
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 5.5,14.5
-      parent: 82
-  - uid: 727
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,14.5
-      parent: 82
-  - uid: 728
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,14.5
-      parent: 82
-  - uid: 737
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -0.5,14.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#947507FF'
   - uid: 2152
     components:
     - type: Transform
@@ -81936,19 +82245,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 11.5,71.5
       parent: 82
-- proto: GasMixerFlipped
-  entities:
-  - uid: 754
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 12.5,14.5
-      parent: 82
-    - type: GasMixer
-      inletTwoConcentration: 0.22000003
-      inletOneConcentration: 0.78
-    - type: AtmosPipeColor
-      color: '#03FCD3FF'
 - proto: GasOutletInjector
   entities:
   - uid: 412
@@ -81975,12 +82271,16 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -0.5,24.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#DB48CFFF'
   - uid: 551
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,24.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#C4C0C1FF'
   - uid: 552
     components:
     - type: Transform
@@ -81993,39 +82293,37 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 5.5,24.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#A114DEFF'
   - uid: 554
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,24.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#262426FF'
   - uid: 555
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 9.5,24.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#52D1F7FF'
   - uid: 556
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 11.5,24.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#F7526AFF'
   - uid: 557
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 15.5,24.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#03FCD3FF'
-- proto: GasPassiveGate
-  entities:
-  - uid: 375
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 16.5,17.5
       parent: 82
     - type: AtmosPipeColor
       color: '#03FCD3FF'
@@ -82072,11 +82370,15 @@ entities:
     - type: Transform
       pos: -0.5,22.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#DB48CFFF'
   - uid: 559
     components:
     - type: Transform
       pos: 1.5,22.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#C4C0C1FF'
   - uid: 560
     components:
     - type: Transform
@@ -82087,40 +82389,41 @@ entities:
     - type: Transform
       pos: 5.5,22.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#A114DEFF'
   - uid: 562
     components:
     - type: Transform
       pos: 7.5,22.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#262426FF'
   - uid: 563
     components:
     - type: Transform
       pos: 9.5,22.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#52D1F7FF'
   - uid: 564
     components:
     - type: Transform
       pos: 11.5,22.5
       parent: 82
-  - uid: 565
-    components:
-    - type: Transform
-      pos: 15.5,22.5
-      parent: 82
     - type: AtmosPipeColor
-      color: '#03FCD3FF'
-  - uid: 676
+      color: '#F7526AFF'
+  - uid: 731
     components:
     - type: Transform
-      pos: 13.5,19.5
+      pos: 13.5,22.5
+      parent: 82
+  - uid: 741
+    components:
+    - type: Transform
+      pos: 15.5,19.5
       parent: 82
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 683
-    components:
-    - type: Transform
-      pos: -1.5,19.5
-      parent: 82
   - uid: 1356
     components:
     - type: Transform
@@ -82186,11 +82489,15 @@ entities:
     - type: Transform
       pos: 0.5,24.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#DB48CFFF'
   - uid: 660
     components:
     - type: Transform
       pos: 2.5,24.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#C4C0C1FF'
   - uid: 661
     components:
     - type: Transform
@@ -82201,21 +82508,29 @@ entities:
     - type: Transform
       pos: 6.5,24.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#A114DEFF'
   - uid: 663
     components:
     - type: Transform
       pos: 8.5,24.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#262426FF'
   - uid: 664
     components:
     - type: Transform
       pos: 10.5,24.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#52D1F7FF'
   - uid: 665
     components:
     - type: Transform
       pos: 12.5,24.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#F7526AFF'
   - uid: 666
     components:
     - type: Transform
@@ -82223,51 +82538,30 @@ entities:
       parent: 82
     - type: AtmosPipeColor
       color: '#03FCD3FF'
-  - uid: 713
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 15.5,16.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#03FCD3FF'
-  - uid: 753
-    components:
-    - type: Transform
-      pos: 12.5,15.5
-      parent: 82
-  - uid: 758
+  - uid: 733
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 16.5,14.5
+      pos: -2.5,16.5
       parent: 82
     - type: AtmosPipeColor
-      color: '#03FCD3FF'
-  - uid: 815
+      color: '#990000FF'
+  - uid: 743
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 15.5,17.5
+      parent: 82
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 865
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -1.5,14.5
+      pos: -2.5,17.5
       parent: 82
     - type: AtmosPipeColor
-      color: '#947507FF'
-  - uid: 818
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -1.5,11.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#947507FF'
-  - uid: 822
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 15.5,11.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#947507FF'
+      color: '#990000FF'
   - uid: 900
     components:
     - type: Transform
@@ -83545,14 +83839,6 @@ entities:
       parent: 82
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 373
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 16.5,16.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#03FCD3FF'
   - uid: 382
     components:
     - type: Transform
@@ -83709,54 +83995,56 @@ entities:
       rot: 3.141592653589793 rad
       pos: 14.5,9.5
       parent: 82
-  - uid: 428
+  - uid: 578
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,16.5
+      rot: 1.5707963267948966 rad
+      pos: 3.5,17.5
       parent: 82
-  - uid: 429
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,15.5
-      parent: 82
-  - uid: 430
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,16.5
-      parent: 82
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 593
     components:
     - type: Transform
       pos: 0.5,23.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#DB48CFFF'
   - uid: 594
     components:
     - type: Transform
       pos: 0.5,22.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#DB48CFFF'
   - uid: 595
     components:
     - type: Transform
       pos: 0.5,21.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#DB48CFFF'
   - uid: 596
     components:
     - type: Transform
       pos: 2.5,23.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#C4C0C1FF'
   - uid: 597
     components:
     - type: Transform
       pos: 2.5,22.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#C4C0C1FF'
   - uid: 598
     components:
     - type: Transform
       pos: 2.5,21.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#C4C0C1FF'
   - uid: 599
     components:
     - type: Transform
@@ -83777,61 +84065,85 @@ entities:
     - type: Transform
       pos: 6.5,23.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#A114DEFF'
   - uid: 603
     components:
     - type: Transform
       pos: 6.5,22.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#A114DEFF'
   - uid: 604
     components:
     - type: Transform
       pos: 6.5,21.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#A114DEFF'
   - uid: 605
     components:
     - type: Transform
       pos: 8.5,23.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#262426FF'
   - uid: 606
     components:
     - type: Transform
       pos: 8.5,22.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#262426FF'
   - uid: 607
     components:
     - type: Transform
       pos: 8.5,21.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#262426FF'
   - uid: 608
     components:
     - type: Transform
       pos: 10.5,23.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#52D1F7FF'
   - uid: 609
     components:
     - type: Transform
       pos: 10.5,22.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#52D1F7FF'
   - uid: 610
     components:
     - type: Transform
       pos: 10.5,21.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#52D1F7FF'
   - uid: 611
     components:
     - type: Transform
       pos: 12.5,23.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#F7526AFF'
   - uid: 612
     components:
     - type: Transform
       pos: 12.5,22.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#F7526AFF'
   - uid: 613
     components:
     - type: Transform
       pos: 12.5,21.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#F7526AFF'
   - uid: 614
     components:
     - type: Transform
@@ -83853,33 +84165,34 @@ entities:
       parent: 82
     - type: AtmosPipeColor
       color: '#03FCD3FF'
-  - uid: 617
-    components:
-    - type: Transform
-      pos: 15.5,21.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#03FCD3FF'
   - uid: 618
     components:
     - type: Transform
       pos: 11.5,21.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#F7526AFF'
   - uid: 619
     components:
     - type: Transform
       pos: 9.5,21.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#52D1F7FF'
   - uid: 620
     components:
     - type: Transform
       pos: 7.5,21.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#262426FF'
   - uid: 621
     components:
     - type: Transform
       pos: 5.5,21.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#A114DEFF'
   - uid: 622
     components:
     - type: Transform
@@ -83890,46 +84203,64 @@ entities:
     - type: Transform
       pos: 1.5,21.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#C4C0C1FF'
   - uid: 624
     components:
     - type: Transform
       pos: -0.5,21.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#DB48CFFF'
   - uid: 626
     components:
     - type: Transform
       pos: -0.5,20.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#DB48CFFF'
   - uid: 627
     components:
     - type: Transform
       pos: -0.5,19.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#DB48CFFF'
   - uid: 628
     components:
     - type: Transform
       pos: 0.5,19.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#DB48CFFF'
   - uid: 629
     components:
     - type: Transform
       pos: 1.5,20.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#C4C0C1FF'
   - uid: 630
     components:
     - type: Transform
       pos: 1.5,19.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#C4C0C1FF'
   - uid: 631
     components:
     - type: Transform
       pos: 2.5,20.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#C4C0C1FF'
   - uid: 632
     components:
     - type: Transform
       pos: 2.5,19.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#C4C0C1FF'
   - uid: 633
     components:
     - type: Transform
@@ -83955,120 +84286,117 @@ entities:
     - type: Transform
       pos: 5.5,20.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#A114DEFF'
   - uid: 638
     components:
     - type: Transform
       pos: 5.5,19.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#A114DEFF'
   - uid: 639
     components:
     - type: Transform
       pos: 6.5,20.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#A114DEFF'
   - uid: 640
     components:
     - type: Transform
       pos: 6.5,19.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#A114DEFF'
   - uid: 641
     components:
     - type: Transform
       pos: 7.5,20.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#262426FF'
   - uid: 642
     components:
     - type: Transform
       pos: 7.5,19.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#262426FF'
   - uid: 643
     components:
     - type: Transform
       pos: 8.5,20.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#262426FF'
   - uid: 644
     components:
     - type: Transform
       pos: 8.5,19.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#262426FF'
   - uid: 645
     components:
     - type: Transform
       pos: 9.5,20.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#52D1F7FF'
   - uid: 646
     components:
     - type: Transform
       pos: 9.5,19.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#52D1F7FF'
   - uid: 647
     components:
     - type: Transform
       pos: 10.5,20.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#52D1F7FF'
   - uid: 648
     components:
     - type: Transform
       pos: 10.5,19.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#52D1F7FF'
   - uid: 649
     components:
     - type: Transform
       pos: 11.5,20.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#F7526AFF'
   - uid: 650
     components:
     - type: Transform
       pos: 11.5,19.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#F7526AFF'
   - uid: 651
     components:
     - type: Transform
       pos: 12.5,20.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#F7526AFF'
   - uid: 652
     components:
     - type: Transform
       pos: 12.5,19.5
       parent: 82
-  - uid: 653
-    components:
-    - type: Transform
-      pos: 15.5,20.5
-      parent: 82
     - type: AtmosPipeColor
-      color: '#03FCD3FF'
-  - uid: 654
-    components:
-    - type: Transform
-      pos: 15.5,19.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#03FCD3FF'
+      color: '#F7526AFF'
   - uid: 655
     components:
     - type: Transform
       pos: 16.5,20.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#03FCD3FF'
-  - uid: 656
-    components:
-    - type: Transform
-      pos: 16.5,19.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#03FCD3FF'
-  - uid: 657
-    components:
-    - type: Transform
-      pos: 16.5,18.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#03FCD3FF'
-  - uid: 658
-    components:
-    - type: Transform
-      pos: 15.5,18.5
       parent: 82
     - type: AtmosPipeColor
       color: '#03FCD3FF'
@@ -84078,79 +84406,32 @@ entities:
       rot: 3.141592653589793 rad
       pos: 0.5,18.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#DB48CFFF'
   - uid: 668
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,18.5
       parent: 82
-  - uid: 669
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,17.5
-      parent: 82
-  - uid: 670
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,17.5
-      parent: 82
-  - uid: 671
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,17.5
-      parent: 82
-  - uid: 672
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,17.5
-      parent: 82
-  - uid: 673
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 8.5,17.5
-      parent: 82
-  - uid: 674
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 10.5,17.5
-      parent: 82
-  - uid: 675
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 13.5,18.5
-      parent: 82
     - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 677
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 12.5,17.5
-      parent: 82
-  - uid: 679
-    components:
-    - type: Transform
-      pos: -1.5,18.5
-      parent: 82
+      color: '#DB48CFFF'
   - uid: 684
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,18.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#C4C0C1FF'
   - uid: 685
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,18.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#C4C0C1FF'
   - uid: 686
     components:
     - type: Transform
@@ -84169,55 +84450,80 @@ entities:
       rot: 3.141592653589793 rad
       pos: 5.5,18.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#A114DEFF'
   - uid: 689
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,18.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#A114DEFF'
   - uid: 690
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,18.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#262426FF'
   - uid: 691
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,18.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#262426FF'
   - uid: 692
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,18.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#52D1F7FF'
   - uid: 693
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 10.5,18.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#52D1F7FF'
   - uid: 694
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 11.5,18.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#F7526AFF'
   - uid: 695
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,18.5
       parent: 82
-  - uid: 714
+    - type: AtmosPipeColor
+      color: '#F7526AFF'
+  - uid: 711
     components:
     - type: Transform
-      pos: 16.5,16.5
+      rot: 1.5707963267948966 rad
+      pos: 5.5,17.5
       parent: 82
     - type: AtmosPipeColor
-      color: '#03FCD3FF'
+      color: '#990000FF'
+  - uid: 713
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 9.5,17.5
+      parent: 82
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 720
     components:
     - type: Transform
@@ -84232,100 +84538,38 @@ entities:
       parent: 82
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 723
+  - uid: 725
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 11.5,15.5
+      rot: 1.5707963267948966 rad
+      pos: 11.5,17.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 739
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,15.5
+      rot: -1.5707963267948966 rad
+      pos: 13.5,17.5
       parent: 82
-  - uid: 740
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,16.5
-      parent: 82
-  - uid: 741
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,15.5
-      parent: 82
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 742
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 5.5,16.5
-      parent: 82
-  - uid: 743
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 5.5,15.5
-      parent: 82
-  - uid: 744
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 7.5,16.5
-      parent: 82
-  - uid: 745
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 7.5,15.5
-      parent: 82
-  - uid: 746
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 9.5,16.5
-      parent: 82
-  - uid: 748
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 11.5,16.5
-      parent: 82
-  - uid: 750
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 10.5,14.5
-      parent: 82
-  - uid: 751
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 10.5,15.5
-      parent: 82
-  - uid: 752
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 11.5,15.5
-      parent: 82
-  - uid: 755
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,14.5
+      pos: 15.5,18.5
       parent: 82
     - type: AtmosPipeColor
-      color: '#03FCD3FF'
-  - uid: 759
+      color: '#990000FF'
+  - uid: 763
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 16.5,15.5
+      rot: 1.5707963267948966 rad
+      pos: 7.5,17.5
       parent: 82
     - type: AtmosPipeColor
-      color: '#03FCD3FF'
+      color: '#990000FF'
   - uid: 765
     components:
     - type: Transform
@@ -84341,186 +84585,19 @@ entities:
       parent: 82
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 790
+  - uid: 866
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 0.5,14.5
-      parent: 82
-  - uid: 791
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 2.5,14.5
-      parent: 82
-  - uid: 792
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,16.5
-      parent: 82
-  - uid: 793
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -0.5,16.5
+      pos: -0.5,17.5
       parent: 82
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 794
+  - uid: 873
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 3.5,16.5
-      parent: 82
-  - uid: 795
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 5.5,16.5
-      parent: 82
-  - uid: 796
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 7.5,16.5
-      parent: 82
-  - uid: 797
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 9.5,16.5
-      parent: 82
-  - uid: 798
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 11.5,16.5
-      parent: 82
-  - uid: 816
-    components:
-    - type: Transform
-      pos: -1.5,13.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#947507FF'
-  - uid: 817
-    components:
-    - type: Transform
-      pos: -1.5,12.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#947507FF'
-  - uid: 826
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 14.5,13.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#680285FF'
-  - uid: 827
-    components:
-    - type: Transform
-      pos: 13.5,14.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#680285FF'
-  - uid: 828
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,14.5
-      parent: 82
-  - uid: 829
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,14.5
-      parent: 82
-  - uid: 830
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 8.5,14.5
-      parent: 82
-  - uid: 878
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 2.5,13.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#680285FF'
-  - uid: 879
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,13.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#680285FF'
-  - uid: 880
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 0.5,13.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#680285FF'
-  - uid: 881
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,13.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#680285FF'
-  - uid: 882
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,13.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#680285FF'
-  - uid: 883
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 7.5,13.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#680285FF'
-  - uid: 884
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 8.5,13.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#680285FF'
-  - uid: 885
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 10.5,13.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#680285FF'
-  - uid: 886
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 12.5,13.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#680285FF'
-  - uid: 897
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,16.5
+      pos: 1.5,17.5
       parent: 82
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -84540,14 +84617,6 @@ entities:
       parent: 82
     - type: AtmosPipeColor
       color: '#680285FF'
-  - uid: 910
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -1.5,13.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#680285FF'
   - uid: 915
     components:
     - type: Transform
@@ -84563,14 +84632,6 @@ entities:
       parent: 82
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 948
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 16.5,13.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#680285FF'
   - uid: 952
     components:
     - type: Transform
@@ -84894,22 +84955,6 @@ entities:
       parent: 82
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 1857
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 15.5,14.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#03FCD3FF'
-  - uid: 1861
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 14.5,14.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#03FCD3FF'
   - uid: 1965
     components:
     - type: Transform
@@ -87267,6 +87312,8 @@ entities:
     - type: Transform
       pos: 0.5,20.5
       parent: 82
+    - type: AtmosPipeColor
+      color: '#DB48CFFF'
   - uid: 10838
     components:
     - type: Transform
@@ -101325,26 +101372,6 @@ entities:
       parent: 82
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 736
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,16.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 747
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 11.5,14.5
-      parent: 82
-  - uid: 749
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 9.5,15.5
-      parent: 82
   - uid: 766
     components:
     - type: Transform
@@ -101353,146 +101380,6 @@ entities:
       parent: 82
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 799
-    components:
-    - type: Transform
-      pos: 8.5,11.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#947507FF'
-  - uid: 800
-    components:
-    - type: Transform
-      pos: 6.5,11.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#947507FF'
-  - uid: 801
-    components:
-    - type: Transform
-      pos: 0.5,11.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#947507FF'
-  - uid: 802
-    components:
-    - type: Transform
-      pos: 2.5,11.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#947507FF'
-  - uid: 809
-    components:
-    - type: Transform
-      pos: 12.5,11.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#947507FF'
-  - uid: 810
-    components:
-    - type: Transform
-      pos: 14.5,11.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#947507FF'
-  - uid: 811
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 11.5,11.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#947507FF'
-  - uid: 812
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 9.5,11.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#947507FF'
-  - uid: 813
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 5.5,11.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#947507FF'
-  - uid: 814
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,11.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#947507FF'
-  - uid: 819
-    components:
-    - type: Transform
-      pos: -0.5,13.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#680285FF'
-  - uid: 820
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -1.5,16.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 824
-    components:
-    - type: Transform
-      pos: 15.5,13.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#680285FF'
-  - uid: 873
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,11.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#947507FF'
-  - uid: 874
-    components:
-    - type: Transform
-      pos: 3.5,13.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#680285FF'
-  - uid: 875
-    components:
-    - type: Transform
-      pos: 5.5,13.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#680285FF'
-  - uid: 876
-    components:
-    - type: Transform
-      pos: 11.5,13.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#680285FF'
-  - uid: 877
-    components:
-    - type: Transform
-      pos: 9.5,13.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#680285FF'
-  - uid: 887
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 13.5,13.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#680285FF'
   - uid: 899
     components:
     - type: Transform
@@ -101624,22 +101511,6 @@ entities:
       parent: 82
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 1865
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,11.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#947507FF'
-  - uid: 1867
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 10.5,11.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#947507FF'
   - uid: 1879
     components:
     - type: Transform
@@ -103686,20 +103557,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 22.5,17.5
       parent: 82
-  - uid: 1866
-    components:
-    - type: Transform
-      pos: 10.5,12.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#947507FF'
-  - uid: 1875
-    components:
-    - type: Transform
-      pos: 4.5,12.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#947507FF'
   - uid: 7276
     components:
     - type: Transform
@@ -103835,18 +103692,10 @@ entities:
   - uid: 418
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 8.5,10.5
+      pos: -0.5,17.5
       parent: 82
     - type: AtmosPipeColor
-      color: '#947507FF'
-  - uid: 419
-    components:
-    - type: Transform
-      pos: 12.5,10.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#947507FF'
+      color: '#DB48CFFF'
   - uid: 420
     components:
     - type: Transform
@@ -103861,41 +103710,6 @@ entities:
       parent: 82
     - type: AtmosPipeColor
       color: '#947507FF'
-  - uid: 705
-    components:
-    - type: Transform
-      pos: -0.5,17.5
-      parent: 82
-  - uid: 706
-    components:
-    - type: Transform
-      pos: 1.5,17.5
-      parent: 82
-  - uid: 707
-    components:
-    - type: Transform
-      pos: 3.5,17.5
-      parent: 82
-  - uid: 708
-    components:
-    - type: Transform
-      pos: 5.5,17.5
-      parent: 82
-  - uid: 709
-    components:
-    - type: Transform
-      pos: 7.5,17.5
-      parent: 82
-  - uid: 710
-    components:
-    - type: Transform
-      pos: 11.5,17.5
-      parent: 82
-  - uid: 711
-    components:
-    - type: Transform
-      pos: 9.5,17.5
-      parent: 82
   - uid: 719
     components:
     - type: Transform
@@ -103903,14 +103717,13 @@ entities:
       parent: 82
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 724
+  - uid: 735
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 14.5,10.5
+      pos: 1.5,17.5
       parent: 82
     - type: AtmosPipeColor
-      color: '#947507FF'
+      color: '#C4C0C1FF'
   - uid: 738
     components:
     - type: Transform
@@ -103919,51 +103732,62 @@ entities:
       parent: 82
     - type: AtmosPipeColor
       color: '#947507FF'
+  - uid: 748
+    components:
+    - type: Transform
+      pos: 11.5,17.5
+      parent: 82
+    - type: AtmosPipeColor
+      color: '#F7526AFF'
+  - uid: 790
+    components:
+    - type: Transform
+      pos: 3.5,17.5
+      parent: 82
+  - uid: 802
+    components:
+    - type: Transform
+      pos: 5.5,17.5
+      parent: 82
+    - type: AtmosPipeColor
+      color: '#A114DEFF'
+  - uid: 814
+    components:
+    - type: Transform
+      pos: 9.5,17.5
+      parent: 82
+    - type: AtmosPipeColor
+      color: '#52D1F7FF'
+  - uid: 819
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 14.5,10.5
+      parent: 82
+    - type: AtmosPipeColor
+      color: '#947507FF'
+  - uid: 820
+    components:
+    - type: Transform
+      pos: 12.5,10.5
+      parent: 82
+    - type: AtmosPipeColor
+      color: '#947507FF'
+  - uid: 822
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 8.5,10.5
+      parent: 82
+    - type: AtmosPipeColor
+      color: '#947507FF'
   - uid: 823
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 15.5,12.5
+      pos: 7.5,17.5
       parent: 82
     - type: AtmosPipeColor
-      color: '#947507FF'
-  - uid: 825
-    components:
-    - type: Transform
-      pos: 11.5,12.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#947507FF'
-  - uid: 864
-    components:
-    - type: Transform
-      pos: -0.5,12.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#947507FF'
-  - uid: 865
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,12.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#947507FF'
-  - uid: 866
-    components:
-    - type: Transform
-      pos: 5.5,12.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#947507FF'
-  - uid: 867
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 9.5,12.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#947507FF'
+      color: '#262426FF'
   - uid: 908
     components:
     - type: Transform
@@ -104158,69 +103982,22 @@ entities:
       parent: 82
     - type: GasValve
       open: False
-  - uid: 678
+  - uid: 737
     components:
     - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 14.5,17.5
+      parent: 82
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 745
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
       pos: -1.5,17.5
       parent: 82
-    - type: GasValve
-      open: False
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 763
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 13.5,15.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 764
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 13.5,17.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 1856
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 15.5,17.5
-      parent: 82
-    - type: AtmosPipeColor
-      color: '#03FCD3FF'
-  - uid: 1868
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 7.5,11.5
-      parent: 82
-    - type: GasValve
-      open: False
-    - type: AtmosPipeColor
-      color: '#947507FF'
-  - uid: 1869
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 1.5,11.5
-      parent: 82
-    - type: GasValve
-      open: False
-    - type: AtmosPipeColor
-      color: '#947507FF'
-  - uid: 1878
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 13.5,11.5
-      parent: 82
-    - type: GasValve
-      open: False
-    - type: AtmosPipeColor
-      color: '#947507FF'
 - proto: GasVentPump
   entities:
   - uid: 1002
@@ -106994,11 +106771,6 @@ entities:
     components:
     - type: Transform
       pos: 16.5,18.5
-      parent: 82
-  - uid: 432
-    components:
-    - type: Transform
-      pos: -1.5,18.5
       parent: 82
   - uid: 433
     components:
@@ -132015,11 +131787,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 15.5,18.5
       parent: 82
-  - uid: 680
-    components:
-    - type: Transform
-      pos: -1.5,18.5
-      parent: 82
   - uid: 681
     components:
     - type: Transform
@@ -143197,27 +142964,6 @@ entities:
       - SurveillanceCameraEngineering
       nameSet: True
       id: Reception
-  - uid: 3849
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,20.5
-      parent: 82
-    - type: SurveillanceCamera
-      setupAvailableNetworks:
-      - SurveillanceCameraEngineering
-      nameSet: True
-      id: Atmos 1
-  - uid: 3850
-    components:
-    - type: Transform
-      pos: 9.5,7.5
-      parent: 82
-    - type: SurveillanceCamera
-      setupAvailableNetworks:
-      - SurveillanceCameraEngineering
-      nameSet: True
-      id: Atmos 2
   - uid: 3851
     components:
     - type: Transform
@@ -143252,11 +142998,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 29.5,15.5
       parent: 82
-  - uid: 26315
-    components:
-    - type: Transform
-      pos: 17.5,19.5
-      parent: 82
   - uid: 26316
     components:
     - type: Transform
@@ -143268,32 +143009,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,27.5
-      parent: 82
-  - uid: 26318
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -1.5,20.5
-      parent: 82
-  - uid: 26319
-    components:
-    - type: Transform
-      pos: -3.5,19.5
-      parent: 82
-  - uid: 26320
-    components:
-    - type: Transform
-      pos: 7.5,19.5
-      parent: 82
-  - uid: 26321
-    components:
-    - type: Transform
-      pos: 2.5,19.5
-      parent: 82
-  - uid: 26322
-    components:
-    - type: Transform
-      pos: 11.5,19.5
       parent: 82
   - uid: 26359
     components:
@@ -149602,11 +149317,6 @@ entities:
     components:
     - type: Transform
       pos: 19.5,27.5
-      parent: 82
-  - uid: 578
-    components:
-    - type: Transform
-      pos: -2.5,18.5
       parent: 82
   - uid: 579
     components:
@@ -166269,13 +165979,6 @@ entities:
       parent: 82
     - type: WarpPoint
       location: Security
-  - uid: 25245
-    components:
-    - type: Transform
-      pos: 7.5,15.5
-      parent: 82
-    - type: WarpPoint
-      location: Atmos
   - uid: 25246
     components:
     - type: Transform


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
Adds Station beacons back to Kettle.

The consequences of trusting Icepick for mapping, smh.

## About the PR
<!-- What did you change? -->
Stations Beacons have been added to Kettle, and Kettle's Atmospherics area has been reworked a bit.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/0cb73088-5758-4262-a0c8-a01f821ecb42)
![image](https://github.com/user-attachments/assets/482c4ca5-9503-4479-8db7-b3a4d2de1b0a)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Kettle has been granted the pleasure of having station beacons. (again)
- tweak: Kettle's Atmospherics area no longer has overt pre-built piping
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
