### PR TITLE
Vocaloid Names for Syndicate Loneops and Reinforcements

### DIFF
--- a/Resources/Prototypes/Datasets/Names/death_commando.yml
+++ b/Resources/Prototypes/Datasets/Names/death_commando.yml
@@ -60,3 +60,13 @@
   - Thick McRunfast
   - Touch Rustrod
   - Trunk Slamchest
+##vocaloid names
+  - Merciless Miku
+  - Ruthless Rin
+  - Lawless Len
+  - Lethal Luka
+  - Killer Kikuo
+  - Gunnner Gumi
+  - Keen Kaito
+  - Murderous Meiko
+  - Traitorous Teto

--- a/Resources/Prototypes/Datasets/Names/syndicate.yml
+++ b/Resources/Prototypes/Datasets/Names/syndicate.yml
@@ -26,6 +26,13 @@
   - Whiskey
   - X-Ray
   - Zulu
+  - Rin
+  - Len
+  - Luka
+  - Kikuo
+  - Gumi
+  - Kaito
+  - Meiko 
 
 - type: dataset
   id: SyndicateNamesElite
@@ -53,6 +60,9 @@
   - Chi
   - Psi
   - Omega
+  - Miku
+  - Teto
+  - Neru
 
 - type: dataset
   id: SyndicateNamesPrefix


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This all started during an admin QnA, where someone noted the lack of diversity regarding the gender of syndicate names. The first female icon I thought of was miku, so I decided to added the most popular (at least in my opinion, I'm not the most dedicated vocaloid fan) names to the list.

## Why / Balance
Operator Miku.

**Changelog**
-added the first set of names (open to more)

:cl:
- add: Syndicate Reinforcements and Lone Operatives can now start with Vocaloid names.
-->
