### PR TITLE
Revs: Popup now appears when an HRev converts crew

### DIFF
--- a/Content.Server/Flash/FlashSystem.cs
+++ b/Content.Server/Flash/FlashSystem.cs
@@ -147,10 +147,15 @@ namespace Content.Server.Flash
             if (melee || revFlash)
             {
                 var ev = new AfterFlashedEvent(target, user, used);
-                if (user != null)
-                    RaiseLocalEvent(user.Value, ref ev);
-                if (used != null)
-                    RaiseLocalEvent(used.Value, ref ev);
+
+                if (user == null)
+                    return;
+
+                if (used == null)
+                    return;
+
+                _popup.PopupEntity(Loc.GetString("flash-component-user-head-rev",
+                        ("victim", Identity.Entity(target, EntityManager))), target);
             }
         }
 

--- a/Resources/Locale/en-US/flash/components/flash-component.ftl
+++ b/Resources/Locale/en-US/flash/components/flash-component.ftl
@@ -5,3 +5,6 @@ flash-component-user-blinds-you = {$user} blinds you with the flash!
 
 # Shown when a flash runs out of uses
 flash-component-becomes-empty = The flash burns out!
+
+# funky station
+flash-component-user-head-rev = {$victim}'s eyes turn white for a second, before returning to normal.

--- a/Resources/Prototypes/StatusIcon/faction.yml
+++ b/Resources/Prototypes/StatusIcon/faction.yml
@@ -29,7 +29,7 @@
   showTo:
     components:
       - ShowAntagIcons
-      - Revolutionary
+      - HeadRevolutionary
   icon:
     sprite: /Textures/Interface/Misc/job_icons.rsi
     state: Revolutionary


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

# This PR is part of a larger Revolutionaries rework.
Any PR with this as the header is considered a part of the larger revs rework at Funky Station.

## About the PR
A small pop up appears when a crew member is converted.

`Dawn Leander's eyes turn white for a second, before returning to normal.`

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Finally, a give for when someone is a head rev. No more LOOC mald nonsense.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Converting someone as a head revolutionary now creates a pop-up for everyone who witnesses it.
