### PR TITLE
Vocaloid names for Operatives

### DIFF
--- a/Resources/Prototypes/Datasets/Names/syndicate.yml
+++ b/Resources/Prototypes/Datasets/Names/syndicate.yml
@@ -26,6 +26,14 @@
   - Whiskey
   - X-Ray
   - Zulu
+  - Miku
+  - Teto
+  - Rin
+  - Len
+  - Luka
+  - Gumi
+  - Kaito
+  - Meiko
 
 - type: dataset
   id: SyndicateNamesElite


### PR DESCRIPTION
(I'm not a huge vocaloid listener, so I might be missing a few)

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added some of the more popular Vocaloid names to the operative pool

## Why / Balance
This all started from an Admin QnA about how most of the syndicate agents names are very masculine, without many options for everyone else. I then had the idea of how funny it would be for a nuclear operative team of vocaloid members.

**Changelog**
- Added the names (Comment if I should add more / missing any big ones)
:cl:
- add: Nuclear Operatives can now start with Vocaloid names
-->
