### PR TITLE
Added a minimum of 2 Head Revs

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -213,8 +213,9 @@
     selectionTime: BeforeJobs # Goobstation
     definitions:
     - prefRoles: [ HeadRev ]
+      min: 2
       max: 3
-      playerRatio: 30
+      playerRatio: 25
       briefing:
         text: head-rev-role-greeting
         color: CornflowerBlue


### PR DESCRIPTION
Fixes the issue where the Revolutionaries gamemode will start with no headrevs. Also drops ratio to 25, so there can be 3 if there are 75 pop readied up (so, never)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Also makes Revolutionaries as a gamemode viable with 2 headrevs, so if one goes down the shift doesn't immediately end.