### PR TITLE
Funky NightVision Item implementation

### DIFF
--- a/Content.Client/_Goobstation/Nigthvision/NightVisionSystem.cs
+++ b/Content.Client/_Goobstation/Nigthvision/NightVisionSystem.cs
@@ -20,6 +20,8 @@ public sealed class NightVisionSystem : EquipmentHudSystem<NightVisionComponent>
     {
         base.Initialize();
 
+        SubscribeLocalEvent<NightVisionComponent, AfterAutoHandleStateEvent>(SyncClientComponent);
+
         _overlay = new(Color.Green);
     }
 
@@ -33,10 +35,12 @@ public sealed class NightVisionSystem : EquipmentHudSystem<NightVisionComponent>
             if (comp.IsNightVision)
                 _lightManager.DrawLighting = false;
         }
-        if (!_overlayMan.HasOverlay<NightVisionOverlay>())
+        // remove the old overlay if it exists, always override with a new overlay if we have one.
+        if (_overlayMan.HasOverlay<NightVisionOverlay>())
         {
-            _overlayMan.AddOverlay(_overlay);
+            _overlayMan.RemoveOverlay<NightVisionOverlay>();
         }
+        _overlayMan.AddOverlay(_overlay);
     }
 
     protected override void DeactivateInternal()
@@ -44,5 +48,13 @@ public sealed class NightVisionSystem : EquipmentHudSystem<NightVisionComponent>
         base.DeactivateInternal();
         _overlayMan.RemoveOverlay(_overlay);
         _lightManager.DrawLighting = true;
+    }
+
+    private void SyncClientComponent(EntityUid uid, NightVisionComponent component, ref AfterAutoHandleStateEvent handleEvent)
+    {
+        // not implemented, 
+        // Somehow the client color is not matching the Server color. IDK if its an issue with the component copy
+        // constructor or what, but someone can implement this if they want custumizable Nv colors, or track down
+        // whatever other issue is making the color in the client component incorrect/ default. (it is correct in the server component)
     }
 }

--- a/Content.Shared/_Goobstation/Nigthvision/Components/NightVisionComponent.cs
+++ b/Content.Shared/_Goobstation/Nigthvision/Components/NightVisionComponent.cs
@@ -6,7 +6,8 @@ using Robust.Shared.GameStates;
 namespace Content.Shared.NightVision.Components;
 
 [RegisterComponent]
-[NetworkedComponent, AutoGenerateComponentState]
+// fieldDeltas: true because otherwise the color and other weird nuanced variables are not correctly passed to the client.
+[NetworkedComponent, AutoGenerateComponentState(raiseAfterAutoHandleState: true)]
 [Access(typeof(NightVisionSystem))]
 public sealed partial class NightVisionComponent : Component
 {
@@ -33,3 +34,6 @@ public sealed partial class NightVisionComponent : Component
 }
 
 public sealed partial class NVInstantActionEvent : InstantActionEvent { }
+
+[ByRefEvent]
+public record struct NightVisionChangedEvent(bool NightVision);

--- a/Content.Shared/_Goobstation/Nigthvision/Systems/NightVisionSystem.cs
+++ b/Content.Shared/_Goobstation/Nigthvision/Systems/NightVisionSystem.cs
@@ -5,6 +5,9 @@ using JetBrains.Annotations;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
+using Robust.Shared.Player;
+using Content.Shared.Clothing;
+using Robust.Shared.Serialization.Manager;
 
 namespace Content.Shared.NightVision.Systems;
 
@@ -13,13 +16,19 @@ public sealed class NightVisionSystem : EntitySystem
     [Dependency] private readonly SharedActionsSystem _actionsSystem = default!;
     [Dependency] private readonly SharedAudioSystem _audioSystem = default!;
     [Dependency] private readonly INetManager _net = default!;
+    [Dependency] private readonly ISerializationManager _serMan = default!;
 
     public override void Initialize()
     {
         base.Initialize();
 
-        if(_net.IsServer)
+        if (_net.IsServer)
+        {
             SubscribeLocalEvent<NightVisionComponent, ComponentStartup>(OnComponentStartup);
+            SubscribeLocalEvent<NightVisionComponent, ComponentShutdown>(OnComponentShutdown);
+            SubscribeLocalEvent<NightVisionComponent, ClothingGotEquippedEvent>(OnGotEquipped);
+            SubscribeLocalEvent<NightVisionComponent, ClothingGotUnequippedEvent>(OnGotUnequipped);
+        }
         SubscribeLocalEvent<NightVisionComponent, NVInstantActionEvent>(OnActionToggle);
     }
 
@@ -30,12 +39,45 @@ public sealed class NightVisionSystem : EntitySystem
     {
         if (component.IsToggle)
             _actionsSystem.AddAction(uid, ref component.ActionContainer, SwitchNightVisionAction);
+        else
+            component.IsNightVision = true;
+    }
+
+    private void OnComponentShutdown(EntityUid uid, NightVisionComponent component, ComponentShutdown args)
+    {
+        _actionsSystem.RemoveAction(uid, component.ActionContainer);
+    }
+
+    private void OnGotEquipped(EntityUid uid, NightVisionComponent component, ref ClothingGotEquippedEvent args)
+    {
+        if (!HasComp<NightVisionComponent>(args.Wearer))
+        {
+            var newComp = new NightVisionComponent
+            {
+                IsNightVision = component.IsNightVision,
+                IsToggle = component.IsToggle,
+                PlaySoundOn = component.PlaySoundOn,
+                OnOffSound = component.OnOffSound
+            };
+            AddComp(args.Wearer, newComp, true);
+            // dirty because yea. They have a fancy new action or overlay now.
+            DirtyEntity(args.Wearer);
+        }
+    }
+
+    private void OnGotUnequipped(EntityUid uid, NightVisionComponent component, ref ClothingGotUnequippedEvent args)
+    {
+        if (HasComp<NightVisionComponent>(args.Wearer))
+        {
+            RemComp<NightVisionComponent>(args.Wearer);
+            DirtyEntity(args.Wearer);
+        }
     }
 
     private void OnActionToggle(EntityUid uid, NightVisionComponent component, NVInstantActionEvent args)
     {
         component.IsNightVision = !component.IsNightVision;
-        var changeEv = new NightVisionnessChangedEvent(component.IsNightVision);
+        var changeEv = new NightVisionChangedEvent(component.IsNightVision); // theres nothing anywhere subscribed to this event? Unless theres metacode/macros involved...
         RaiseLocalEvent(uid, ref changeEv);
         Dirty(uid, component);
         _actionsSystem.SetCooldown(component.ActionContainer, TimeSpan.FromSeconds(1));
@@ -55,22 +97,18 @@ public sealed class NightVisionSystem : EntitySystem
         var old = component.IsNightVision;
 
 
-        var ev = new CanVisionAttemptEvent();
+        var ev = new CanVisionAttemptEvent(); // theres nothing anywhere subscribed to this event?
         RaiseLocalEvent(uid, ev);
         component.IsNightVision = ev.NightVision;
 
         if (old == component.IsNightVision)
             return;
 
-        var changeEv = new NightVisionnessChangedEvent(component.IsNightVision);
+        var changeEv = new NightVisionChangedEvent(component.IsNightVision);
         RaiseLocalEvent(uid, ref changeEv);
         Dirty(uid, component);
     }
 }
-
-[ByRefEvent]
-public record struct NightVisionnessChangedEvent(bool NightVision);
-
 
 public sealed class CanVisionAttemptEvent : CancellableEntityEventArgs, IInventoryRelayEvent
 {


### PR DESCRIPTION
## About the PR
Added onEquip, onUnequip, and onShutdown event handlers to NightVisionComponents
In order to not break / over complicate current implementation uses of the component type I just made it so the component gets added and removed from the wearer following the appropriate event, along with the action as necessary.

## Why / Balance
people were asking for it, personally I don't care either way and I've invested enough time trying to figure out the cursed nightvision implementation and don't feel a desire to invest more time at this point. but its here for anyone who wants to build on it or get it to 100% functionality instead of the 90% functionality its at right now.

## Technical details
added event subscriptions to shared nightvision system and moved the nightvisionchangedevent to the shared component file so it can be imported to the client if needed. 

## Media
No in-game changes, just added functionality for anyone who WANTS to add NightVision to certain items. I won't begin to pretend I understand the balance implications of item fuckery.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
It should be noted that just due to the way adding components works, and the overcomplicated spaghetti that is EntityUid's and Components - plus a lack of simple 1 - 1 functionality between the two types -  that if something that already has nightvision puts on an item granting night vision, then removes the item, their original night vision will likely ALSO be removed. This can probably be fixed with a simple boolean inside the component and adding a check to the unequipped event, maybe with a loop that goes through all the NV components in the wearer. 
It should also be noted that due to something I wasn't willing to invest the time to figure out the reasoning behind, the CLIENT component will always use the default color green for item nightvision. 

**Changelog**
clothing items like sunglasses can now use `- type:  NightVision` argument in their yaml to give toggleable or non toggleable nightvision to the wearer.
