### PR TITLE
Fixed health analyzer limb display and asserts on Heretic mansus

### DIFF
--- a/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml
+++ b/Content.Client/HealthAnalyzer/UI/HealthAnalyzerWindow.xaml
@@ -29,7 +29,7 @@
                               Margin="0 0 0 5">
                     <PanelContainer>
                         <SpriteView OverrideDirection="South"
-                                    Scale="2.5 2.5"
+                                    Scale="1.0 1.0"
                                     Name="SpriteView"
                                     Access="Public"
                                     SetSize="96 96"/>

--- a/Content.Server/_Goobstation/Heretic/EntitySystems/MansusGraspSystem.cs
+++ b/Content.Server/_Goobstation/Heretic/EntitySystems/MansusGraspSystem.cs
@@ -109,6 +109,7 @@ public sealed partial class MansusGraspSystem : EntitySystem
 
         if (!TryComp<HereticComponent>(args.User, out var hereticComp))
         {
+            args.Handled = true;
             QueueDel(ent);
             return;
         }
@@ -141,6 +142,7 @@ public sealed partial class MansusGraspSystem : EntitySystem
         }
 
         hereticComp.MansusGraspActive = false;
+        args.Handled = true;
         QueueDel(ent);
     }
 
@@ -160,6 +162,7 @@ public sealed partial class MansusGraspSystem : EntitySystem
         if (args.Target != null && HasComp<HereticRitualRuneComponent>(args.Target))
         {
             // todo: add more fluff
+            args.Handled = true;
             QueueDel(args.Target);
             return;
         }

--- a/Resources/Prototypes/_Goobstation/Heretic/Entities/Objects/Specific/heretic.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Entities/Objects/Specific/heretic.yml
@@ -25,7 +25,7 @@
     radius: 2
     energy: 1
     color: "#6e7500"
-    netsync: true
+    netsync: false
   - type: Appearance
   - type: ItemToggle
     predictable: false


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed the assert crashes/changed the code to fit other code changes from merging upstream (maybe??) with heretic. Changed the scale of the body part selection sprite on the health analyzer so it is no longer larger than it's own viewport and fits neatly and correctly within the bounds of the clickable buttons for the individual parts. 

Not a change but noteworthy: I screwed around with Heretic and Shitmed for like two hours and did not experience a crash after these changes, further testing is probably a good idea but it seems mostly stable ish.

## Why / Balance
Because, uh, uhm, upstream, uh
Hristov rework is cool so yea because this enables us to have that

## Technical details
The mansus grasp was triggering an assert crash because it kept checking if the grasp was deleted and then throwing the assert. The mismatch probably came from the fact that the assert seemed to be wizden/upstream code and was in the system itself, while the OnAfterInteract code for the heretic was from goobstation and not accounting for code changes.

I have no idea why the health limb display was overscaled. It was at 2.5 scale before but I have no idea why it had to be. I can only assume it was a workaround for some other strange engine bug or interaction that doesn't exist anymore.

Also the pointlightcomponent or whatever it's called on the heretic codex no longer has netsync enabled so if there is weird lighting desyncs with it that's probably why. Hopefully there aren't any though, because welders have the same light-when-on no-light-when-off functionality but don't have netsync enabled.

## Media
im so tired im sorry, but also
both the heretic and the health analyzer look identical in game to before the upstream merge

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Hopefully none, except maybe that the mansus grasp now signifies that the OnAfterInteract event has been handled by it, so any further processing from that same single action isn't possible unless it happens before the Mansus grasp's system's handling of it. This seems unavoidable unless we change how the assert works (which I mean, it probably is there for a reason) or we add workarounds for specific interactions.

**Changelog**
fix: fixed debug assert crash with mansus grasp
fix: fixed debug assert crash with heretic codex (i forgot the name of it)
fix: fixed sprite scale of health analyzer limb selection menu 
