### PR TITLE
Singing Speed Snails

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
@@ -545,6 +545,27 @@
     baseSprintSpeed : 7
 #  - type: ActiveJetpack # I think this will need a custom component to not make tests angry.
   - type: MovementAlwaysTouching
+  - type: HarpySinger #start of singing snails change
+  - type: Instrument
+    allowPercussion: false
+    program: 52
+  - type: SwappableInstrument
+    instrumentList:
+      "Voice": {52: 0}
+      "Trumpet": {56: 0}
+      "Electric": {27: 0}
+      "Bass": {33: 0}
+      "Rock": {29: 0}
+      "Acoustic": {24: 0}
+      "Flute": {73: 0}
+      "Sax": {66: 0}
+      "Piano": {1: 0}
+      "Church Organ": {19: 0}
+      "Violin": {41: 0}
+  - type: UserInterface
+    interfaces:
+      enum.InstrumentUiKey.Key:
+        type: InstrumentBoundUserInterface #end of singing snails change
 
 - type: entity
   parent: MobSnail


### PR DESCRIPTION
why are snails stored in the salvage creatures dataset

## About the PR
Speed snails now have the same singing capabilities as a harpy (for better or worse. Could just restrict it to one type if needed)
## Why / Balance
Another quest PR from the maintainer QnA
## Technical details
singular yml change

## Media

https://github.com/user-attachments/assets/789af528-40bb-4ac5-b534-a1b0986c5873

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**

:cl: Middleson
- tweak: Speed Snails can now sing!

