### PR TITLE
makes maxim hardsuit real

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/tables_loot.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/tables_loot.yml
@@ -252,7 +252,7 @@
     - !type:GroupSelector
       children:
       - id: ClothingOuterHardsuitSalvage
-      - id: ClothingOuterHardsuitMaxim # funk
+      - id: ClothingOuterHardsuitMaxim # funkystatopn
         weight: 0.05
     - id: OmnizineChemistryBottle
     - !type:GroupSelector

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/tables_loot.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/tables_loot.yml
@@ -252,7 +252,7 @@
     - !type:GroupSelector
       children:
       - id: ClothingOuterHardsuitSalvage
-      - id: ClothingOuterHardsuitMaxim # funkystatopn
+      - id: ClothingOuterHardsuitMaxim # funkystation
         weight: 0.05
     - id: OmnizineChemistryBottle
     - !type:GroupSelector

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/tables_loot.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/tables_loot.yml
@@ -252,7 +252,7 @@
     - !type:GroupSelector
       children:
       - id: ClothingOuterHardsuitSalvage
-      - id: ClothingOuterHardsuitMaxim
+      - id: ClothingOuterHardsuitMaxim # funk
         weight: 0.05
     - id: OmnizineChemistryBottle
     - !type:GroupSelector

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/tables_loot.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/tables_loot.yml
@@ -249,7 +249,11 @@
     - id: BlueprintFulton
     - id: BlueprintSeismicCharge
     - id: WeaponCrusherGlaive
-    - id: ClothingOuterHardsuitSalvage
+    - !type:GroupSelector
+      children:
+      - id: ClothingOuterHardsuitSalvage
+      - id: ClothingOuterHardsuitMaxim
+        weight: 0.05
     - id: OmnizineChemistryBottle
     - !type:GroupSelector
       children:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
makes a very low chance for the mining hardsuit on the already legendary rarity loot table to be replaced by the maxim hardsuit

## Why / Balance
it makes the maxim hardsuit actually obtainable aside from an extreme edge case that i haven't quite figured out yet on a certain exped type

## Technical details
changed the ClothingOuterHardsuitSalvage on the legendary loot table to a GroupSelector between the COHS and the ClothingOuterHardsuitMaxim with a 0.05 weight on the COHM

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
there's no media it's a code change grrrr

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [totally] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [hella] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
THE MAXIM HARDSUIT IS REAL!!!!

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Made the maxim hardsuit obtainable as an extremely rare treasure loot