### PR TITLE
MAKE RODENTIA GREAT AGAIN

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/rodentia.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/rodentia.yml
@@ -34,7 +34,7 @@
         layer:
         - MobLayer
   - type: Sprite
-    scale: 0.8, 0.8
+    #scale: 0.8, 0.8 - Funkystation hehehell naw
     layers:
       - map: [ "enum.HumanoidVisualLayers.Chest" ]
       - map: [ "enum.HumanoidVisualLayers.Head" ]
@@ -100,17 +100,12 @@
       Unsexed: MaleRodentia
   - type: Rummager
   - type: AlwaysTriggerMousetrap
-  - type: PseudoItem
-    storedOffset: -10,0
-    shape:
-      - 0, 0, 3, 2
-      - 0, 2, 5, 4
   - type: MouthStorage
     mouthProto: CheekStorage
     openStorageAction: ActionOpenMouthStorage
     spitDamageThreshold: 3
-  - type: CrawlUnderObjects
-    actionProto: ActionToggleSneakMode
+#  - type: CrawlUnderObjects
+#    actionProto: ActionToggleSneakMode - funkystation no sneak
 
 - type: entity
   save: false

--- a/Resources/Prototypes/_DV/Species/rodentia.yml
+++ b/Resources/Prototypes/_DV/Species/rodentia.yml
@@ -1,7 +1,7 @@
 - type: species
   id: Rodentia
   name: species-name-rodentia
-  roundStart: false
+  roundStart: true
   prototype: MobRodentia
   sprites: MobRodentiaSprites
   defaultSkinTone: "#747474"


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Re-enables rodentia.

## Why / Balance
I've had a change of heart on the Rats. Rodentia are no longer scaled to be smaller, which allows their features to be more known and present (makes them less ugly). Oh yeah, their crawl is also gone.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
- add: Rodentia have been re-enabled.