### PR TITLE
Change evil corgium descriptor

### DIFF
--- a/Resources/Prototypes/_Funkystation/Reagents/exotic.yml
+++ b/Resources/Prototypes/_Funkystation/Reagents/exotic.yml
@@ -150,7 +150,7 @@
   name: reagent-name-muigroc
   group: Exotic
   desc: reagent-desc-muigroc
-  physicalDesc: reagent-physical-desc-inverted
+  physicalDesc: reagent-physical-desc-inversed
   flavor: medicine
   color: "#ffaa00"
   metabolisms:

--- a/Resources/Prototypes/_Funkystation/Reagents/exotic.yml
+++ b/Resources/Prototypes/_Funkystation/Reagents/exotic.yml
@@ -150,7 +150,7 @@
   name: reagent-name-muigroc
   group: Exotic
   desc: reagent-desc-muigroc
-  physicalDesc: reagent-physical-desc-fluffy
+  physicalDesc: reagent-physical-desc-inverted
   flavor: medicine
   color: "#ffaa00"
   metabolisms:


### PR DESCRIPTION

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changed the description for Muigroc to inverted

## Why / Balance
Makes more sense to have it match with juice that makes you hew which is also spelled backwards. 

## Technical details
minor YML changes

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl: Changed evil corgium descriptor
