### PR TITLE
Revs: Revolutionaries can no longer see each others rev status

### DIFF
--- a/Resources/Prototypes/StatusIcon/faction.yml
+++ b/Resources/Prototypes/StatusIcon/faction.yml
@@ -29,7 +29,7 @@
   showTo:
     components:
       - ShowAntagIcons
-      - Revolutionary
+      - HeadRevolutionary
   icon:
     sprite: /Textures/Interface/Misc/job_icons.rsi
     state: Revolutionary


### PR DESCRIPTION
# This PR is part of a larger Revolutionaries rework.
Any PR with this as the header is considered a part of the larger revs rework at Funky Station.

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
one line yaml change. Revolutionaries can no longer see each others status, they can only see Head Revolutionaries.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Revolutionaries have a severe snowballing problem. Doing this will force revolutionaries to co-ordinate more through other means, and using IC methods to do so, rather than just looking at each other, finding the red R, and going in and killing people. That entirely defeats any methods to do fun stuff IC, because you already know who's who.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: 
- tweak: Revolutionaries can no longer see each others rev status.
- tweak: Revolutionaries can only see HRevs.
