### PR TITLE
Fixing ISerializationGeneration errors or THE pull request of all time

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "RobustToolbox"]
 	path = RobustToolbox
-	url = https://github.com/space-wizards/RobustToolbox.git
+	url = https://github.com/space-wizards/RobustToolbox
 	branch = master

--- a/Content.Shared/Roles/Jobs/SharedJobSystem.cs
+++ b/Content.Shared/Roles/Jobs/SharedJobSystem.cs
@@ -112,7 +112,7 @@ public abstract class SharedJobSystem : EntitySystem
         if (role is null)
             return false;
 
-        comp = role.Value.Comp;
+        comp = role.Value.Comp1;
 
         return (comp.JobPrototype == prototypeId);
     }
@@ -137,7 +137,7 @@ public abstract class SharedJobSystem : EntitySystem
             return false;
 
         if (_roles.MindHasRole<JobRoleComponent>(mindId.Value, out var role))
-            job = role.Value.Comp.JobPrototype;
+            job = role.Value.Comp1.JobPrototype;
 
         return (job is not null);
     }

--- a/Content.Shared/StepTrigger/Components/StepTriggerImmuneComponent.cs
+++ b/Content.Shared/StepTrigger/Components/StepTriggerImmuneComponent.cs
@@ -3,6 +3,7 @@ using Content.Shared.StepTrigger.Systems;
 using Robust.Shared.GameStates;
 
 namespace Content.Shared.StepTrigger.Components;
+
 /// <summary>
 ///     Goobstation: This component marks an entity as being immune to all step triggers.
 ///     For example, a Harpy being so low density, that they don't set off landmines.
@@ -13,7 +14,6 @@ namespace Content.Shared.StepTrigger.Components;
 ///     Consider using a subscription to StepTriggerAttemptEvent if you wish to be more selective.
 /// </remarks>
 [RegisterComponent, NetworkedComponent]
-public sealed partial class StepTriggerImmuneComponent : Component { }
 [Access(typeof(StepTriggerSystem))]
 public sealed partial class StepTriggerImmuneComponent : Component
 {


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed "The Error" that made it impossible to tell what was or wasn't actually needing to be updated. 

## Why / Balance
Because without fixing The Error no progress would be made.

## Technical details
I had originally planned to rollback RobustToolkit engine optimizations to fix The Error, hence the name of the branch, but I was persuaded otherwise. Those rollbacks aren't present in this because RobustToolkit isn't present in the repository itself, and the rollback wouldn't be necessary anyways. The actual fix was just to change a single duplicate class definition in StepTriggerImmuneComponent.cs . In other words noslips broke the game for multiple weeks. 

Also there was exactly one change I made to how a job role was accessed to fit update class structures, but there's a lot more of that that needs to be done and I don't even know if I did it right. That wasn't necessary to fix The Error though and was just an extra thing I did and might as well throw in, I guess.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have ~~skimmed~~ read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
There are so many. So many. But they weren't introduced by this PR so I'm a-ok!

**Changelog**
- fix: Removed duplicate class definition in StepTriggerImmuneComponent.cs
- fix: Tried to refactor the usage of methods in SharedJobSystem to fit updated class structure
- oops: Removed the ".git" from RobustToolbox in the git submodule definitions somehow, probably while reverting to the regular wiznerds repo instead of my own, but I don't know I'm too tired to fix it and it doesn't seem to break anything 
