### PR TITLE
Operating Table is no longer useless

### DIFF
--- a/Resources/Prototypes/_Shitmed/Entities/Surgery/surgeries.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Surgery/surgeries.yml
@@ -371,7 +371,7 @@
     steps:
     - SurgeryStepSawBones
     - SurgeryStepClampInternalBleeders
-    - SurgeryStepRemoveOrgan
+    - SurgeryStepRemoveVitalOrgan
   - type: SurgeryPartCondition
     part: Head
   - type: SurgeryOrganCondition
@@ -409,7 +409,7 @@
     steps:
     - SurgeryStepSawBones
     - SurgeryStepClampInternalBleeders
-    - SurgeryStepRemoveOrgan
+    - SurgeryStepRemoveVitalOrgan
   - type: SurgeryPartCondition
     part: Torso
   - type: SurgeryOrganCondition

--- a/Resources/Prototypes/_Shitmed/Entities/Surgery/surgery_steps.yml
+++ b/Resources/Prototypes/_Shitmed/Entities/Surgery/surgery_steps.yml
@@ -207,6 +207,7 @@
     sprite: _Shitmed/Objects/Specific/Medical/Surgery/manipulation.rsi
     state: insertion
   - type: SurgeryAddPartStep
+  - type: SurgeryOperatingTableCondition # funkystation - fuck you
 
 - type: entity
   parent: SurgeryStepBase
@@ -333,6 +334,7 @@
       groups:
         Brute: -5
   - type: SurgeryRepeatableStep
+  - type: SurgeryOperatingTableCondition # funkystation - fuck you
 
 - type: entity
   parent: SurgeryStepBase
@@ -353,6 +355,7 @@
       groups:
         Burn: -5
   - type: SurgeryRepeatableStep
+  - type: SurgeryOperatingTableCondition # funkystation - fuck you
 
 - type: entity
   parent: SurgeryStepBase
@@ -427,6 +430,14 @@
   - type: SurgeryStepEmoteEffect
 
 - type: entity
+  parent: SurgeryStepRemoveOrgan
+  id: SurgeryStepRemoveVitalOrgan
+  name: Remove vital organ
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: SurgeryOperatingTableCondition # funkystation - fuck you
+
+- type: entity
   parent: SurgeryStepBase
   id: SurgeryStepInsertOrgan
   name: Add organ
@@ -441,6 +452,7 @@
     state: insertion
   - type: SurgeryAddOrganStep
   - type: SurgeryStepEmoteEffect
+  - type: SurgeryOperatingTableCondition # funkystation - fuck you
 
 - type: entity
   parent: SurgeryStepInsertOrgan
@@ -454,12 +466,15 @@
         Asphyxiation: -2147483648 # Literally the max 32 bit value, if your patient has gone higher than this, maybe it's time to restart the round.
     sleepModifier: 1
     isConsumable: true
+  - type: SurgeryOperatingTableCondition # funkystation - fuck you
 
 - type: entity
   parent: SurgeryStepInsertOrgan
   id: SurgeryStepInsertStomach
   name: Add stomach
   categories: [ HideSpawnMenu ]
+  components:
+  - type: SurgeryOperatingTableCondition # funkystation - fuck you
   # no effect its just for minmaxing metabolism
 
 - type: entity
@@ -474,12 +489,15 @@
         Poison: -2147483648 # Literally the max 32 bit value, if your patient has gone higher than this, maybe it's time to restart the round.
     sleepModifier: 1
     isConsumable: true
+  - type: SurgeryOperatingTableCondition # funkystation - fuck you
 
 - type: entity
   parent: SurgeryStepInsertOrgan
   id: SurgeryStepInsertEyes
   name: Add eyes
   categories: [ HideSpawnMenu ]
+  components:
+  - type: SurgeryOperatingTableCondition # funkystation - fuck you
 
 - type: entity
   parent: SurgeryStepInsertOrgan
@@ -490,6 +508,7 @@
   - type: SurgerySpecialDamageChangeEffect
     damageType: Rot
     isConsumable: true
+  - type: SurgeryOperatingTableCondition # funkystation - fuck you
 
 - type: entity
   parent: SurgeryStepBase
@@ -511,6 +530,7 @@
       types:
         Heat: -5
     sleepModifier: 2
+  - type: SurgeryOperatingTableCondition # funkystation - fuck you
 
 - type: entity
   parent: SurgeryStepBase
@@ -523,7 +543,7 @@
     - type: Drill
     addOrganOnAdd:
       brain:
-        - type: OhioAccent
+        # - type: OhioAccent funkystation 1984
         - type: RatvarianLanguage
         - type: Clumsy
     duration: 5
@@ -548,13 +568,14 @@
     duration: 4
     removeOrganOnAdd:
       brain:
-        - type: OhioAccent
+        # - type: OhioAccent funkystation 1984
         - type: RatvarianLanguage
         - type: Clumsy
   - type: Sprite
     sprite: _Shitmed/Objects/Specific/Medical/Surgery/hemostat.rsi
     state: hemostat
   - type: SurgeryStepEmoteEffect
+  - type: SurgeryOperatingTableCondition # funkystation - fuck you
 
 # The lengths I go to just for a joke... I HATE HARDCODING AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
 # Maybe I should modify species prototypes to include tails and ears properly...


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Removing the heart, tending to brute and burn wounds, and other important surgeries now require the use of an operating table.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Surgery was too inconsequential and allowed doctors to roam the halls fixing stuff wherever. It makes certain aspects of medical, like chemistry, useless, as most damage types can be repaired by a tider with a glass shard. No more.

Don't worry Tidermains, you can still put C4 into someones chest.

## Technical details
<!-- Summary of code changes for easier review. -->
SurgeryStepRemoveVitalOrgan now exists, which can be used to block certain surgeries on things. 
SurgeryStepRepairBruteTissue & SurgeryStepRepairBurnTissue now have the SurgeryOperatingTableCondition component.
Insert steps also have the SurgeryOperatingTableCondition.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
none lol

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Rainbeon, taydeo
- :tweak: An Operating Table is now required for tending wounds, inserting Organs, adding Limbs, removing the Heart/Brain, and mending brain tissue.