### PR TITLE
Role timer updates

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/quartermaster.yml
@@ -9,12 +9,12 @@
       time: 18000 #5 hrs
     - !type:RoleTimeRequirement
       role: JobSalvageSpecialist
-      time: 7200 #2 hrs
+      time: 18000 #5 hrs
     - !type:DepartmentTimeRequirement
       department: Cargo
-      time: 36000 #10 hrs
-    - !type:OverallPlaytimeRequirement
       time: 54000 #15 hrs
+    - !type:OverallPlaytimeRequirement
+      time: 72000 #20 hrs
   weight: 10
   startingGear: QuartermasterGear
   icon: "JobIconQuarterMaster"

--- a/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Cargo/salvage_specialist.yml
@@ -4,6 +4,9 @@
   description: job-description-salvagespec
   playTimeTracker: JobSalvageSpecialist
   requirements:
+    - !type:RoleTimeRequirement
+      role: JobCargoTechnician
+      time: 3600 #1 hr
     - !type:OverallPlaytimeRequirement
       time: 10800 #3 hrs
   icon: "JobIconShaftMiner"

--- a/Resources/Prototypes/Roles/Jobs/Command/captain.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/captain.yml
@@ -6,18 +6,18 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Engineering
-      time: 10800 #3 hrs
-    - !type:DepartmentTimeRequirement
-      department: Medical
-      time: 10800 #3 hrs
-    - !type:DepartmentTimeRequirement
-      department: Security
       time: 18000 #5 hrs
     - !type:DepartmentTimeRequirement
-      department: Command
+      department: Medical
+      time: 18000 #5 hrs
+    - !type:DepartmentTimeRequirement
+      department: Security
       time: 36000 #10 hrs
+    - !type:DepartmentTimeRequirement
+      department: Command
+      time: 72000 #20 hrs
     - !type:OverallPlaytimeRequirement
-      time: 90000 #25 hrs
+      time: 144000 #40 hrs
   weight: 20
   startingGear: CaptainGear
   icon: "JobIconCaptain"

--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -5,7 +5,7 @@
   playTimeTracker: JobHeadOfPersonnel
   requirements:
     - !type:OverallPlaytimeRequirement
-      time: 72000 #15 hrs
+      time: 90000 #25 hrs
     - !type:DepartmentTimeRequirement
       department: Civilian
       time: 18000 #5 hrs

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -6,15 +6,15 @@
   requirements:
     - !type:RoleTimeRequirement
       role: JobAtmosphericTechnician
-      time: 21600 #6 hrs
+      time: 36000 #10 hrs
     - !type:RoleTimeRequirement
       role: JobStationEngineer
-      time: 21600 #6 hrs
-    - !type:DepartmentTimeRequirement
-      department: Engineering
       time: 36000 #10 hrs
+    - !type:DepartmentTimeRequirement #redundant but consistent
+      department: Engineering
+      time: 72000 #20 hrs
     - !type:OverallPlaytimeRequirement
-      time: 54000 #15 hrs
+      time: 90000 #25 hrs
   weight: 10
   startingGear: ChiefEngineerGear
   icon: "JobIconChiefEngineer"

--- a/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
@@ -6,7 +6,7 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Engineering
-      time: 7200 #2 hrs
+      time: 14400 #4 hrs
   startingGear: StationEngineerGear
   icon: "JobIconStationEngineer"
   supervisors: job-supervisors-ce

--- a/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
@@ -6,7 +6,7 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Engineering
-      time: 54000 #15 hrs
+      time: 72000 #20 hrs
       inverted: true # stop playing intern if you're good at engineering!
   startingGear: TechnicalAssistantGear
   icon: "JobIconTechnicalAssistant"

--- a/Resources/Prototypes/Roles/Jobs/Medical/chemist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chemist.yml
@@ -4,9 +4,11 @@
   description: job-description-chemist
   playTimeTracker: JobChemist
   requirements:
-    - !type:DepartmentTimeRequirement
-      department: Medical
-      time: 14400 #4 hrs
+    - !type:OverallPlaytimeRequirement #different chems
+      time: 7200 #2 hrs
+    - !type:RoleTimeRequirement
+      role: JobMedicalDoctor
+      time: 18000 #5 hrs
   startingGear: ChemistGear
   icon: "JobIconChemist"
   supervisors: job-supervisors-cmo

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -6,15 +6,15 @@
   requirements:
     - !type:RoleTimeRequirement
       role: JobChemist
-      time: 18000 #5 hrs
+      time: 36000 #10 hrs
     - !type:RoleTimeRequirement
       role: JobMedicalDoctor
-      time: 18000 #5 hrs
+      time: 36000 #10 hrs
     - !type:DepartmentTimeRequirement
       department: Medical
-      time: 36000 #10 hrs
+      time: 72000 #20 hrs
     - !type:OverallPlaytimeRequirement
-      time: 54000 #15 hrs
+      time: 90000 #25 hrs
   weight: 10
   startingGear: CMOGear
   icon: "JobIconChiefMedicalOfficer"

--- a/Resources/Prototypes/Roles/Jobs/Medical/medical_doctor.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/medical_doctor.yml
@@ -6,7 +6,7 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Medical
-      time: 7200 #2 hrs
+      time: 14400 #4 hrs
   startingGear: DoctorGear
   icon: "JobIconMedicalDoctor"
   supervisors: job-supervisors-cmo

--- a/Resources/Prototypes/Roles/Jobs/Medical/medical_intern.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/medical_intern.yml
@@ -6,7 +6,7 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Medical
-      time: 54000 # 15 hrs
+      time: 72000 #20 hrs
       inverted: true # stop playing intern if you're good at med!
   startingGear: MedicalInternGear
   icon: "JobIconMedicalIntern"

--- a/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
@@ -6,6 +6,9 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Medical
+      time: 14400 #4 hrs
+    - !type:RoleTimeRequirement
+      role: JobMedicalDoctor
       time: 7200 #2 hrs
   startingGear: ParamedicGear
   icon: "JobIconParamedic"

--- a/Resources/Prototypes/Roles/Jobs/Science/borg.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/borg.yml
@@ -7,7 +7,9 @@
   requirements:
   - !type:RoleTimeRequirement
     role: JobBorg
-    time: 18000  # 5 hrs
+    time: 72000 #20 hrs
+  - !type:OverallPlaytimeRequirement
+    time: 90000 #25 hrs
   canBeAntag: false
   icon: JobIconStationAi
   supervisors: job-supervisors-rd

--- a/Resources/Prototypes/Roles/Jobs/Science/research_assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_assistant.yml
@@ -6,7 +6,7 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Science
-      time: 54000 #15 hrs
+      time: 72000 #20 hrs
       inverted: true # stop playing intern if you're good at science!
   startingGear: ResearchAssistantGear
   icon: "JobIconResearchAssistant"

--- a/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/research_director.yml
@@ -4,11 +4,17 @@
   description: job-description-rd
   playTimeTracker: JobResearchDirector
   requirements:
+    - !type:RoleTimeRequirement
+      role: JobRoboticist
+      time: 18000 #5 hrs
+    - !type:RoleTimeRequirement
+      role: JobScientist
+      time: 36000 #10 hrs
     - !type:DepartmentTimeRequirement
       department: Science
-      time: 36000 #10 hrs
+      time: 72000 #20 hrs
     - !type:OverallPlaytimeRequirement
-      time: 54000 #15 hrs
+      time: 90000 #25 hrs
   weight: 10
   startingGear: ResearchDirectorGear
   icon: "JobIconResearchDirector"

--- a/Resources/Prototypes/Roles/Jobs/Science/roboticist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/roboticist.yml
@@ -6,7 +6,7 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Science
-      time: 21600 #6 hrs
+      time: 14400 #4 hrs
   startingGear: RoboticistGear
   icon: "JobIconRoboticist"
   supervisors: job-supervisors-rd

--- a/Resources/Prototypes/Roles/Jobs/Science/scientist.yml
+++ b/Resources/Prototypes/Roles/Jobs/Science/scientist.yml
@@ -6,7 +6,7 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Science
-      time: 7200 #2 hrs
+      time: 14400 #4 hrs
   startingGear: ScientistGear
   icon: "JobIconScientist"
   supervisors: job-supervisors-rd

--- a/Resources/Prototypes/Roles/Jobs/Security/detective.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/detective.yml
@@ -4,9 +4,9 @@
   description: job-description-detective
   playTimeTracker: JobDetective
   requirements:
-    - !type:DepartmentTimeRequirement
-      department: Security
-      time: 18000 #5 hrs
+  - !type:RoleTimeRequirement
+    role: JobSecurityOfficer
+    time: 18000 #5 hrs
   startingGear: DetectiveGear
   icon: "JobIconDetective"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/head_of_security.yml
@@ -6,15 +6,15 @@
   requirements:
     - !type:RoleTimeRequirement
       role: JobWarden
-      time: 18000 #5 hrs
+      time: 36000 #10 hrs
     - !type:RoleTimeRequirement
       role: JobSecurityOfficer
-      time: 36000 #10 hrs
+      time: 72000 #20 hrs
     - !type:DepartmentTimeRequirement
       department: Security
-      time: 54000 # 15 hrs
+      time: 108000 #30 hrs
     - !type:OverallPlaytimeRequirement
-      time: 90000 #25 hrs
+      time: 144000 #40 hrs
   weight: 10
   startingGear: HoSGear
   icon: "JobIconHeadOfSecurity"

--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -8,7 +8,7 @@
       time: 36000 #10 hrs
     - !type:DepartmentTimeRequirement
       department: Security
-      time: 54000 #15 hrs
+      time: 72000 #20 hrs
       inverted: true # stop playing intern if you're good at security!
   startingGear: SecurityCadetGear
   icon: "JobIconSecurityCadet"

--- a/Resources/Prototypes/Roles/Jobs/Security/warden.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/warden.yml
@@ -6,7 +6,7 @@
   requirements:
     - !type:RoleTimeRequirement
       role: JobSecurityOfficer
-      time: 18000 #5 hrs
+      time: 36000 #10 hrs
   startingGear: WardenGear
   icon: "JobIconWarden"
   supervisors: job-supervisors-hos

--- a/Resources/Prototypes/_Funkystation/Roles/Jobs/Command/internal_affairs_agent.yml
+++ b/Resources/Prototypes/_Funkystation/Roles/Jobs/Command/internal_affairs_agent.yml
@@ -5,7 +5,10 @@
   playTimeTracker: JobInternalAffairsAgent
   requirements:
     - !type:OverallPlaytimeRequirement
-      time: 36000  #10 hrs
+      time: 72000 #20 hrs
+    - !type:RoleTimeRequirement
+      role: JobLawyer
+      time: 18000 #5 hrs
   weight: 20
   startingGear: InternalAffairsAgentGear
   icon: "JobIconInternalAffairsAgent"
@@ -22,6 +25,7 @@
   - Engineering
   - Medical
   - Research
+  - Lawyer
   special:
   - !type:AddImplantSpecial
     implants: [ MindShieldImplant ]

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
@@ -5,7 +5,7 @@
   playTimeTracker: JobBlueshieldOfficer
   requirements:
     - !type:OverallPlaytimeRequirement
-      time: 54000 #15 hrs
+      time: 72000 #20 hrs
     - !type:DepartmentTimeRequirement
       department: Medical
       time: 18000 # 5 hours

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/nanotrasen_representative.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/nanotrasen_representative.yml
@@ -6,7 +6,10 @@
   requirements:
     - !type:DepartmentTimeRequirement
       department: Command
-      time: 36000  #10 hrs
+      time: 144000 #40 hrs
+    - !type:RoleTimeRequirement
+      role: JobInternalAffairsAgent
+      time: 36000 #10 hrs
   weight: 20
   startingGear: NanotrasenRepresentativeGear
   icon: "JobIconNanotrasenRepresentative"


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Biggest changes:
NTR now requires 10 hours IAA and 40 hours Command playtime
Across the board, all Command (besides BSO and QM, both of which require 20 overall and 20 departmental respectively) now require 25 hours overall time and 20 hours in their department. Captain and HoS both require 40 hours overall playtime.
Interns now need 4 hours (or a playtime transfer) to graduate instead of 2, and can continue to play until 20 hours playtime as that intern role (previously 15)

Also added Law access to IAA (I double dipped sorry)

## Why / Balance
Overall discussion about roletime changes in the Discord
Particularly for Command and Sec.
This was beyond due as our playerbase now collectively has a lotta hours to justify increasing from our previously low time requirements (which was necessary at the time because we were new)

## Changelog

:cl: Miiish
- tweak: Role timers increased across the board