### PR TITLE
Standardize mantle time requirements for BSO/NTR

### DIFF
--- a/Resources/Prototypes/_Goobstation/Loadouts/Jobs/Command/blueshield_officer.yml
+++ b/Resources/Prototypes/_Goobstation/Loadouts/Jobs/Command/blueshield_officer.yml
@@ -5,7 +5,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobBlueshieldOfficer
-      time: 187200
+      time: 72000 #20 hrs
 
 # Hats
 - type: loadout

--- a/Resources/Prototypes/_Goobstation/Loadouts/Jobs/Command/nanotrasen_representative.yml
+++ b/Resources/Prototypes/_Goobstation/Loadouts/Jobs/Command/nanotrasen_representative.yml
@@ -5,7 +5,7 @@
     requirement:
       !type:RoleTimeRequirement
       role: JobNanotrasenRepresentative
-      time: 187200
+      time: 72000 #20 hrs
 
 #hat
 - type: loadout


### PR DESCRIPTION
## About the PR
Blueshield Officer and Nanotrasen Representative's mantle time requirements were previously 50 hours. They are now 20 hours, matching the rest of the mantles' time requirements.

## Why / Balance
I see no convincing reason for BSO/NTR to specifically have more difficult mantles when compared to command members.

## Technical details
2 lines have been changed in yaml...

## Media
NO!!!

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A

**Changelog**
:cl:
- tweak: BSO/NTR mantle time requirements are now 20 hours instead of 50 hours
