### PR TITLE
Minor shuttle tweaks and spawnweight changes

### DIFF
--- a/Resources/Maps/_Funkystation/Shuttles/ShuttleEvent/clownpatrol.yml
+++ b/Resources/Maps/_Funkystation/Shuttles/ShuttleEvent/clownpatrol.yml
@@ -1,6 +1,17 @@
 meta:
-  format: 6
-  postmapinit: false
+  format: 7
+  category: Grid
+  engineVersion: 247.2.0
+  forkId: ""
+  forkVersion: ""
+  time: 03/20/2025 22:23:22
+  entityCount: 833
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
 tilemap:
   0: Space
   4: FloorArcadeBlue
@@ -279,7 +290,7 @@ entities:
       pos: -3.5,-16.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -537.29846
+      secondsUntilStateChange: -634.15625
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -292,7 +303,7 @@ entities:
       pos: 5.5,-9.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -4914.97
+      secondsUntilStateChange: -5011.828
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -307,48 +318,36 @@ entities:
     - type: Transform
       pos: -0.5,-3.5
       parent: 1
-  - uid: 47
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 9.5,-9.5
-      parent: 1
-  - uid: 50
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,-9.5
-      parent: 1
 - proto: AirlockSecurityGlass
   entities:
-  - uid: 10
+  - uid: 11
     components:
     - type: Transform
       pos: -10.5,-8.5
       parent: 1
     - type: DeviceLinkSink
       invokeCounter: 2
-  - uid: 11
+  - uid: 12
     components:
     - type: Transform
       pos: -10.5,-10.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -422.28815
+      secondsUntilStateChange: -519.14594
       state: Opening
     - type: DeviceLinkSink
       invokeCounter: 2
     - type: DeviceLinkSource
       lastSignals:
         DoorStatus: True
-  - uid: 12
+  - uid: 13
     components:
     - type: Transform
       pos: 9.5,-10.5
       parent: 1
     - type: DeviceLinkSink
       invokeCounter: 1
-  - uid: 13
+  - uid: 14
     components:
     - type: Transform
       pos: 9.5,-8.5
@@ -357,73 +356,73 @@ entities:
       invokeCounter: 1
 - proto: AirlockShuttle
   entities:
-  - uid: 14
+  - uid: 15
     components:
     - type: Transform
       pos: -12.5,-8.5
       parent: 1
-  - uid: 15
+  - uid: 16
     components:
     - type: Transform
       pos: -12.5,-10.5
       parent: 1
-  - uid: 16
+  - uid: 17
     components:
     - type: Transform
       pos: 11.5,-8.5
       parent: 1
-  - uid: 17
+  - uid: 18
     components:
     - type: Transform
       pos: 11.5,-10.5
       parent: 1
 - proto: AltarBananium
   entities:
-  - uid: 18
+  - uid: 19
     components:
     - type: Transform
       pos: -0.5,-10.5
       parent: 1
 - proto: APCBasic
   entities:
-  - uid: 19
+  - uid: 20
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-15.5
       parent: 1
-  - uid: 20
+  - uid: 21
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-11.5
       parent: 1
-  - uid: 21
+  - uid: 22
     components:
     - type: Transform
       pos: -2.5,0.5
       parent: 1
 - proto: AtmosDeviceFanDirectional
   entities:
-  - uid: 22
+  - uid: 23
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,-10.5
       parent: 1
-  - uid: 23
+  - uid: 24
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -12.5,-8.5
       parent: 1
-  - uid: 24
+  - uid: 25
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 11.5,-8.5
       parent: 1
-  - uid: 25
+  - uid: 26
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -431,7 +430,7 @@ entities:
       parent: 1
 - proto: BananiumHorn
   entities:
-  - uid: 26
+  - uid: 27
     components:
     - type: Transform
       pos: 8.572436,-4.381456
@@ -439,7 +438,7 @@ entities:
     - type: Physics
       angularDamping: 0
       linearDamping: 0
-  - uid: 27
+  - uid: 28
     components:
     - type: Transform
       pos: 8.396655,-4.803331
@@ -447,28 +446,28 @@ entities:
     - type: Physics
       angularDamping: 0
       linearDamping: 0
-  - uid: 29
+  - uid: 30
     components:
     - type: Transform
-      parent: 28
+      parent: 29
     - type: Physics
       angularDamping: 0
       linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 32
+  - uid: 33
     components:
     - type: Transform
-      parent: 31
+      parent: 32
     - type: Physics
       angularDamping: 0
       linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 35
+  - uid: 36
     components:
     - type: Transform
-      parent: 34
+      parent: 35
     - type: Physics
       angularDamping: 0
       linearDamping: 0
@@ -476,61 +475,61 @@ entities:
     - type: InsideEntityStorage
 - proto: BannerSecurity
   entities:
-  - uid: 37
+  - uid: 38
     components:
     - type: Transform
       pos: 8.5,-7.5
       parent: 1
-  - uid: 38
+  - uid: 39
     components:
     - type: Transform
       pos: 8.5,-11.5
       parent: 1
-  - uid: 39
+  - uid: 40
     components:
     - type: Transform
       pos: -9.5,-7.5
       parent: 1
-  - uid: 40
+  - uid: 41
     components:
     - type: Transform
       pos: -9.5,-11.5
       parent: 1
 - proto: Bed
   entities:
-  - uid: 41
+  - uid: 42
     components:
     - type: Transform
       pos: 0.5,-19.5
       parent: 1
 - proto: BedsheetOrange
   entities:
-  - uid: 42
+  - uid: 43
     components:
     - type: Transform
       pos: 0.5,-19.5
       parent: 1
 - proto: BlastDoor
   entities:
-  - uid: 43
+  - uid: 44
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-9.5
       parent: 1
-  - uid: 44
+  - uid: 45
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-6.5
       parent: 1
-  - uid: 45
+  - uid: 46
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-9.5
       parent: 1
-  - uid: 46
+  - uid: 47
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -548,23 +547,11 @@ entities:
       rot: 3.141592653589793 rad
       pos: 9.5,-10.5
       parent: 1
-  - uid: 51
+  - uid: 50
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 9.5,-8.5
-      parent: 1
-  - uid: 806
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,-9.5
-      parent: 1
-  - uid: 833
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 9.5,-9.5
       parent: 1
 - proto: BookSecurity
   entities:
@@ -2095,28 +2082,28 @@ entities:
       parent: 1
 - proto: ClothingBeltSecurityFilled
   entities:
-  - uid: 30
+  - uid: 31
     components:
     - type: Transform
-      parent: 28
+      parent: 29
     - type: Physics
       angularDamping: 0
       linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 33
+  - uid: 34
     components:
     - type: Transform
-      parent: 31
+      parent: 32
     - type: Physics
       angularDamping: 0
       linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 36
+  - uid: 37
     components:
     - type: Transform
-      parent: 34
+      parent: 35
     - type: Physics
       angularDamping: 0
       linearDamping: 0
@@ -2140,16 +2127,6 @@ entities:
     - type: InsideEntityStorage
 - proto: ClothingMaskMime
   entities:
-  - uid: 835
-    components:
-    - type: Transform
-      parent: 834
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-- proto: ClothingOuterHardsuitClown
-  entities:
   - uid: 353
     components:
     - type: Transform
@@ -2158,20 +2135,30 @@ entities:
       angularDamping: 0
       linearDamping: 0
       canCollide: False
-    - type: InsideEntityStorage
-  - uid: 358
+- proto: ClothingOuterHardsuitClown
+  entities:
+  - uid: 355
     components:
     - type: Transform
-      parent: 357
+      parent: 354
     - type: Physics
       angularDamping: 0
       linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 363
+  - uid: 360
     components:
     - type: Transform
-      parent: 362
+      parent: 359
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+      canCollide: False
+    - type: InsideEntityStorage
+  - uid: 365
+    components:
+    - type: Transform
+      parent: 364
     - type: Physics
       angularDamping: 0
       linearDamping: 0
@@ -2179,7 +2166,7 @@ entities:
     - type: InsideEntityStorage
 - proto: CluwneHorn
   entities:
-  - uid: 367
+  - uid: 369
     components:
     - type: Transform
       pos: -1.2660286,-20.187843
@@ -2189,20 +2176,20 @@ entities:
       linearDamping: 0
 - proto: ComputerShuttle
   entities:
-  - uid: 368
+  - uid: 370
     components:
     - type: Transform
       pos: -0.5,2.5
       parent: 1
 - proto: ComputerSurveillanceCameraMonitor
   entities:
-  - uid: 369
+  - uid: 371
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,1.5
       parent: 1
-  - uid: 370
+  - uid: 372
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2210,35 +2197,35 @@ entities:
       parent: 1
 - proto: CrateFunToyBox
   entities:
-  - uid: 371
+  - uid: 373
     components:
     - type: Transform
       pos: -5.5,-16.5
       parent: 1
 - proto: EmergencyFunnyOxygenTankFilled
   entities:
-  - uid: 354
+  - uid: 356
     components:
     - type: Transform
-      parent: 352
+      parent: 354
     - type: Physics
       angularDamping: 0
       linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 359
+  - uid: 361
     components:
     - type: Transform
-      parent: 357
+      parent: 359
     - type: Physics
       angularDamping: 0
       linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 364
+  - uid: 366
     components:
     - type: Transform
-      parent: 362
+      parent: 364
     - type: Physics
       angularDamping: 0
       linearDamping: 0
@@ -2246,29 +2233,29 @@ entities:
     - type: InsideEntityStorage
 - proto: FaxMachineBase
   entities:
-  - uid: 372
+  - uid: 374
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
 - proto: FloorBananiumEntity
   entities:
-  - uid: 373
+  - uid: 375
     components:
     - type: Transform
       pos: -0.5,-7.5
       parent: 1
-  - uid: 374
+  - uid: 376
     components:
     - type: Transform
       pos: 1.5,-9.5
       parent: 1
-  - uid: 375
+  - uid: 377
     components:
     - type: Transform
       pos: -2.5,-9.5
       parent: 1
-  - uid: 376
+  - uid: 378
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2276,12 +2263,12 @@ entities:
       parent: 1
 - proto: FoodPieBananaCream
   entities:
-  - uid: 377
+  - uid: 379
     components:
     - type: Transform
       pos: 0.20663476,-10.109755
       parent: 1
-  - uid: 378
+  - uid: 380
     components:
     - type: Transform
       pos: 0.2229104,-10.513397
@@ -2289,7 +2276,7 @@ entities:
     - type: Physics
       angularDamping: 0
       linearDamping: 0
-  - uid: 379
+  - uid: 381
     components:
     - type: Transform
       pos: 0.5354104,-10.357147
@@ -2297,7 +2284,7 @@ entities:
     - type: Physics
       angularDamping: 0
       linearDamping: 0
-  - uid: 380
+  - uid: 382
     components:
     - type: Transform
       pos: 0.8791604,-10.638397
@@ -2305,7 +2292,7 @@ entities:
     - type: Physics
       angularDamping: 0
       linearDamping: 0
-  - uid: 381
+  - uid: 383
     components:
     - type: Transform
       pos: 0.5041604,-10.669647
@@ -2313,7 +2300,7 @@ entities:
     - type: Physics
       angularDamping: 0
       linearDamping: 0
-  - uid: 382
+  - uid: 384
     components:
     - type: Transform
       pos: 0.2229104,-10.294647
@@ -2321,12 +2308,12 @@ entities:
     - type: Physics
       angularDamping: 0
       linearDamping: 0
-  - uid: 383
+  - uid: 385
     components:
     - type: Transform
       pos: 0.53475976,-10.12538
       parent: 1
-  - uid: 384
+  - uid: 386
     components:
     - type: Transform
       pos: 0.1604104,-10.685272
@@ -2334,12 +2321,12 @@ entities:
     - type: Physics
       angularDamping: 0
       linearDamping: 0
-  - uid: 385
+  - uid: 387
     components:
     - type: Transform
       pos: 0.81600976,-10.06288
       parent: 1
-  - uid: 386
+  - uid: 388
     components:
     - type: Transform
       pos: 0.8322854,-10.216522
@@ -2347,7 +2334,7 @@ entities:
     - type: Physics
       angularDamping: 0
       linearDamping: 0
-  - uid: 387
+  - uid: 389
     components:
     - type: Transform
       pos: 0.9416604,-10.419647
@@ -2355,7 +2342,7 @@ entities:
     - type: Physics
       angularDamping: 0
       linearDamping: 0
-  - uid: 388
+  - uid: 390
     components:
     - type: Transform
       pos: 0.4729104,-10.279022
@@ -2365,7 +2352,7 @@ entities:
       linearDamping: 0
 - proto: FoodSoupClown
   entities:
-  - uid: 389
+  - uid: 391
     components:
     - type: Transform
       pos: -1.5993617,-20.396175
@@ -2375,76 +2362,76 @@ entities:
       linearDamping: 0
 - proto: GasPipeBend
   entities:
-  - uid: 390
+  - uid: 392
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-16.5
       parent: 1
-  - uid: 391
+  - uid: 393
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-12.5
       parent: 1
-  - uid: 392
+  - uid: 394
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-4.5
       parent: 1
-  - uid: 393
+  - uid: 395
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -6.5,-4.5
       parent: 1
-  - uid: 394
+  - uid: 396
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -6.5,-3.5
       parent: 1
-  - uid: 395
+  - uid: 397
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -5.5,-3.5
       parent: 1
-  - uid: 396
+  - uid: 398
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-2.5
       parent: 1
-  - uid: 397
-    components:
-    - type: Transform
-      pos: 6.5,-4.5
-      parent: 1
-  - uid: 398
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 5.5,-4.5
-      parent: 1
   - uid: 399
     components:
     - type: Transform
-      pos: 5.5,-3.5
+      pos: 6.5,-4.5
       parent: 1
   - uid: 400
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 4.5,-3.5
+      pos: 5.5,-4.5
       parent: 1
   - uid: 401
     components:
     - type: Transform
-      pos: 4.5,-2.5
+      pos: 5.5,-3.5
       parent: 1
   - uid: 402
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-3.5
+      parent: 1
+  - uid: 403
+    components:
+    - type: Transform
+      pos: 4.5,-2.5
+      parent: 1
+  - uid: 404
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2452,252 +2439,252 @@ entities:
       parent: 1
 - proto: GasPipeStraight
   entities:
-  - uid: 403
+  - uid: 405
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-6.5
       parent: 1
-  - uid: 404
+  - uid: 406
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-16.5
       parent: 1
-  - uid: 405
+  - uid: 407
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-16.5
       parent: 1
-  - uid: 406
+  - uid: 408
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-16.5
       parent: 1
-  - uid: 407
+  - uid: 409
     components:
     - type: Transform
       pos: -0.5,-15.5
       parent: 1
-  - uid: 408
+  - uid: 410
     components:
     - type: Transform
       pos: -0.5,-14.5
       parent: 1
-  - uid: 409
+  - uid: 411
     components:
     - type: Transform
       pos: -0.5,-13.5
       parent: 1
-  - uid: 410
+  - uid: 412
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-11.5
       parent: 1
-  - uid: 411
+  - uid: 413
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-10.5
       parent: 1
-  - uid: 412
+  - uid: 414
     components:
     - type: Transform
       pos: -0.5,-17.5
       parent: 1
-  - uid: 413
-    components:
-    - type: Transform
-      pos: -0.5,-18.5
-      parent: 1
-  - uid: 414
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,-12.5
-      parent: 1
   - uid: 415
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,-12.5
+      pos: -0.5,-18.5
       parent: 1
   - uid: 416
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -5.5,-12.5
+      pos: -2.5,-12.5
       parent: 1
   - uid: 417
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -4.5,-12.5
+      pos: -3.5,-12.5
       parent: 1
   - uid: 418
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -6.5,-12.5
+      pos: -5.5,-12.5
       parent: 1
   - uid: 419
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -7.5,-11.5
+      rot: -1.5707963267948966 rad
+      pos: -4.5,-12.5
       parent: 1
   - uid: 420
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -7.5,-10.5
+      rot: -1.5707963267948966 rad
+      pos: -6.5,-12.5
       parent: 1
   - uid: 421
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -7.5,-8.5
+      pos: -7.5,-11.5
       parent: 1
   - uid: 422
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -7.5,-7.5
+      pos: -7.5,-10.5
       parent: 1
   - uid: 423
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -7.5,-5.5
+      pos: -7.5,-8.5
       parent: 1
   - uid: 424
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,-12.5
+      rot: 3.141592653589793 rad
+      pos: -7.5,-7.5
       parent: 1
   - uid: 425
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 3.5,-12.5
+      rot: 3.141592653589793 rad
+      pos: -7.5,-5.5
       parent: 1
   - uid: 426
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 2.5,-12.5
+      pos: 0.5,-12.5
       parent: 1
   - uid: 427
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 1.5,-12.5
+      pos: 3.5,-12.5
       parent: 1
   - uid: 428
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 4.5,-12.5
+      pos: 2.5,-12.5
       parent: 1
   - uid: 429
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 5.5,-12.5
+      pos: 1.5,-12.5
       parent: 1
   - uid: 430
     components:
     - type: Transform
-      pos: 6.5,-11.5
+      rot: 1.5707963267948966 rad
+      pos: 4.5,-12.5
       parent: 1
   - uid: 431
     components:
     - type: Transform
-      pos: 6.5,-10.5
+      rot: 1.5707963267948966 rad
+      pos: 5.5,-12.5
       parent: 1
   - uid: 432
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,-7.5
+      pos: 6.5,-11.5
       parent: 1
   - uid: 433
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 6.5,-8.5
+      pos: 6.5,-10.5
       parent: 1
   - uid: 434
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 6.5,-6.5
+      pos: 6.5,-7.5
       parent: 1
   - uid: 435
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 6.5,-5.5
+      pos: 6.5,-8.5
       parent: 1
   - uid: 436
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -4.5,-2.5
+      rot: 3.141592653589793 rad
+      pos: 6.5,-6.5
       parent: 1
   - uid: 437
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,-2.5
+      rot: 3.141592653589793 rad
+      pos: 6.5,-5.5
       parent: 1
   - uid: 438
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -2.5,-2.5
+      pos: -4.5,-2.5
       parent: 1
   - uid: 439
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -1.5,-2.5
+      pos: -3.5,-2.5
       parent: 1
   - uid: 440
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 3.5,-2.5
+      pos: -2.5,-2.5
       parent: 1
   - uid: 441
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 2.5,-2.5
+      pos: -1.5,-2.5
       parent: 1
   - uid: 442
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 1.5,-2.5
+      pos: 3.5,-2.5
       parent: 1
   - uid: 443
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 0.5,-2.5
+      pos: 2.5,-2.5
       parent: 1
   - uid: 444
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-2.5
+      parent: 1
+  - uid: 445
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 0.5,-2.5
+      parent: 1
+  - uid: 446
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-1.5
       parent: 1
-  - uid: 445
+  - uid: 447
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2705,42 +2692,42 @@ entities:
       parent: 1
 - proto: GasPipeTJunction
   entities:
-  - uid: 446
+  - uid: 448
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-16.5
       parent: 1
-  - uid: 447
+  - uid: 449
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-16.5
       parent: 1
-  - uid: 448
+  - uid: 450
     components:
     - type: Transform
       pos: -0.5,-12.5
       parent: 1
-  - uid: 449
+  - uid: 451
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-12.5
       parent: 1
-  - uid: 450
+  - uid: 452
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,-9.5
       parent: 1
-  - uid: 451
+  - uid: 453
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-9.5
       parent: 1
-  - uid: 452
+  - uid: 454
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2748,406 +2735,406 @@ entities:
       parent: 1
 - proto: GasPort
   entities:
-  - uid: 453
+  - uid: 455
     components:
     - type: Transform
       pos: 3.5,-15.5
       parent: 1
-  - uid: 454
+  - uid: 456
     components:
     - type: Transform
       pos: 4.5,-15.5
       parent: 1
 - proto: GasVentPump
   entities:
-  - uid: 455
+  - uid: 457
     components:
     - type: Transform
       pos: -0.5,-15.5
       parent: 1
-  - uid: 456
+  - uid: 458
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-19.5
       parent: 1
-  - uid: 457
+  - uid: 459
     components:
     - type: Transform
       pos: -1.5,-9.5
       parent: 1
-  - uid: 458
+  - uid: 460
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-9.5
       parent: 1
-  - uid: 459
+  - uid: 461
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,-9.5
       parent: 1
-  - uid: 460
+  - uid: 462
     components:
     - type: Transform
       pos: -0.5,-0.5
       parent: 1
-  - uid: 461
+  - uid: 463
     components:
     - type: Transform
       pos: -0.5,0.5
       parent: 1
 - proto: GeneratorBasic15kW
   entities:
-  - uid: 462
+  - uid: 464
     components:
     - type: Transform
       pos: -5.5,-15.5
       parent: 1
-  - uid: 463
+  - uid: 465
     components:
     - type: Transform
       pos: -4.5,-15.5
       parent: 1
 - proto: GravityGeneratorMini
   entities:
-  - uid: 464
+  - uid: 466
     components:
     - type: Transform
       pos: -4.5,-17.5
       parent: 1
 - proto: Grille
   entities:
-  - uid: 465
+  - uid: 467
     components:
     - type: Transform
       pos: 0.5,-3.5
       parent: 1
-  - uid: 466
+  - uid: 468
     components:
     - type: Transform
       pos: -2.5,1.5
       parent: 1
-  - uid: 467
+  - uid: 469
     components:
     - type: Transform
       pos: -2.5,2.5
       parent: 1
-  - uid: 468
+  - uid: 470
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 1
-  - uid: 469
+  - uid: 471
     components:
     - type: Transform
       pos: -1.5,3.5
       parent: 1
-  - uid: 470
+  - uid: 472
     components:
     - type: Transform
       pos: -0.5,3.5
       parent: 1
-  - uid: 471
+  - uid: 473
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
-  - uid: 472
+  - uid: 474
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 1
-  - uid: 473
+  - uid: 475
     components:
     - type: Transform
       pos: 1.5,2.5
       parent: 1
-  - uid: 474
+  - uid: 476
     components:
     - type: Transform
       pos: 1.5,1.5
       parent: 1
-  - uid: 475
+  - uid: 477
     components:
     - type: Transform
       pos: -1.5,-3.5
       parent: 1
-  - uid: 476
+  - uid: 478
     components:
     - type: Transform
       pos: -2.5,-3.5
       parent: 1
-  - uid: 477
+  - uid: 479
     components:
     - type: Transform
       pos: -3.5,-3.5
       parent: 1
-  - uid: 478
+  - uid: 480
     components:
     - type: Transform
       pos: -4.5,-3.5
       parent: 1
-  - uid: 479
+  - uid: 481
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 1
-  - uid: 480
+  - uid: 482
     components:
     - type: Transform
       pos: 2.5,-3.5
       parent: 1
-  - uid: 481
+  - uid: 483
     components:
     - type: Transform
       pos: 3.5,-3.5
       parent: 1
-  - uid: 482
+  - uid: 484
     components:
     - type: Transform
       pos: 3.5,-4.5
       parent: 1
-  - uid: 483
+  - uid: 485
     components:
     - type: Transform
       pos: 4.5,-4.5
       parent: 1
-  - uid: 484
+  - uid: 486
     components:
     - type: Transform
       pos: 4.5,-5.5
       parent: 1
-  - uid: 485
+  - uid: 487
     components:
     - type: Transform
       pos: 5.5,-5.5
       parent: 1
-  - uid: 486
+  - uid: 488
     components:
     - type: Transform
       pos: 5.5,-6.5
       parent: 1
-  - uid: 487
+  - uid: 489
     components:
     - type: Transform
       pos: 5.5,-7.5
       parent: 1
-  - uid: 488
+  - uid: 490
     components:
     - type: Transform
       pos: 0.5,-5.5
       parent: 1
-  - uid: 489
+  - uid: 491
     components:
     - type: Transform
       pos: -1.5,-5.5
       parent: 1
-  - uid: 490
+  - uid: 492
     components:
     - type: Transform
       pos: -4.5,-4.5
       parent: 1
-  - uid: 491
+  - uid: 493
     components:
     - type: Transform
       pos: -5.5,-4.5
       parent: 1
-  - uid: 492
+  - uid: 494
     components:
     - type: Transform
       pos: -5.5,-5.5
       parent: 1
-  - uid: 493
+  - uid: 495
     components:
     - type: Transform
       pos: -6.5,-5.5
       parent: 1
-  - uid: 494
+  - uid: 496
     components:
     - type: Transform
       pos: -6.5,-6.5
       parent: 1
-  - uid: 495
+  - uid: 497
     components:
     - type: Transform
       pos: -6.5,-7.5
       parent: 1
-  - uid: 496
+  - uid: 498
     components:
     - type: Transform
       pos: -6.5,-8.5
       parent: 1
-  - uid: 497
+  - uid: 499
     components:
     - type: Transform
       pos: -6.5,-10.5
       parent: 1
-  - uid: 498
+  - uid: 500
     components:
     - type: Transform
       pos: -4.5,-10.5
       parent: 1
-  - uid: 499
+  - uid: 501
     components:
     - type: Transform
       pos: -4.5,-8.5
       parent: 1
-  - uid: 500
+  - uid: 502
     components:
     - type: Transform
       pos: 3.5,-10.5
       parent: 1
-  - uid: 501
+  - uid: 503
     components:
     - type: Transform
       pos: 3.5,-8.5
       parent: 1
-  - uid: 502
+  - uid: 504
     components:
     - type: Transform
       pos: 5.5,-8.5
       parent: 1
-  - uid: 503
-    components:
-    - type: Transform
-      pos: 5.5,-10.5
-      parent: 1
-  - uid: 504
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 9.5,-6.5
-      parent: 1
   - uid: 505
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,-6.5
+      pos: 5.5,-10.5
       parent: 1
   - uid: 506
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -10.5,-5.5
+      pos: 9.5,-6.5
       parent: 1
   - uid: 507
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -10.5,-4.5
+      pos: -10.5,-6.5
       parent: 1
   - uid: 508
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 9.5,-5.5
+      pos: -10.5,-5.5
       parent: 1
   - uid: 509
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 9.5,-4.5
+      pos: -10.5,-4.5
       parent: 1
   - uid: 510
     components:
     - type: Transform
-      pos: -1.5,-21.5
+      rot: 3.141592653589793 rad
+      pos: 9.5,-5.5
       parent: 1
   - uid: 511
     components:
     - type: Transform
-      pos: -0.5,-21.5
+      rot: 3.141592653589793 rad
+      pos: 9.5,-4.5
       parent: 1
   - uid: 512
     components:
     - type: Transform
-      pos: 0.5,-21.5
+      pos: -1.5,-21.5
       parent: 1
   - uid: 513
     components:
     - type: Transform
-      pos: -2.5,-18.5
+      pos: -0.5,-21.5
       parent: 1
   - uid: 514
     components:
     - type: Transform
-      pos: -1.5,-18.5
+      pos: 0.5,-21.5
       parent: 1
   - uid: 515
     components:
     - type: Transform
-      pos: 0.5,-18.5
+      pos: -2.5,-18.5
       parent: 1
   - uid: 516
+    components:
+    - type: Transform
+      pos: -1.5,-18.5
+      parent: 1
+  - uid: 517
+    components:
+    - type: Transform
+      pos: 0.5,-18.5
+      parent: 1
+  - uid: 518
     components:
     - type: Transform
       pos: 1.5,-18.5
       parent: 1
 - proto: Gyroscope
   entities:
-  - uid: 517
+  - uid: 519
     components:
     - type: Transform
       pos: -4.5,-18.5
       parent: 1
 - proto: Handcuffs
   entities:
-  - uid: 518
+  - uid: 520
     components:
     - type: Transform
       pos: -9.501018,-4.2703247
       parent: 1
-  - uid: 519
+  - uid: 521
     components:
     - type: Transform
       pos: -9.501018,-4.621887
       parent: 1
 - proto: HighSecDoor
   entities:
-  - uid: 520
+  - uid: 522
     components:
     - type: Transform
       pos: -2.5,-9.5
       parent: 1
-  - uid: 521
+  - uid: 523
     components:
     - type: Transform
       pos: 1.5,-9.5
       parent: 1
-  - uid: 522
+  - uid: 524
     components:
     - type: Transform
       pos: -0.5,-7.5
       parent: 1
 - proto: HolopadBluespace
   entities:
-  - uid: 523
+  - uid: 525
     components:
     - type: Transform
       pos: -0.5,-1.5
       parent: 1
 - proto: LauncherCreamPie
   entities:
-  - uid: 524
+  - uid: 526
     components:
     - type: Transform
       pos: -1.6996152,-10.28163
       parent: 1
-  - uid: 525
+  - uid: 527
     components:
     - type: Transform
       pos: -1.5589902,-10.46913
       parent: 1
-  - uid: 526
+  - uid: 528
     components:
     - type: Transform
       pos: -1.3089902,-10.734755
       parent: 1
 - proto: LockerSyndicatePersonal
   entities:
-  - uid: 28
+  - uid: 29
     components:
     - type: Transform
       pos: 3.5,-13.5
@@ -3180,13 +3167,13 @@ entities:
           showEnts: False
           occludes: True
           ents:
+          - 31
           - 30
-          - 29
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
-  - uid: 31
+  - uid: 32
     components:
     - type: Transform
       pos: 4.5,-13.5
@@ -3219,13 +3206,13 @@ entities:
           showEnts: False
           occludes: True
           ents:
+          - 34
           - 33
-          - 32
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
-  - uid: 34
+  - uid: 35
     components:
     - type: Transform
       pos: 5.5,-13.5
@@ -3258,15 +3245,15 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 35
           - 36
+          - 37
         paper_label: !type:ContainerSlot
           showEnts: False
           occludes: True
           ent: null
 - proto: LubeGrenade
   entities:
-  - uid: 527
+  - uid: 529
     components:
     - type: Transform
       pos: 0.7678242,-8.562113
@@ -3276,35 +3263,35 @@ entities:
       linearDamping: 0
 - proto: NitrogenCanister
   entities:
-  - uid: 528
+  - uid: 530
     components:
     - type: Transform
       pos: 4.5,-17.5
       parent: 1
 - proto: NitrogenTankFilled
   entities:
-  - uid: 355
+  - uid: 357
     components:
     - type: Transform
-      parent: 352
+      parent: 354
     - type: Physics
       angularDamping: 0
       linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 360
+  - uid: 362
     components:
     - type: Transform
-      parent: 357
+      parent: 359
     - type: Physics
       angularDamping: 0
       linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 365
+  - uid: 367
     components:
     - type: Transform
-      parent: 362
+      parent: 364
     - type: Physics
       angularDamping: 0
       linearDamping: 0
@@ -3312,35 +3299,35 @@ entities:
     - type: InsideEntityStorage
 - proto: OxygenCanister
   entities:
-  - uid: 529
+  - uid: 531
     components:
     - type: Transform
       pos: 3.5,-18.5
       parent: 1
 - proto: OxygenTankFilled
   entities:
-  - uid: 356
+  - uid: 358
     components:
     - type: Transform
-      parent: 352
+      parent: 354
     - type: Physics
       angularDamping: 0
       linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 361
+  - uid: 363
     components:
     - type: Transform
-      parent: 357
+      parent: 359
     - type: Physics
       angularDamping: 0
       linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 366
+  - uid: 368
     components:
     - type: Transform
-      parent: 362
+      parent: 364
     - type: Physics
       angularDamping: 0
       linearDamping: 0
@@ -3348,7 +3335,7 @@ entities:
     - type: InsideEntityStorage
 - proto: PaintingAmogusTriptych
   entities:
-  - uid: 530
+  - uid: 532
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3356,7 +3343,7 @@ entities:
       parent: 1
 - proto: PaintingMonkey
   entities:
-  - uid: 531
+  - uid: 533
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3364,20 +3351,20 @@ entities:
       parent: 1
 - proto: PaintingSadClown
   entities:
-  - uid: 532
+  - uid: 534
     components:
     - type: Transform
       pos: -2.5,-8.5
       parent: 1
 - proto: PlasmaReinforcedWindowDirectional
   entities:
-  - uid: 533
+  - uid: 535
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-0.5
       parent: 1
-  - uid: 534
+  - uid: 536
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3385,73 +3372,73 @@ entities:
       parent: 1
 - proto: PlasmaShiv
   entities:
-  - uid: 696
+  - uid: 538
     components:
     - type: Transform
-      parent: 695
+      parent: 537
     - type: Physics
       angularDamping: 0
       linearDamping: 0
       canCollide: False
 - proto: PlasticBanana
   entities:
-  - uid: 535
+  - uid: 539
     components:
     - type: Transform
       pos: -1.1788485,-20.646349
       parent: 1
 - proto: PosterContrabandClown
   entities:
-  - uid: 536
+  - uid: 540
     components:
     - type: Transform
       pos: 0.5,-4.5
       parent: 1
-  - uid: 537
+  - uid: 541
     components:
     - type: Transform
       pos: -1.5,-4.5
       parent: 1
-  - uid: 538
+  - uid: 542
     components:
     - type: Transform
       pos: 4.5,-10.5
       parent: 1
-  - uid: 539
+  - uid: 543
     components:
     - type: Transform
       pos: 4.5,-8.5
       parent: 1
-  - uid: 540
+  - uid: 544
     components:
     - type: Transform
       pos: -5.5,-10.5
       parent: 1
-  - uid: 541
+  - uid: 545
     components:
     - type: Transform
       pos: -5.5,-8.5
       parent: 1
 - proto: PosterLegitSecWatch
   entities:
-  - uid: 542
+  - uid: 546
     components:
     - type: Transform
       pos: -4.5,0.5
       parent: 1
-  - uid: 543
+  - uid: 547
     components:
     - type: Transform
       pos: 3.5,0.5
       parent: 1
-  - uid: 544
+  - uid: 548
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 1
 - proto: PottedPlant10
   entities:
-  - uid: 546
+  - uid: 549
     components:
     - type: Transform
       pos: 2.5,-2.5
@@ -3461,10 +3448,10 @@ entities:
         stash: !type:ContainerSlot
           showEnts: False
           occludes: True
-          ent: 547
+          ent: 550
 - proto: PottedPlant30
   entities:
-  - uid: 834
+  - uid: 352
     components:
     - type: Transform
       pos: -2.5,-17.5
@@ -3474,72 +3461,72 @@ entities:
         stash: !type:ContainerSlot
           showEnts: False
           occludes: True
-          ent: 835
+          ent: 353
 - proto: PottedPlantRandom
   entities:
-  - uid: 545
+  - uid: 551
     components:
     - type: Transform
       pos: -7.5,-7.5
       parent: 1
-  - uid: 548
+  - uid: 552
     components:
     - type: Transform
       pos: 1.5,-17.5
       parent: 1
-  - uid: 549
+  - uid: 553
     components:
     - type: Transform
       pos: -3.5,-2.5
       parent: 1
-  - uid: 550
+  - uid: 554
     components:
     - type: Transform
       pos: -7.5,-10.5
       parent: 1
-  - uid: 551
+  - uid: 555
     components:
     - type: Transform
       pos: 6.5,-7.5
       parent: 1
-  - uid: 552
+  - uid: 556
     components:
     - type: Transform
       pos: 6.5,-10.5
       parent: 1
 - proto: PoweredDimSmallLight
   entities:
-  - uid: 553
+  - uid: 557
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -5.5,-16.5
       parent: 1
-  - uid: 554
+  - uid: 558
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-19.5
       parent: 1
-  - uid: 555
+  - uid: 559
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-9.5
       parent: 1
-  - uid: 556
+  - uid: 560
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-9.5
       parent: 1
-  - uid: 557
+  - uid: 561
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-16.5
       parent: 1
-  - uid: 558
+  - uid: 562
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3547,352 +3534,352 @@ entities:
       parent: 1
 - proto: Poweredlight
   entities:
-  - uid: 559
+  - uid: 563
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-17.5
       parent: 1
-  - uid: 560
+  - uid: 564
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-17.5
       parent: 1
-  - uid: 561
+  - uid: 565
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-10.5
       parent: 1
-  - uid: 562
+  - uid: 566
     components:
     - type: Transform
       pos: -1.5,-8.5
       parent: 1
-  - uid: 563
-    components:
-    - type: Transform
-      pos: 0.5,-8.5
-      parent: 1
-  - uid: 564
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -9.5,-11.5
-      parent: 1
-  - uid: 565
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -9.5,-7.5
-      parent: 1
-  - uid: 566
-    components:
-    - type: Transform
-      pos: -4.5,-0.5
-      parent: 1
   - uid: 567
     components:
     - type: Transform
-      pos: 3.5,-0.5
+      pos: 0.5,-8.5
       parent: 1
   - uid: 568
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -1.5,0.5
+      pos: -9.5,-11.5
       parent: 1
   - uid: 569
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,-7.5
+      parent: 1
+  - uid: 570
+    components:
+    - type: Transform
+      pos: -4.5,-0.5
+      parent: 1
+  - uid: 571
+    components:
+    - type: Transform
+      pos: 3.5,-0.5
+      parent: 1
+  - uid: 572
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 573
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,0.5
       parent: 1
-  - uid: 570
+  - uid: 574
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,-5.5
       parent: 1
-  - uid: 571
+  - uid: 575
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-5.5
       parent: 1
-  - uid: 572
+  - uid: 576
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -7.5,-10.5
       parent: 1
-  - uid: 573
+  - uid: 577
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-10.5
       parent: 1
-  - uid: 574
+  - uid: 578
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,-11.5
       parent: 1
-  - uid: 575
+  - uid: 579
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -11.5,-9.5
       parent: 1
-  - uid: 576
+  - uid: 580
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,-9.5
       parent: 1
-  - uid: 577
+  - uid: 581
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,-7.5
       parent: 1
-  - uid: 578
+  - uid: 582
     components:
     - type: Transform
       pos: 8.5,-4.5
       parent: 1
-  - uid: 579
+  - uid: 583
     components:
     - type: Transform
       pos: -9.5,-4.5
       parent: 1
-  - uid: 580
+  - uid: 584
     components:
     - type: Transform
       pos: 2.5,-11.5
       parent: 1
-  - uid: 581
+  - uid: 585
     components:
     - type: Transform
       pos: -3.5,-11.5
       parent: 1
 - proto: ReinforcedPlasmaWindow
   entities:
-  - uid: 582
+  - uid: 586
     components:
     - type: Transform
       pos: 4.5,-5.5
       parent: 1
-  - uid: 583
+  - uid: 587
     components:
     - type: Transform
       pos: 3.5,-4.5
       parent: 1
-  - uid: 584
+  - uid: 588
     components:
     - type: Transform
       pos: -6.5,-5.5
       parent: 1
-  - uid: 585
+  - uid: 589
     components:
     - type: Transform
       pos: -4.5,-4.5
       parent: 1
-  - uid: 586
+  - uid: 590
     components:
     - type: Transform
       pos: 0.5,-3.5
       parent: 1
-  - uid: 587
+  - uid: 591
     components:
     - type: Transform
       pos: 5.5,-5.5
       parent: 1
-  - uid: 588
+  - uid: 592
     components:
     - type: Transform
       pos: -1.5,-3.5
       parent: 1
-  - uid: 589
+  - uid: 593
     components:
     - type: Transform
       pos: -2.5,2.5
       parent: 1
-  - uid: 590
+  - uid: 594
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
-  - uid: 591
+  - uid: 595
     components:
     - type: Transform
       pos: -1.5,3.5
       parent: 1
-  - uid: 592
+  - uid: 596
     components:
     - type: Transform
       pos: 1.5,2.5
       parent: 1
-  - uid: 593
+  - uid: 597
     components:
     - type: Transform
       pos: -5.5,-4.5
       parent: 1
-  - uid: 594
+  - uid: 598
     components:
     - type: Transform
       pos: 5.5,-8.5
       parent: 1
-  - uid: 595
+  - uid: 599
     components:
     - type: Transform
       pos: -5.5,-5.5
       parent: 1
-  - uid: 596
+  - uid: 600
     components:
     - type: Transform
       pos: 5.5,-10.5
       parent: 1
-  - uid: 597
+  - uid: 601
     components:
     - type: Transform
       pos: -6.5,-8.5
       parent: 1
-  - uid: 598
+  - uid: 602
     components:
     - type: Transform
       pos: -4.5,-3.5
       parent: 1
-  - uid: 599
+  - uid: 603
     components:
     - type: Transform
       pos: 3.5,-3.5
       parent: 1
-  - uid: 600
+  - uid: 604
     components:
     - type: Transform
       pos: 4.5,-4.5
       parent: 1
-  - uid: 601
+  - uid: 605
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 1
-  - uid: 602
+  - uid: 606
     components:
     - type: Transform
       pos: -2.5,1.5
       parent: 1
-  - uid: 603
+  - uid: 607
     components:
     - type: Transform
       pos: -0.5,3.5
       parent: 1
-  - uid: 604
+  - uid: 608
     components:
     - type: Transform
       pos: 1.5,1.5
       parent: 1
-  - uid: 605
+  - uid: 609
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 1
-  - uid: 606
+  - uid: 610
     components:
     - type: Transform
       pos: -6.5,-10.5
       parent: 1
-  - uid: 607
+  - uid: 611
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,-4.5
       parent: 1
-  - uid: 608
+  - uid: 612
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,-6.5
       parent: 1
-  - uid: 609
+  - uid: 613
     components:
     - type: Transform
       pos: -1.5,-21.5
       parent: 1
-  - uid: 610
+  - uid: 614
     components:
     - type: Transform
       pos: -0.5,-21.5
       parent: 1
-  - uid: 611
+  - uid: 615
     components:
     - type: Transform
       pos: 0.5,-18.5
       parent: 1
-  - uid: 612
+  - uid: 616
     components:
     - type: Transform
       pos: 0.5,-21.5
       parent: 1
-  - uid: 613
+  - uid: 617
     components:
     - type: Transform
       pos: -1.5,-18.5
       parent: 1
-  - uid: 614
+  - uid: 618
     components:
     - type: Transform
       pos: -2.5,-18.5
       parent: 1
-  - uid: 615
+  - uid: 619
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -10.5,-6.5
       parent: 1
-  - uid: 616
+  - uid: 620
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -10.5,-4.5
       parent: 1
-  - uid: 617
+  - uid: 621
     components:
     - type: Transform
       pos: 1.5,-18.5
       parent: 1
 - proto: ReinforcedPlasmaWindowDiagonal
   entities:
-  - uid: 618
+  - uid: 622
     components:
     - type: Transform
       pos: -2.5,3.5
       parent: 1
-  - uid: 619
+  - uid: 623
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,3.5
       parent: 1
-  - uid: 620
+  - uid: 624
     components:
     - type: Transform
       pos: -5.5,-3.5
       parent: 1
-  - uid: 621
+  - uid: 625
     components:
     - type: Transform
       pos: -6.5,-4.5
       parent: 1
-  - uid: 622
+  - uid: 626
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-3.5
       parent: 1
-  - uid: 623
+  - uid: 627
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3900,83 +3887,83 @@ entities:
       parent: 1
 - proto: ReinforcedUraniumWindow
   entities:
-  - uid: 624
+  - uid: 628
     components:
     - type: Transform
       pos: 5.5,-6.5
       parent: 1
-  - uid: 625
+  - uid: 629
     components:
     - type: Transform
       pos: -3.5,-3.5
       parent: 1
-  - uid: 626
+  - uid: 630
     components:
     - type: Transform
       pos: -1.5,-5.5
       parent: 1
-  - uid: 627
+  - uid: 631
     components:
     - type: Transform
       pos: -6.5,-6.5
       parent: 1
-  - uid: 628
+  - uid: 632
     components:
     - type: Transform
       pos: 0.5,-5.5
       parent: 1
-  - uid: 629
+  - uid: 633
     components:
     - type: Transform
       pos: 5.5,-7.5
       parent: 1
-  - uid: 630
+  - uid: 634
     components:
     - type: Transform
       pos: -6.5,-7.5
       parent: 1
-  - uid: 631
+  - uid: 635
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 1
-  - uid: 632
+  - uid: 636
     components:
     - type: Transform
       pos: -4.5,-8.5
       parent: 1
-  - uid: 633
+  - uid: 637
     components:
     - type: Transform
       pos: -4.5,-10.5
       parent: 1
-  - uid: 634
+  - uid: 638
     components:
     - type: Transform
       pos: 3.5,-10.5
       parent: 1
-  - uid: 635
+  - uid: 639
     components:
     - type: Transform
       pos: 3.5,-8.5
       parent: 1
-  - uid: 636
+  - uid: 640
     components:
     - type: Transform
       pos: -2.5,-3.5
       parent: 1
-  - uid: 637
+  - uid: 641
     components:
     - type: Transform
       pos: 2.5,-3.5
       parent: 1
-  - uid: 638
+  - uid: 642
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -10.5,-5.5
       parent: 1
-  - uid: 639
+  - uid: 643
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3984,33 +3971,33 @@ entities:
       parent: 1
 - proto: RemoteSignaller
   entities:
-  - uid: 640
+  - uid: 644
     components:
     - type: Transform
       pos: 2.5196605,-13.36137
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        830:
-        - Pressed: DoorBolt
         831:
         - Pressed: DoorBolt
-  - uid: 641
+        832:
+        - Pressed: DoorBolt
+  - uid: 645
     components:
     - type: Transform
       pos: -1.5406063,0.7100365
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
+        45:
+        - Pressed: Toggle
         44:
         - Pressed: Toggle
-        43:
-        - Pressed: Toggle
-        45:
+        46:
         - Pressed: Toggle
 - proto: RevolverCapGun
   entities:
-  - uid: 642
+  - uid: 646
     components:
     - type: Transform
       pos: -1.5583394,-8.092754
@@ -4018,7 +4005,7 @@ entities:
     - type: Physics
       angularDamping: 0
       linearDamping: 0
-  - uid: 643
+  - uid: 647
     components:
     - type: Transform
       pos: -1.5427144,-8.342754
@@ -4026,7 +4013,7 @@ entities:
     - type: Physics
       angularDamping: 0
       linearDamping: 0
-  - uid: 644
+  - uid: 648
     components:
     - type: Transform
       pos: -1.5583394,-8.561504
@@ -4036,10 +4023,10 @@ entities:
       linearDamping: 0
 - proto: SciFlash
   entities:
-  - uid: 547
+  - uid: 550
     components:
     - type: Transform
-      parent: 546
+      parent: 549
     - type: LimitedCharges
       charges: 0
     - type: Physics
@@ -4049,14 +4036,14 @@ entities:
     - type: Timer
 - proto: ScreenTimer
   entities:
-  - uid: 645
+  - uid: 649
     components:
     - type: Transform
       pos: -1.5,-18.5
       parent: 1
 - proto: SignalButton
   entities:
-  - uid: 646
+  - uid: 650
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4066,9 +4053,9 @@ entities:
       linkedPorts:
         49:
         - Pressed: Toggle
-        51:
+        50:
         - Pressed: Toggle
-  - uid: 647
+  - uid: 651
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4076,103 +4063,103 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        46:
+        47:
         - Pressed: Toggle
         48:
         - Pressed: Toggle
 - proto: SignArmory
   entities:
-  - uid: 648
+  - uid: 652
     components:
     - type: Transform
       pos: 2.5,-10.5
       parent: 1
-  - uid: 649
+  - uid: 653
     components:
     - type: Transform
       pos: -1.5,-6.5
       parent: 1
-  - uid: 650
+  - uid: 654
     components:
     - type: Transform
       pos: -3.5,-10.5
       parent: 1
-  - uid: 651
+  - uid: 655
     components:
     - type: Transform
       pos: -3.5,-8.5
       parent: 1
-  - uid: 652
+  - uid: 656
     components:
     - type: Transform
       pos: 0.5,-6.5
       parent: 1
-  - uid: 653
+  - uid: 657
     components:
     - type: Transform
       pos: 2.5,-8.5
       parent: 1
 - proto: SignDirectionalBrig
   entities:
-  - uid: 654
+  - uid: 658
     components:
     - type: Transform
       pos: 2.5,-14.5
       parent: 1
-  - uid: 655
+  - uid: 659
     components:
     - type: Transform
       pos: -3.5,-14.5
       parent: 1
 - proto: SignSecurity
   entities:
-  - uid: 656
+  - uid: 660
     components:
     - type: Transform
       pos: 10.5,-7.5
       parent: 1
-  - uid: 657
+  - uid: 661
     components:
     - type: Transform
       pos: 10.5,-11.5
       parent: 1
-  - uid: 658
+  - uid: 662
     components:
     - type: Transform
       pos: -11.5,-7.5
       parent: 1
-  - uid: 659
+  - uid: 663
     components:
     - type: Transform
       pos: -11.5,-11.5
       parent: 1
 - proto: SpawnHonkBot
   entities:
-  - uid: 660
+  - uid: 664
     components:
     - type: Transform
       pos: -0.5,-20.5
       parent: 1
 - proto: StatueBananiumClown
   entities:
-  - uid: 661
+  - uid: 665
     components:
     - type: Transform
       pos: -3.5,-0.5
       parent: 1
-  - uid: 662
+  - uid: 666
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-0.5
       parent: 1
-  - uid: 663
+  - uid: 667
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,-12.5
       parent: 1
-  - uid: 664
+  - uid: 668
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4180,14 +4167,14 @@ entities:
       parent: 1
 - proto: SubstationBasic
   entities:
-  - uid: 665
+  - uid: 669
     components:
     - type: Transform
       pos: -5.5,-17.5
       parent: 1
 - proto: SuitStorageBase
   entities:
-  - uid: 352
+  - uid: 354
     components:
     - type: Transform
       pos: -6.5,-13.5
@@ -4220,11 +4207,11 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 353
           - 355
-          - 354
+          - 357
           - 356
-  - uid: 357
+          - 358
+  - uid: 359
     components:
     - type: Transform
       pos: -5.5,-13.5
@@ -4257,11 +4244,11 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 359
-          - 360
           - 361
-          - 358
-  - uid: 362
+          - 362
+          - 363
+          - 360
+  - uid: 364
     components:
     - type: Transform
       pos: -4.5,-13.5
@@ -4294,20 +4281,20 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 365
+          - 367
+          - 368
           - 366
-          - 364
-          - 363
+          - 365
 - proto: SurveillanceCameraRouterSecurity
   entities:
-  - uid: 666
+  - uid: 670
     components:
     - type: Transform
       pos: 1.5,-0.5
       parent: 1
 - proto: SurveillanceCameraSecurity
   entities:
-  - uid: 667
+  - uid: 671
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4318,7 +4305,7 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: Port Docking Arm
-  - uid: 668
+  - uid: 672
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4329,7 +4316,7 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: Brig
-  - uid: 669
+  - uid: 673
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4340,7 +4327,7 @@ entities:
       - SurveillanceCameraSecurity
       nameSet: True
       id: Starboard Docking Arm
-  - uid: 670
+  - uid: 674
     components:
     - type: Transform
       pos: -0.5,-10.5
@@ -4352,138 +4339,138 @@ entities:
       id: Armory
 - proto: Table
   entities:
-  - uid: 671
+  - uid: 675
     components:
     - type: Transform
       pos: -1.5,-20.5
       parent: 1
 - proto: TableFancyRed
   entities:
-  - uid: 672
+  - uid: 676
     components:
     - type: Transform
       pos: 0.5,-8.5
       parent: 1
-  - uid: 673
+  - uid: 677
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
-  - uid: 674
+  - uid: 678
     components:
     - type: Transform
       pos: 0.5,-10.5
       parent: 1
-  - uid: 675
+  - uid: 679
     components:
     - type: Transform
       pos: 2.5,-13.5
       parent: 1
-  - uid: 676
-    components:
-    - type: Transform
-      pos: -3.5,-13.5
-      parent: 1
-  - uid: 677
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 8.5,-6.5
-      parent: 1
-  - uid: 678
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -9.5,-4.5
-      parent: 1
-  - uid: 679
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -9.5,-5.5
-      parent: 1
   - uid: 680
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -9.5,-6.5
+      pos: -3.5,-13.5
       parent: 1
   - uid: 681
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 8.5,-5.5
+      pos: 8.5,-6.5
       parent: 1
   - uid: 682
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 8.5,-4.5
+      pos: -9.5,-4.5
       parent: 1
   - uid: 683
     components:
     - type: Transform
-      pos: -1.5,0.5
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-5.5
       parent: 1
   - uid: 684
     components:
     - type: Transform
-      pos: -1.5,-10.5
+      rot: -1.5707963267948966 rad
+      pos: -9.5,-6.5
       parent: 1
   - uid: 685
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-5.5
+      parent: 1
+  - uid: 686
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 8.5,-4.5
+      parent: 1
+  - uid: 687
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 688
+    components:
+    - type: Transform
+      pos: -1.5,-10.5
+      parent: 1
+  - uid: 689
     components:
     - type: Transform
       pos: -1.5,-8.5
       parent: 1
 - proto: Thruster
   entities:
-  - uid: 686
+  - uid: 690
     components:
     - type: Transform
       pos: -3.5,1.5
       parent: 1
-  - uid: 687
+  - uid: 691
     components:
     - type: Transform
       pos: 2.5,1.5
       parent: 1
-  - uid: 688
+  - uid: 692
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-22.5
       parent: 1
-  - uid: 689
+  - uid: 693
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-22.5
       parent: 1
-  - uid: 690
+  - uid: 694
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-22.5
       parent: 1
-  - uid: 691
+  - uid: 695
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-16.5
       parent: 1
-  - uid: 692
+  - uid: 696
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-15.5
       parent: 1
-  - uid: 693
+  - uid: 697
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -7.5,-16.5
       parent: 1
-  - uid: 694
+  - uid: 698
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4491,7 +4478,7 @@ entities:
       parent: 1
 - proto: ToiletEmpty
   entities:
-  - uid: 695
+  - uid: 537
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4509,22 +4496,22 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 696
+          - 538
 - proto: ToyFigurineSecurity
   entities:
-  - uid: 697
+  - uid: 699
     components:
     - type: Transform
       pos: 8.463775,-5.325675
       parent: 1
-  - uid: 698
+  - uid: 700
     components:
     - type: Transform
       pos: -9.536225,-5.4311438
       parent: 1
 - proto: Truncheon
   entities:
-  - uid: 699
+  - uid: 701
     components:
     - type: Transform
       pos: -0.4926107,-10.124786
@@ -4534,42 +4521,42 @@ entities:
       linearDamping: 0
 - proto: VisitorSecurityClownSpawner
   entities:
-  - uid: 700
+  - uid: 702
     components:
     - type: Transform
       pos: -0.5,0.5
       parent: 1
-  - uid: 701
+  - uid: 703
     components:
     - type: Transform
       pos: -2.5,-1.5
       parent: 1
-  - uid: 702
+  - uid: 704
     components:
     - type: Transform
       pos: -1.5,-15.5
       parent: 1
 - proto: WallPlastic
   entities:
-  - uid: 703
+  - uid: 705
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-19.5
       parent: 1
-  - uid: 704
+  - uid: 706
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-20.5
       parent: 1
-  - uid: 705
+  - uid: 707
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,-20.5
       parent: 1
-  - uid: 706
+  - uid: 708
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4577,150 +4564,150 @@ entities:
       parent: 1
 - proto: WallReinforced
   entities:
-  - uid: 707
+  - uid: 709
     components:
     - type: Transform
       pos: 1.5,-11.5
       parent: 1
-  - uid: 708
+  - uid: 710
     components:
     - type: Transform
       pos: -1.5,-4.5
       parent: 1
-  - uid: 709
+  - uid: 711
     components:
     - type: Transform
       pos: 0.5,-4.5
       parent: 1
-  - uid: 710
+  - uid: 712
     components:
     - type: Transform
       pos: 0.5,-6.5
       parent: 1
-  - uid: 711
+  - uid: 713
     components:
     - type: Transform
       pos: -1.5,-6.5
       parent: 1
-  - uid: 712
+  - uid: 714
     components:
     - type: Transform
       pos: 1.5,-7.5
       parent: 1
-  - uid: 713
+  - uid: 715
     components:
     - type: Transform
       pos: -2.5,-7.5
       parent: 1
-  - uid: 714
+  - uid: 716
     components:
     - type: Transform
       pos: 1.5,-8.5
       parent: 1
-  - uid: 715
+  - uid: 717
     components:
     - type: Transform
       pos: 0.5,-7.5
       parent: 1
-  - uid: 716
+  - uid: 718
     components:
     - type: Transform
       pos: -1.5,-7.5
       parent: 1
-  - uid: 717
+  - uid: 719
     components:
     - type: Transform
       pos: 1.5,-10.5
       parent: 1
-  - uid: 718
+  - uid: 720
     components:
     - type: Transform
       pos: 0.5,-11.5
       parent: 1
-  - uid: 719
+  - uid: 721
     components:
     - type: Transform
       pos: -1.5,-11.5
       parent: 1
-  - uid: 720
+  - uid: 722
     components:
     - type: Transform
       pos: -2.5,-11.5
       parent: 1
-  - uid: 721
+  - uid: 723
     components:
     - type: Transform
       pos: -2.5,-10.5
       parent: 1
-  - uid: 722
+  - uid: 724
     components:
     - type: Transform
       pos: -2.5,-8.5
       parent: 1
-  - uid: 723
+  - uid: 725
     components:
     - type: Transform
       pos: -0.5,-11.5
       parent: 1
-  - uid: 724
+  - uid: 726
     components:
     - type: Transform
       pos: 2.5,-10.5
       parent: 1
-  - uid: 725
+  - uid: 727
     components:
     - type: Transform
       pos: 4.5,-10.5
       parent: 1
-  - uid: 726
+  - uid: 728
     components:
     - type: Transform
       pos: 2.5,-8.5
       parent: 1
-  - uid: 727
+  - uid: 729
     components:
     - type: Transform
       pos: 4.5,-8.5
       parent: 1
-  - uid: 728
+  - uid: 730
     components:
     - type: Transform
       pos: -5.5,-10.5
       parent: 1
-  - uid: 729
+  - uid: 731
     components:
     - type: Transform
       pos: -3.5,-8.5
       parent: 1
-  - uid: 730
+  - uid: 732
     components:
     - type: Transform
       pos: -3.5,-10.5
       parent: 1
-  - uid: 731
-    components:
-    - type: Transform
-      pos: -5.5,-8.5
-      parent: 1
-  - uid: 732
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.5,-7.5
-      parent: 1
   - uid: 733
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -2.5,-6.5
+      pos: -5.5,-8.5
       parent: 1
   - uid: 734
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 1.5,-6.5
+      pos: -3.5,-7.5
       parent: 1
   - uid: 735
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -2.5,-6.5
+      parent: 1
+  - uid: 736
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 1.5,-6.5
+      parent: 1
+  - uid: 737
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4728,410 +4715,420 @@ entities:
       parent: 1
 - proto: WallShuttle
   entities:
-  - uid: 736
+  - uid: 10
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -12.5,-11.5
+      pos: 9.5,-9.5
       parent: 1
-  - uid: 737
+  - uid: 51
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -4.5,0.5
+      pos: -10.5,-9.5
       parent: 1
   - uid: 738
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -3.5,0.5
+      pos: -12.5,-11.5
       parent: 1
   - uid: 739
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 8.5,-3.5
+      rot: 3.141592653589793 rad
+      pos: -4.5,0.5
       parent: 1
   - uid: 740
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -2.5,0.5
+      pos: -3.5,0.5
       parent: 1
   - uid: 741
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -5.5,0.5
+      pos: 8.5,-3.5
       parent: 1
   - uid: 742
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -6.5,-0.5
+      rot: 3.141592653589793 rad
+      pos: -2.5,0.5
       parent: 1
   - uid: 743
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -8.5,-2.5
+      pos: -5.5,0.5
       parent: 1
   - uid: 744
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 4.5,0.5
+      pos: -6.5,-0.5
       parent: 1
   - uid: 745
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,0.5
+      rot: 1.5707963267948966 rad
+      pos: -8.5,-2.5
       parent: 1
   - uid: 746
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,0.5
+      rot: 1.5707963267948966 rad
+      pos: 4.5,0.5
       parent: 1
   - uid: 747
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 2.5,0.5
+      pos: 3.5,0.5
       parent: 1
   - uid: 748
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 7.5,-2.5
+      rot: 3.141592653589793 rad
+      pos: 1.5,0.5
       parent: 1
   - uid: 749
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 6.5,-1.5
+      rot: 3.141592653589793 rad
+      pos: 2.5,0.5
       parent: 1
   - uid: 750
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: 5.5,-0.5
+      pos: 7.5,-2.5
       parent: 1
   - uid: 751
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -9.5,-3.5
+      pos: 6.5,-1.5
       parent: 1
   - uid: 752
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
-      pos: -7.5,-1.5
+      pos: 5.5,-0.5
       parent: 1
   - uid: 753
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 9.5,-7.5
+      rot: 1.5707963267948966 rad
+      pos: -9.5,-3.5
       parent: 1
   - uid: 754
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 10.5,-7.5
+      rot: 1.5707963267948966 rad
+      pos: -7.5,-1.5
       parent: 1
   - uid: 755
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 11.5,-7.5
+      pos: 9.5,-7.5
       parent: 1
   - uid: 756
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 11.5,-11.5
+      pos: 10.5,-7.5
       parent: 1
   - uid: 757
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 9.5,-11.5
+      pos: 11.5,-7.5
       parent: 1
   - uid: 758
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 10.5,-11.5
+      pos: 11.5,-11.5
       parent: 1
   - uid: 759
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 11.5,-9.5
+      pos: 9.5,-11.5
       parent: 1
   - uid: 760
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -12.5,-9.5
+      pos: 10.5,-11.5
       parent: 1
   - uid: 761
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -10.5,-7.5
+      pos: 11.5,-9.5
       parent: 1
   - uid: 762
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -11.5,-7.5
+      pos: -12.5,-9.5
       parent: 1
   - uid: 763
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -12.5,-7.5
+      pos: -10.5,-7.5
       parent: 1
   - uid: 764
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -11.5,-11.5
+      pos: -11.5,-7.5
       parent: 1
   - uid: 765
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -10.5,-11.5
+      pos: -12.5,-7.5
       parent: 1
   - uid: 766
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -6.5,-15.5
+      rot: 3.141592653589793 rad
+      pos: -11.5,-11.5
       parent: 1
   - uid: 767
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -10.5,-12.5
+      rot: 3.141592653589793 rad
+      pos: -10.5,-11.5
       parent: 1
   - uid: 768
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -9.5,-13.5
+      pos: -6.5,-15.5
       parent: 1
   - uid: 769
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -8.5,-13.5
+      pos: -10.5,-12.5
       parent: 1
   - uid: 770
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 6.5,-14.5
+      pos: -9.5,-13.5
       parent: 1
   - uid: 771
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 4.5,-14.5
+      pos: -8.5,-13.5
       parent: 1
   - uid: 772
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -3.5,-17.5
+      pos: 6.5,-14.5
       parent: 1
   - uid: 773
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -6.5,-14.5
+      pos: 4.5,-14.5
       parent: 1
   - uid: 774
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -7.5,-14.5
+      pos: -3.5,-17.5
       parent: 1
   - uid: 775
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -5.5,-14.5
+      pos: -6.5,-14.5
       parent: 1
   - uid: 776
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: -6.5,-16.5
+      pos: -7.5,-14.5
       parent: 1
   - uid: 777
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 5.5,-14.5
+      pos: -5.5,-14.5
       parent: 1
   - uid: 778
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 9.5,-12.5
+      pos: -6.5,-16.5
       parent: 1
   - uid: 779
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 8.5,-12.5
+      pos: 5.5,-14.5
       parent: 1
   - uid: 780
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 8.5,-13.5
+      pos: 9.5,-12.5
       parent: 1
   - uid: 781
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 7.5,-13.5
+      pos: 8.5,-12.5
       parent: 1
   - uid: 782
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 2.5,-17.5
+      pos: 8.5,-13.5
       parent: 1
   - uid: 783
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 5.5,-16.5
+      pos: 7.5,-13.5
       parent: 1
   - uid: 784
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
-      pos: 5.5,-15.5
+      pos: 2.5,-17.5
       parent: 1
   - uid: 785
     components:
     - type: Transform
-      pos: -9.5,-12.5
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-16.5
       parent: 1
   - uid: 786
     components:
     - type: Transform
-      pos: -4.5,-14.5
+      rot: -1.5707963267948966 rad
+      pos: 5.5,-15.5
       parent: 1
   - uid: 787
     components:
     - type: Transform
-      pos: -3.5,-14.5
+      pos: -9.5,-12.5
       parent: 1
   - uid: 788
     components:
     - type: Transform
-      pos: -3.5,-15.5
+      pos: -4.5,-14.5
       parent: 1
   - uid: 789
     components:
     - type: Transform
-      pos: 3.5,-14.5
+      pos: -3.5,-14.5
       parent: 1
   - uid: 790
     components:
     - type: Transform
-      pos: 2.5,-14.5
+      pos: -3.5,-15.5
       parent: 1
   - uid: 791
     components:
     - type: Transform
-      pos: 2.5,-15.5
+      pos: 3.5,-14.5
       parent: 1
   - uid: 792
     components:
     - type: Transform
-      pos: 2.5,-18.5
+      pos: 2.5,-14.5
       parent: 1
   - uid: 793
     components:
     - type: Transform
-      pos: 2.5,-19.5
+      pos: 2.5,-15.5
       parent: 1
   - uid: 794
     components:
     - type: Transform
-      pos: -3.5,-18.5
+      pos: 2.5,-18.5
       parent: 1
   - uid: 795
     components:
     - type: Transform
-      pos: -3.5,-19.5
+      pos: 2.5,-19.5
       parent: 1
   - uid: 796
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -6.5,-17.5
+      pos: -3.5,-18.5
       parent: 1
   - uid: 797
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -6.5,-18.5
+      pos: -3.5,-19.5
       parent: 1
   - uid: 798
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -5.5,-18.5
+      pos: -6.5,-17.5
       parent: 1
   - uid: 799
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -5.5,-19.5
+      pos: -6.5,-18.5
       parent: 1
   - uid: 800
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -4.5,-19.5
+      pos: -5.5,-18.5
       parent: 1
   - uid: 801
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 5.5,-17.5
+      pos: -5.5,-19.5
       parent: 1
   - uid: 802
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 5.5,-18.5
+      pos: -4.5,-19.5
       parent: 1
   - uid: 803
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 4.5,-18.5
+      pos: 5.5,-17.5
       parent: 1
   - uid: 804
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 4.5,-19.5
+      pos: 5.5,-18.5
       parent: 1
   - uid: 805
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-18.5
+      parent: 1
+  - uid: 806
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 4.5,-19.5
+      parent: 1
+  - uid: 807
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5139,127 +5136,127 @@ entities:
       parent: 1
 - proto: WallShuttleDiagonal
   entities:
-  - uid: 807
+  - uid: 808
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -6.5,-1.5
       parent: 1
-  - uid: 808
+  - uid: 809
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,-0.5
       parent: 1
-  - uid: 809
+  - uid: 810
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,0.5
       parent: 1
-  - uid: 810
+  - uid: 811
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,-3.5
       parent: 1
-  - uid: 811
+  - uid: 812
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -7.5,-2.5
       parent: 1
-  - uid: 812
+  - uid: 813
     components:
     - type: Transform
       pos: -6.5,0.5
       parent: 1
-  - uid: 813
+  - uid: 814
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,-1.5
       parent: 1
-  - uid: 814
+  - uid: 815
     components:
     - type: Transform
       pos: -7.5,-0.5
       parent: 1
-  - uid: 815
+  - uid: 816
     components:
     - type: Transform
       pos: -9.5,-2.5
       parent: 1
-  - uid: 816
+  - uid: 817
     components:
     - type: Transform
       pos: -8.5,-1.5
       parent: 1
-  - uid: 817
+  - uid: 818
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -5.5,-0.5
       parent: 1
-  - uid: 818
+  - uid: 819
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 8.5,-2.5
       parent: 1
-  - uid: 819
+  - uid: 820
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-0.5
       parent: 1
-  - uid: 820
+  - uid: 821
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-1.5
       parent: 1
-  - uid: 821
+  - uid: 822
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 6.5,-2.5
       parent: 1
-  - uid: 822
+  - uid: 823
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,-3.5
       parent: 1
-  - uid: 823
+  - uid: 824
     components:
     - type: Transform
       pos: -10.5,-3.5
       parent: 1
-  - uid: 824
+  - uid: 825
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 9.5,-3.5
       parent: 1
-  - uid: 825
+  - uid: 826
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-21.5
       parent: 1
-  - uid: 826
+  - uid: 827
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-21.5
       parent: 1
-  - uid: 827
+  - uid: 828
     components:
     - type: Transform
       pos: 6.5,-13.5
       parent: 1
-  - uid: 828
+  - uid: 829
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5267,25 +5264,25 @@ entities:
       parent: 1
 - proto: WardrobePrisonFilled
   entities:
-  - uid: 829
+  - uid: 830
     components:
     - type: Transform
       pos: 0.5,-17.5
       parent: 1
 - proto: WindoorSecurePlasma
   entities:
-  - uid: 830
+  - uid: 831
     components:
     - type: Transform
       pos: -0.5,-18.5
       parent: 1
-  - uid: 831
+  - uid: 832
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-18.5
       parent: 1
-  - uid: 832
+  - uid: 833
     components:
     - type: Transform
       rot: 3.141592653589793 rad

--- a/Resources/Maps/_Funkystation/Shuttles/ShuttleEvent/loneroboticist.yml
+++ b/Resources/Maps/_Funkystation/Shuttles/ShuttleEvent/loneroboticist.yml
@@ -1,6 +1,17 @@
 meta:
-  format: 6
-  postmapinit: false
+  format: 7
+  category: Grid
+  engineVersion: 247.2.0
+  forkId: ""
+  forkVersion: ""
+  time: 03/20/2025 22:15:11
+  entityCount: 246
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
 tilemap:
   0: Space
   1: FloorDark
@@ -131,11 +142,11 @@ entities:
     - type: RadiationGridResistance
 - proto: AirCanister
   entities:
-  - uid: 2
+  - uid: 143
     components:
     - type: Transform
       anchored: True
-      pos: 0.5,-1.5
+      pos: 1.5,-1.5
       parent: 1
     - type: Physics
       angularDamping: 0
@@ -143,13 +154,13 @@ entities:
       bodyType: Static
 - proto: AirlockExternalShuttleLocked
   entities:
-  - uid: 3
+  - uid: 2
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,2.5
       parent: 1
-  - uid: 4
+  - uid: 3
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -157,43 +168,43 @@ entities:
       parent: 1
 - proto: AirlockMaint
   entities:
-  - uid: 5
+  - uid: 4
     components:
     - type: Transform
       pos: 3.5,-0.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -3754.5264
+      secondsUntilStateChange: -3984.144
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
         DoorStatus: True
 - proto: AirlockScienceGlass
   entities:
-  - uid: 6
+  - uid: 5
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,4.5
       parent: 1
-  - uid: 7
+  - uid: 6
     components:
     - type: Transform
       pos: 6.5,4.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -3797.093
+      secondsUntilStateChange: -4026.7107
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
         DoorStatus: True
-  - uid: 8
+  - uid: 7
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,0.5
       parent: 1
-  - uid: 9
+  - uid: 8
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -201,7 +212,7 @@ entities:
       parent: 1
 - proto: APCBasic
   entities:
-  - uid: 10
+  - uid: 9
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -209,13 +220,13 @@ entities:
       parent: 1
 - proto: AtmosDeviceFanDirectional
   entities:
-  - uid: 11
+  - uid: 10
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,0.5
       parent: 1
-  - uid: 12
+  - uid: 11
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -223,7 +234,7 @@ entities:
       parent: 1
 - proto: BikeHorn
   entities:
-  - uid: 13
+  - uid: 12
     components:
     - type: Transform
       pos: 2.5,-2.5
@@ -233,7 +244,7 @@ entities:
       linearDamping: 0
 - proto: BorgCharger
   entities:
-  - uid: 14
+  - uid: 13
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -264,7 +275,7 @@ entities:
           hard: True
           restitution: 0
           friction: 0.4
-  - uid: 15
+  - uid: 14
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -297,57 +308,62 @@ entities:
           friction: 0.4
 - proto: ButtonFrameCaution
   entities:
-  - uid: 16
+  - uid: 15
     components:
     - type: Transform
       pos: 4.5,4.5
       parent: 1
 - proto: CableApcExtension
   entities:
-  - uid: 17
+  - uid: 16
     components:
     - type: Transform
       pos: 2.5,-0.5
       parent: 1
-  - uid: 18
+  - uid: 17
     components:
     - type: Transform
       pos: 2.5,0.5
       parent: 1
-  - uid: 19
+  - uid: 18
     components:
     - type: Transform
       pos: 2.5,1.5
       parent: 1
-  - uid: 20
+  - uid: 19
     components:
     - type: Transform
       pos: 2.5,2.5
       parent: 1
-  - uid: 21
+  - uid: 20
     components:
     - type: Transform
       pos: 3.5,1.5
       parent: 1
-  - uid: 22
+  - uid: 21
     components:
     - type: Transform
       pos: 4.5,1.5
       parent: 1
-  - uid: 23
+  - uid: 22
     components:
     - type: Transform
       pos: 5.5,1.5
       parent: 1
-  - uid: 24
+  - uid: 23
     components:
     - type: Transform
       pos: 2.5,3.5
       parent: 1
-  - uid: 25
+  - uid: 24
     components:
     - type: Transform
       pos: 1.5,1.5
+      parent: 1
+  - uid: 25
+    components:
+    - type: Transform
+      pos: -0.5,1.5
       parent: 1
   - uid: 26
     components:
@@ -357,293 +373,481 @@ entities:
   - uid: 27
     components:
     - type: Transform
-      pos: -0.5,1.5
+      pos: 0.5,1.5
       parent: 1
   - uid: 28
     components:
     - type: Transform
-      pos: 0.5,1.5
+      pos: 6.5,5.5
       parent: 1
   - uid: 29
     components:
     - type: Transform
-      pos: 6.5,5.5
+      pos: 6.5,3.5
       parent: 1
   - uid: 30
     components:
     - type: Transform
-      pos: 6.5,3.5
+      pos: 6.5,2.5
       parent: 1
   - uid: 31
     components:
     - type: Transform
-      pos: 6.5,2.5
+      pos: 6.5,1.5
       parent: 1
   - uid: 32
     components:
     - type: Transform
-      pos: 6.5,1.5
+      pos: 2.5,-1.5
       parent: 1
   - uid: 33
     components:
     - type: Transform
-      pos: 2.5,-1.5
+      pos: 2.5,-2.5
       parent: 1
   - uid: 34
     components:
     - type: Transform
-      pos: 2.5,-2.5
+      pos: 1.5,-2.5
       parent: 1
   - uid: 35
     components:
     - type: Transform
-      pos: 1.5,-2.5
+      pos: 0.5,-2.5
       parent: 1
   - uid: 36
     components:
     - type: Transform
-      pos: 0.5,-2.5
+      pos: -0.5,-2.5
       parent: 1
   - uid: 37
     components:
     - type: Transform
-      pos: -0.5,-2.5
+      pos: 2.5,4.5
       parent: 1
   - uid: 38
     components:
     - type: Transform
-      pos: 2.5,4.5
+      pos: 1.5,4.5
       parent: 1
   - uid: 39
     components:
     - type: Transform
-      pos: 1.5,4.5
+      pos: 0.5,4.5
       parent: 1
   - uid: 40
     components:
     - type: Transform
-      pos: 0.5,4.5
+      pos: -0.5,4.5
       parent: 1
   - uid: 41
     components:
     - type: Transform
-      pos: -0.5,4.5
+      pos: -0.5,5.5
       parent: 1
   - uid: 42
     components:
     - type: Transform
-      pos: -0.5,5.5
+      pos: -0.5,6.5
       parent: 1
   - uid: 43
     components:
     - type: Transform
-      pos: -0.5,6.5
+      pos: 6.5,4.5
       parent: 1
   - uid: 44
     components:
     - type: Transform
-      pos: 6.5,4.5
+      pos: 6.5,6.5
       parent: 1
   - uid: 45
     components:
     - type: Transform
-      pos: 6.5,6.5
+      pos: -1.5,1.5
       parent: 1
   - uid: 46
     components:
     - type: Transform
+      pos: 6.5,0.5
+      parent: 1
+  - uid: 47
+    components:
+    - type: Transform
+      pos: 6.5,0.5
+      parent: 1
+  - uid: 48
+    components:
+    - type: Transform
+      pos: 6.5,-0.5
+      parent: 1
+  - uid: 49
+    components:
+    - type: Transform
+      pos: 6.5,-0.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      pos: 6.5,-0.5
+      parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      pos: 7.5,-0.5
+      parent: 1
+  - uid: 52
+    components:
+    - type: Transform
+      pos: 7.5,-0.5
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      pos: 7.5,-1.5
+      parent: 1
+  - uid: 54
+    components:
+    - type: Transform
+      pos: 7.5,-1.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      pos: 7.5,-1.5
+      parent: 1
+  - uid: 56
+    components:
+    - type: Transform
+      pos: 8.5,-1.5
+      parent: 1
+  - uid: 57
+    components:
+    - type: Transform
+      pos: 8.5,-1.5
+      parent: 1
+  - uid: 58
+    components:
+    - type: Transform
+      pos: 8.5,-1.5
+      parent: 1
+  - uid: 59
+    components:
+    - type: Transform
+      pos: 7.5,4.5
+      parent: 1
+  - uid: 60
+    components:
+    - type: Transform
+      pos: 7.5,4.5
+      parent: 1
+  - uid: 61
+    components:
+    - type: Transform
+      pos: 8.5,4.5
+      parent: 1
+  - uid: 62
+    components:
+    - type: Transform
+      pos: 8.5,4.5
+      parent: 1
+  - uid: 63
+    components:
+    - type: Transform
+      pos: 8.5,4.5
+      parent: 1
+  - uid: 64
+    components:
+    - type: Transform
       pos: -1.5,1.5
+      parent: 1
+  - uid: 65
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 66
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 67
+    components:
+    - type: Transform
+      pos: -1.5,2.5
+      parent: 1
+  - uid: 68
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 69
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 70
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 71
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 72
+    components:
+    - type: Transform
+      pos: -1.5,4.5
+      parent: 1
+  - uid: 73
+    components:
+    - type: Transform
+      pos: -1.5,3.5
+      parent: 1
+  - uid: 74
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 75
+    components:
+    - type: Transform
+      pos: -1.5,1.5
+      parent: 1
+  - uid: 76
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 77
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 78
+    components:
+    - type: Transform
+      pos: -1.5,0.5
+      parent: 1
+  - uid: 79
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+  - uid: 80
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+  - uid: 81
+    components:
+    - type: Transform
+      pos: -1.5,-0.5
+      parent: 1
+  - uid: 82
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 1
+  - uid: 83
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 1
+  - uid: 84
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
+      parent: 1
+  - uid: 85
+    components:
+    - type: Transform
+      pos: -1.5,-1.5
       parent: 1
 - proto: CableHV
   entities:
-  - uid: 47
+  - uid: 86
     components:
     - type: Transform
       pos: 1.5,-2.5
       parent: 1
-  - uid: 48
+  - uid: 87
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 1
 - proto: CableMV
   entities:
-  - uid: 49
+  - uid: 88
     components:
     - type: Transform
       pos: 1.5,-2.5
       parent: 1
-  - uid: 50
+  - uid: 89
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 1
-  - uid: 51
+  - uid: 90
     components:
     - type: Transform
       pos: 2.5,-2.5
       parent: 1
-  - uid: 52
+  - uid: 91
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 1
-  - uid: 53
+  - uid: 92
     components:
     - type: Transform
       pos: 2.5,-0.5
       parent: 1
 - proto: ClockworkGrille
   entities:
-  - uid: 54
+  - uid: 93
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -3.5,1.5
       parent: 1
-  - uid: 55
+  - uid: 94
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,1.5
       parent: 1
-  - uid: 56
+  - uid: 95
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,1.5
       parent: 1
-  - uid: 57
+  - uid: 96
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,-0.5
       parent: 1
-  - uid: 58
+  - uid: 97
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-0.5
       parent: 1
-  - uid: 59
+  - uid: 98
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,3.5
       parent: 1
-  - uid: 60
+  - uid: 99
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,3.5
       parent: 1
-  - uid: 61
+  - uid: 100
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,5.5
       parent: 1
-  - uid: 62
+  - uid: 101
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,5.5
       parent: 1
-  - uid: 63
+  - uid: 102
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,4.5
       parent: 1
-  - uid: 64
+  - uid: 103
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,4.5
       parent: 1
-  - uid: 65
+  - uid: 104
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,4.5
       parent: 1
-  - uid: 66
+  - uid: 105
     components:
     - type: Transform
       pos: -0.5,6.5
       parent: 1
-  - uid: 67
+  - uid: 106
     components:
     - type: Transform
       pos: 4.5,6.5
       parent: 1
-  - uid: 68
+  - uid: 107
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,1.5
       parent: 1
-  - uid: 69
+  - uid: 108
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,-0.5
       parent: 1
-  - uid: 70
+  - uid: 109
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,-0.5
       parent: 1
-  - uid: 71
+  - uid: 110
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,0.5
       parent: 1
-  - uid: 72
+  - uid: 111
     components:
     - type: Transform
       pos: 7.5,5.5
       parent: 1
-  - uid: 73
+  - uid: 112
     components:
     - type: Transform
       pos: 7.5,6.5
       parent: 1
-  - uid: 74
+  - uid: 113
     components:
     - type: Transform
       pos: 6.5,8.5
       parent: 1
-  - uid: 75
+  - uid: 114
     components:
     - type: Transform
       pos: 5.5,8.5
       parent: 1
 - proto: ClockworkGrilleDiagonal
   entities:
-  - uid: 76
+  - uid: 115
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 7.5,8.5
       parent: 1
-  - uid: 77
+  - uid: 116
     components:
     - type: Transform
       pos: 4.5,8.5
       parent: 1
-- proto: ClosetRadiationSuitFilled
-  entities:
-  - uid: 78
-    components:
-    - type: Transform
-      pos: 2.5,-1.5
-      parent: 1
 - proto: ClosetToolFilled
   entities:
-  - uid: 79
+  - uid: 117
     components:
     - type: Transform
       pos: 2.5,-2.5
@@ -698,14 +902,14 @@ entities:
       isPlaceable: True
 - proto: ClosetWallEmergencyFilledRandom
   entities:
-  - uid: 80
+  - uid: 118
     components:
     - type: Transform
       pos: -0.5,3.5
       parent: 1
 - proto: ClosetWallFireFilledRandom
   entities:
-  - uid: 81
+  - uid: 119
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -713,7 +917,7 @@ entities:
       parent: 1
 - proto: ClothingBeltSuspendersRed
   entities:
-  - uid: 82
+  - uid: 120
     components:
     - type: Transform
       pos: 2.5,-2.5
@@ -723,7 +927,7 @@ entities:
       linearDamping: 0
 - proto: ComfyChair
   entities:
-  - uid: 83
+  - uid: 121
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -731,117 +935,117 @@ entities:
       parent: 1
 - proto: ComputerShuttle
   entities:
-  - uid: 84
+  - uid: 122
     components:
     - type: Transform
       pos: 5.5,7.5
       parent: 1
 - proto: CyborgEndoskeleton
   entities:
-  - uid: 85
+  - uid: 123
     components:
     - type: Transform
       pos: 4.55342,0.5796259
       parent: 1
 - proto: DerelictCyborgSpawner
   entities:
-  - uid: 86
+  - uid: 124
     components:
     - type: Transform
       pos: 0.5,6.5
       parent: 1
-  - uid: 87
+  - uid: 125
     components:
     - type: Transform
       pos: 3.5,6.5
       parent: 1
 - proto: FirelockEdge
   entities:
-  - uid: 88
+  - uid: 126
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,3.5
       parent: 1
-  - uid: 89
+  - uid: 127
     components:
     - type: Transform
       pos: 3.5,5.5
       parent: 1
 - proto: GasPipeBend
   entities:
-  - uid: 90
+  - uid: 128
     components:
     - type: Transform
-      pos: 2.5,-0.5
+      rot: 3.141592653589793 rad
+      pos: 0.5,-0.5
       parent: 1
-  - uid: 91
+  - uid: 129
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 6.5,1.5
       parent: 1
+  - uid: 144
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 1
 - proto: GasPipeStraight
   entities:
-  - uid: 92
+  - uid: 130
     components:
     - type: Transform
       pos: 6.5,3.5
       parent: 1
-  - uid: 93
+  - uid: 131
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,1.5
       parent: 1
-  - uid: 94
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 1.5,-0.5
-      parent: 1
-  - uid: 95
+  - uid: 133
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
-  - uid: 96
+  - uid: 134
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,1.5
       parent: 1
-  - uid: 97
+  - uid: 135
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,1.5
       parent: 1
-  - uid: 98
+  - uid: 136
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,1.5
       parent: 1
-  - uid: 99
+  - uid: 137
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,1.5
       parent: 1
-  - uid: 100
+  - uid: 138
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,2.5
       parent: 1
-  - uid: 101
+  - uid: 139
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,4.5
       parent: 1
-  - uid: 102
+  - uid: 140
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -849,13 +1053,7 @@ entities:
       parent: 1
 - proto: GasPipeTJunction
   entities:
-  - uid: 103
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: 0.5,-0.5
-      parent: 1
-  - uid: 104
+  - uid: 142
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -863,47 +1061,41 @@ entities:
       parent: 1
 - proto: GasPort
   entities:
-  - uid: 105
+  - uid: 141
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: 0.5,-1.5
+      pos: 1.5,-1.5
       parent: 1
 - proto: GasVentPump
   entities:
-  - uid: 106
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 2.5,-1.5
-      parent: 1
-  - uid: 107
+  - uid: 145
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 1
-  - uid: 108
+  - uid: 146
     components:
     - type: Transform
       pos: 6.5,6.5
       parent: 1
 - proto: GeneratorRTG
   entities:
-  - uid: 209
+  - uid: 147
     components:
     - type: Transform
       pos: 1.5,-2.5
       parent: 1
 - proto: GravityGeneratorMini
   entities:
-  - uid: 109
+  - uid: 132
     components:
     - type: Transform
-      pos: 1.5,-1.5
+      pos: 0.5,-1.5
       parent: 1
 - proto: Gyroscope
   entities:
-  - uid: 110
+  - uid: 148
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -911,14 +1103,14 @@ entities:
       parent: 1
 - proto: HandheldHealthAnalyzerEmpty
   entities:
-  - uid: 111
+  - uid: 149
     components:
     - type: Transform
       pos: 6.4383373,0.25353348
       parent: 1
 - proto: HappyHonk
   entities:
-  - uid: 112
+  - uid: 150
     components:
     - type: Transform
       pos: 2.5,-2.5
@@ -928,52 +1120,52 @@ entities:
       linearDamping: 0
 - proto: LeftArmBorg
   entities:
-  - uid: 113
+  - uid: 151
     components:
     - type: Transform
       pos: 5.2664623,0.45665848
       parent: 1
-  - uid: 114
+  - uid: 152
     components:
     - type: Transform
       pos: 6.2195873,-0.021942139
       parent: 1
 - proto: LeftLegBorg
   entities:
-  - uid: 115
+  - uid: 153
     components:
     - type: Transform
       pos: 5.2820873,0.11290848
       parent: 1
 - proto: LightHeadBorg
   entities:
-  - uid: 116
+  - uid: 154
     components:
     - type: Transform
       pos: 5.5008373,0.7222835
       parent: 1
 - proto: LootSpawnerRoboticsBorgModule
   entities:
-  - uid: 117
+  - uid: 155
     components:
     - type: Transform
       pos: 5.5,-0.5
       parent: 1
-  - uid: 118
+  - uid: 156
     components:
     - type: Transform
       pos: 6.5,-0.5
       parent: 1
 - proto: Medkit
   entities:
-  - uid: 119
+  - uid: 157
     components:
     - type: Transform
       pos: 6.5046163,0.5649588
       parent: 1
 - proto: PaperOffice
   entities:
-  - uid: 120
+  - uid: 158
     components:
     - type: Transform
       pos: 5.5095854,3.3453743
@@ -991,7 +1183,7 @@ entities:
         █  [head=1]OUT OF ORDER
 - proto: PositronicBrain
   entities:
-  - uid: 121
+  - uid: 159
     components:
     - type: Transform
       pos: 0.67546487,3.8576312
@@ -1001,50 +1193,50 @@ entities:
       linearDamping: 0
 - proto: PowerCellRecharger
   entities:
-  - uid: 122
+  - uid: 160
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
 - proto: PoweredDimSmallLight
   entities:
-  - uid: 123
+  - uid: 161
     components:
     - type: Transform
       pos: 1.5,-1.5
       parent: 1
 - proto: Poweredlight
   entities:
-  - uid: 124
+  - uid: 162
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-0.5
       parent: 1
-  - uid: 125
+  - uid: 163
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,0.5
       parent: 1
-  - uid: 126
+  - uid: 164
     components:
     - type: Transform
       pos: 4.5,3.5
       parent: 1
-  - uid: 127
+  - uid: 165
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,6.5
       parent: 1
-  - uid: 128
+  - uid: 166
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,6.5
       parent: 1
-  - uid: 129
+  - uid: 167
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1052,24 +1244,24 @@ entities:
       parent: 1
 - proto: ReinforcedPlasmaWindow
   entities:
-  - uid: 130
+  - uid: 168
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 1
-  - uid: 131
+  - uid: 169
     components:
     - type: Transform
       pos: 1.5,4.5
       parent: 1
-  - uid: 132
+  - uid: 170
     components:
     - type: Transform
       pos: 0.5,4.5
       parent: 1
 - proto: ResearchAssistantIDCard
   entities:
-  - uid: 133
+  - uid: 171
     components:
     - type: Transform
       pos: 5.487444,5.526781
@@ -1079,33 +1271,33 @@ entities:
       linearDamping: 0
 - proto: RightArmBorg
   entities:
-  - uid: 134
+  - uid: 172
     components:
     - type: Transform
       pos: 6.5008373,-0.11569214
       parent: 1
-  - uid: 135
+  - uid: 173
     components:
     - type: Transform
       pos: 5.7352123,0.45665848
       parent: 1
 - proto: RightLegBorg
   entities:
-  - uid: 136
+  - uid: 174
     components:
     - type: Transform
       pos: 5.7977123,0.06603348
       parent: 1
 - proto: ShuttersNormal
   entities:
-  - uid: 137
+  - uid: 175
     components:
     - type: Transform
       pos: 0.5,7.5
       parent: 1
     - type: DeviceLinkSink
       invokeCounter: 1
-  - uid: 138
+  - uid: 176
     components:
     - type: Transform
       pos: 3.5,7.5
@@ -1114,14 +1306,14 @@ entities:
       invokeCounter: 1
 - proto: ShuttersWindow
   entities:
-  - uid: 139
+  - uid: 177
     components:
     - type: Transform
       pos: 1.5,7.5
       parent: 1
     - type: DeviceLinkSink
       invokeCounter: 1
-  - uid: 140
+  - uid: 178
     components:
     - type: Transform
       pos: 2.5,7.5
@@ -1130,120 +1322,120 @@ entities:
       invokeCounter: 1
 - proto: ShuttleWindow
   entities:
-  - uid: 141
+  - uid: 179
     components:
     - type: Transform
       pos: -0.5,6.5
       parent: 1
-  - uid: 142
+  - uid: 180
     components:
     - type: Transform
       pos: -1.5,3.5
       parent: 1
-  - uid: 143
+  - uid: 181
     components:
     - type: Transform
       pos: -1.5,-0.5
       parent: 1
-  - uid: 144
+  - uid: 182
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,1.5
       parent: 1
-  - uid: 145
+  - uid: 183
     components:
     - type: Transform
       pos: -2.5,3.5
       parent: 1
-  - uid: 146
+  - uid: 184
     components:
     - type: Transform
       pos: -2.5,-0.5
       parent: 1
-  - uid: 147
+  - uid: 185
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,1.5
       parent: 1
-  - uid: 148
+  - uid: 186
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,1.5
       parent: 1
-  - uid: 149
+  - uid: 187
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,5.5
       parent: 1
-  - uid: 150
+  - uid: 188
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,5.5
       parent: 1
-  - uid: 151
+  - uid: 189
     components:
     - type: Transform
       pos: 4.5,6.5
       parent: 1
-  - uid: 152
+  - uid: 190
     components:
     - type: Transform
       pos: 7.5,1.5
       parent: 1
-  - uid: 153
+  - uid: 191
     components:
     - type: Transform
       pos: 7.5,0.5
       parent: 1
-  - uid: 154
+  - uid: 192
     components:
     - type: Transform
       pos: 7.5,-0.5
       parent: 1
-  - uid: 155
+  - uid: 193
     components:
     - type: Transform
       pos: 7.5,6.5
       parent: 1
-  - uid: 156
+  - uid: 194
     components:
     - type: Transform
       pos: 7.5,5.5
       parent: 1
-  - uid: 157
+  - uid: 195
     components:
     - type: Transform
       pos: 5.5,8.5
       parent: 1
-  - uid: 158
+  - uid: 196
     components:
     - type: Transform
       pos: 6.5,8.5
       parent: 1
 - proto: ShuttleWindowDiagonal
   entities:
-  - uid: 159
+  - uid: 197
     components:
     - type: Transform
       pos: -3.5,3.5
       parent: 1
-  - uid: 160
+  - uid: 198
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-0.5
       parent: 1
-  - uid: 161
+  - uid: 199
     components:
     - type: Transform
       pos: 4.5,8.5
       parent: 1
-  - uid: 162
+  - uid: 200
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1251,7 +1443,7 @@ entities:
       parent: 1
 - proto: SignalButton
   entities:
-  - uid: 163
+  - uid: 201
     components:
     - type: Transform
       pos: 4.5,4.5
@@ -1260,17 +1452,17 @@ entities:
       state: True
     - type: DeviceLinkSource
       linkedPorts:
-        137:
+        175:
         - Pressed: Toggle
-        139:
+        177:
         - Pressed: Toggle
-        140:
+        178:
         - Pressed: Toggle
-        138:
+        176:
         - Pressed: Toggle
 - proto: SubstationBasic
   entities:
-  - uid: 164
+  - uid: 202
     components:
     - type: Transform
       pos: 0.5,-2.5
@@ -1280,61 +1472,61 @@ entities:
       linearDamping: 0
 - proto: TablePlasmaGlass
   entities:
-  - uid: 165
+  - uid: 203
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
-  - uid: 166
+  - uid: 204
     components:
     - type: Transform
       pos: 5.5,-0.5
       parent: 1
-  - uid: 167
+  - uid: 205
     components:
     - type: Transform
       pos: 6.5,-0.5
       parent: 1
-  - uid: 168
+  - uid: 206
     components:
     - type: Transform
       pos: 6.5,0.5
       parent: 1
-  - uid: 169
+  - uid: 207
     components:
     - type: Transform
       pos: 6.5,1.5
       parent: 1
-  - uid: 170
+  - uid: 208
     components:
     - type: Transform
       pos: 5.5,5.5
       parent: 1
-  - uid: 171
+  - uid: 209
     components:
     - type: Transform
       pos: 6.5,7.5
       parent: 1
 - proto: Thruster
   entities:
-  - uid: 172
+  - uid: 210
     components:
     - type: Transform
       pos: -1.5,4.5
       parent: 1
-  - uid: 173
+  - uid: 211
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 8.5,4.5
       parent: 1
-  - uid: 174
+  - uid: 212
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-1.5
       parent: 1
-  - uid: 175
+  - uid: 213
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -1342,7 +1534,7 @@ entities:
       parent: 1
 - proto: ToolboxElectricalFilled
   entities:
-  - uid: 176
+  - uid: 214
     components:
     - type: Transform
       pos: 6.513727,1.4562459
@@ -1352,7 +1544,7 @@ entities:
       linearDamping: 0
 - proto: ToolboxMechanicalFilled
   entities:
-  - uid: 177
+  - uid: 215
     components:
     - type: Transform
       pos: 6.482477,1.0968709
@@ -1362,154 +1554,154 @@ entities:
       linearDamping: 0
 - proto: TorsoBorg
   entities:
-  - uid: 178
+  - uid: 216
     components:
     - type: Transform
       pos: 5.5008373,0.33165848
       parent: 1
 - proto: VendingMachineRobotics
   entities:
-  - uid: 179
+  - uid: 217
     components:
     - type: Transform
       pos: 5.5,3.5
       parent: 1
 - proto: VisitorResearchAssistantSpawner
   entities:
-  - uid: 180
+  - uid: 218
     components:
     - type: Transform
       pos: 6.5,5.5
       parent: 1
 - proto: WallShuttle
   entities:
-  - uid: 181
+  - uid: 219
     components:
     - type: Transform
       pos: 7.5,2.5
       parent: 1
-  - uid: 182
+  - uid: 220
     components:
     - type: Transform
       pos: 6.5,-1.5
       parent: 1
-  - uid: 183
+  - uid: 221
     components:
     - type: Transform
       pos: 7.5,3.5
       parent: 1
-  - uid: 184
+  - uid: 222
     components:
     - type: Transform
       pos: 5.5,-1.5
       parent: 1
-  - uid: 185
+  - uid: 223
     components:
     - type: Transform
       pos: 5.5,4.5
       parent: 1
-  - uid: 186
+  - uid: 224
     components:
     - type: Transform
       pos: 4.5,7.5
       parent: 1
-  - uid: 187
+  - uid: 225
     components:
     - type: Transform
       pos: 7.5,4.5
       parent: 1
-  - uid: 188
+  - uid: 226
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,4.5
       parent: 1
-  - uid: 189
+  - uid: 227
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,3.5
       parent: 1
-  - uid: 190
+  - uid: 228
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,4.5
       parent: 1
-  - uid: 191
+  - uid: 229
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-1.5
       parent: 1
-  - uid: 192
+  - uid: 230
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-2.5
       parent: 1
-  - uid: 193
+  - uid: 231
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 1
-  - uid: 194
+  - uid: 232
     components:
     - type: Transform
       pos: 2.5,-3.5
       parent: 1
-  - uid: 195
+  - uid: 233
     components:
     - type: Transform
       pos: 4.5,-2.5
       parent: 1
-  - uid: 196
+  - uid: 234
     components:
     - type: Transform
       pos: 3.5,-3.5
       parent: 1
-  - uid: 197
+  - uid: 235
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-1.5
       parent: 1
-  - uid: 198
+  - uid: 236
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-0.5
       parent: 1
-  - uid: 199
+  - uid: 237
     components:
     - type: Transform
       pos: 0.5,-3.5
       parent: 1
-  - uid: 200
+  - uid: 238
     components:
     - type: Transform
       pos: 7.5,7.5
       parent: 1
 - proto: WallShuttleDiagonal
   entities:
-  - uid: 201
+  - uid: 239
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 7.5,-1.5
       parent: 1
-  - uid: 202
+  - uid: 240
     components:
     - type: Transform
       pos: -0.5,7.5
       parent: 1
-  - uid: 203
+  - uid: 241
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-3.5
       parent: 1
-  - uid: 204
+  - uid: 242
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -1517,25 +1709,25 @@ entities:
       parent: 1
 - proto: WallShuttleInterior
   entities:
-  - uid: 205
+  - uid: 243
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-0.5
       parent: 1
-  - uid: 206
+  - uid: 244
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-0.5
       parent: 1
-  - uid: 207
+  - uid: 245
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-0.5
       parent: 1
-  - uid: 208
+  - uid: 246
     components:
     - type: Transform
       rot: -1.5707963267948966 rad

--- a/Resources/Maps/_Funkystation/Shuttles/ShuttleEvent/mouseJumpscare.yml
+++ b/Resources/Maps/_Funkystation/Shuttles/ShuttleEvent/mouseJumpscare.yml
@@ -1,6 +1,17 @@
 meta:
-  format: 6
-  postmapinit: false
+  format: 7
+  category: Grid
+  engineVersion: 247.2.0
+  forkId: ""
+  forkVersion: ""
+  time: 03/20/2025 18:16:50
+  entityCount: 170
+maps: []
+grids:
+- 1
+orphans:
+- 1
+nullspace: []
 tilemap:
   0: Space
   85: FloorReinforced
@@ -163,7 +174,7 @@ entities:
       pos: 4.5,-2.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -293.54056
+      secondsUntilStateChange: -415.3397
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -360,49 +371,124 @@ entities:
     - type: Transform
       pos: 0.5,-8.5
       parent: 1
-- proto: CableHV
-  entities:
   - uid: 39
     components:
     - type: Transform
-      pos: 5.5,-1.5
+      pos: 3.5,-3.5
       parent: 1
   - uid: 40
     components:
     - type: Transform
-      pos: 5.5,0.5
+      pos: 4.5,-3.5
       parent: 1
   - uid: 41
+    components:
+    - type: Transform
+      pos: 5.5,-3.5
+      parent: 1
+  - uid: 42
+    components:
+    - type: Transform
+      pos: 6.5,-3.5
+      parent: 1
+  - uid: 43
+    components:
+    - type: Transform
+      pos: 5.5,1.5
+      parent: 1
+  - uid: 44
+    components:
+    - type: Transform
+      pos: 1.5,-0.5
+      parent: 1
+  - uid: 45
+    components:
+    - type: Transform
+      pos: 0.5,-0.5
+      parent: 1
+  - uid: 46
+    components:
+    - type: Transform
+      pos: 0.5,0.5
+      parent: 1
+  - uid: 47
+    components:
+    - type: Transform
+      pos: 0.5,1.5
+      parent: 1
+  - uid: 48
+    components:
+    - type: Transform
+      pos: 5.5,-8.5
+      parent: 1
+  - uid: 49
+    components:
+    - type: Transform
+      pos: 0.5,-8.5
+      parent: 1
+  - uid: 50
+    components:
+    - type: Transform
+      pos: -0.5,-8.5
+      parent: 1
+  - uid: 51
+    components:
+    - type: Transform
+      pos: 6.5,-8.5
+      parent: 1
+  - uid: 52
+    components:
+    - type: Transform
+      pos: 6.5,-3.5
+      parent: 1
+  - uid: 53
+    components:
+    - type: Transform
+      pos: -0.5,-3.5
+      parent: 1
+- proto: CableHV
+  entities:
+  - uid: 54
+    components:
+    - type: Transform
+      pos: 5.5,-1.5
+      parent: 1
+  - uid: 55
+    components:
+    - type: Transform
+      pos: 5.5,0.5
+      parent: 1
+  - uid: 56
     components:
     - type: Transform
       pos: 5.5,-0.5
       parent: 1
 - proto: CableMV
   entities:
-  - uid: 42
+  - uid: 57
     components:
     - type: Transform
       pos: 4.5,1.5
       parent: 1
-  - uid: 43
+  - uid: 58
     components:
     - type: Transform
       pos: 4.5,0.5
       parent: 1
-  - uid: 44
+  - uid: 59
     components:
     - type: Transform
       pos: 5.5,0.5
       parent: 1
 - proto: ChairPilotSeat
   entities:
-  - uid: 45
+  - uid: 60
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,0.5
       parent: 1
-  - uid: 46
+  - uid: 61
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -410,60 +496,60 @@ entities:
       parent: 1
 - proto: ComputerRadar
   entities:
-  - uid: 47
+  - uid: 62
     components:
     - type: Transform
       pos: 3.5,1.5
       parent: 1
 - proto: ComputerShuttle
   entities:
-  - uid: 48
+  - uid: 63
     components:
     - type: Transform
       pos: 2.5,1.5
       parent: 1
 - proto: CrateTrashCartFilled
   entities:
-  - uid: 49
+  - uid: 64
     components:
     - type: Transform
       pos: 1.5,-5.5
       parent: 1
-  - uid: 50
+  - uid: 65
     components:
     - type: Transform
       pos: 2.5,-5.5
       parent: 1
-  - uid: 51
+  - uid: 66
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 1
-  - uid: 52
+  - uid: 67
     components:
     - type: Transform
       pos: 1.5,-4.5
       parent: 1
 - proto: FoodBagel
   entities:
-  - uid: 53
+  - uid: 68
     components:
     - type: Transform
       pos: 1.5342197,0.6172106
       parent: 1
-  - uid: 54
+  - uid: 69
     components:
     - type: Transform
       pos: 1.2244,0.41581762
       parent: 1
-  - uid: 55
+  - uid: 70
     components:
     - type: Transform
       pos: 1.771275,0.35331762
       parent: 1
 - proto: GasPipeBend
   entities:
-  - uid: 56
+  - uid: 71
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -471,43 +557,43 @@ entities:
       parent: 1
 - proto: GasPipeStraight
   entities:
-  - uid: 57
+  - uid: 72
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-7.5
       parent: 1
-  - uid: 58
+  - uid: 73
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-6.5
       parent: 1
-  - uid: 59
+  - uid: 74
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-5.5
       parent: 1
-  - uid: 60
+  - uid: 75
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-4.5
       parent: 1
-  - uid: 61
+  - uid: 76
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-3.5
       parent: 1
-  - uid: 62
+  - uid: 77
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-2.5
       parent: 1
-  - uid: 63
+  - uid: 78
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -515,7 +601,7 @@ entities:
       parent: 1
 - proto: GasPipeTJunction
   entities:
-  - uid: 64
+  - uid: 79
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -523,7 +609,7 @@ entities:
       parent: 1
 - proto: GasPort
   entities:
-  - uid: 65
+  - uid: 80
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -531,91 +617,91 @@ entities:
       parent: 1
 - proto: GasVentPump
   entities:
-  - uid: 66
+  - uid: 81
     components:
     - type: Transform
       pos: 4.5,-4.5
       parent: 1
-  - uid: 67
+  - uid: 82
     components:
     - type: Transform
       pos: 4.5,-0.5
       parent: 1
 - proto: GeneratorWallmountAPU
   entities:
-  - uid: 68
+  - uid: 83
     components:
     - type: Transform
       pos: 5.5,-1.5
       parent: 1
-  - uid: 69
+  - uid: 84
     components:
     - type: Transform
       pos: 5.5,-0.5
       parent: 1
 - proto: GravityGeneratorMini
   entities:
-  - uid: 70
+  - uid: 85
     components:
     - type: Transform
       pos: 1.5,-0.5
       parent: 1
 - proto: Grille
   entities:
-  - uid: 71
+  - uid: 86
     components:
     - type: Transform
       pos: 1.5,2.5
       parent: 1
-  - uid: 72
+  - uid: 87
     components:
     - type: Transform
       pos: 2.5,2.5
       parent: 1
-  - uid: 73
+  - uid: 88
     components:
     - type: Transform
       pos: 3.5,2.5
       parent: 1
-  - uid: 74
+  - uid: 89
     components:
     - type: Transform
       pos: 4.5,2.5
       parent: 1
 - proto: Gyroscope
   entities:
-  - uid: 75
+  - uid: 90
     components:
     - type: Transform
       pos: 4.5,0.5
       parent: 1
 - proto: HighSecDoor
   entities:
-  - uid: 76
+  - uid: 91
     components:
     - type: Transform
       pos: 2.5,-6.5
       parent: 1
-  - uid: 77
+  - uid: 92
     components:
     - type: Transform
       pos: 2.5,-2.5
       parent: 1
 - proto: NitrogenTankFilled
   entities:
-  - uid: 79
+  - uid: 94
     components:
     - type: Transform
-      parent: 78
+      parent: 93
     - type: Physics
       angularDamping: 0
       linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 82
+  - uid: 97
     components:
     - type: Transform
-      parent: 81
+      parent: 96
     - type: Physics
       angularDamping: 0
       linearDamping: 0
@@ -623,19 +709,19 @@ entities:
     - type: InsideEntityStorage
 - proto: OxygenTankFilled
   entities:
-  - uid: 80
+  - uid: 95
     components:
     - type: Transform
-      parent: 78
+      parent: 93
     - type: Physics
       angularDamping: 0
       linearDamping: 0
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 83
+  - uid: 98
     components:
     - type: Transform
-      parent: 81
+      parent: 96
     - type: Physics
       angularDamping: 0
       linearDamping: 0
@@ -643,99 +729,99 @@ entities:
     - type: InsideEntityStorage
 - proto: PoweredDimSmallLight
   entities:
-  - uid: 84
+  - uid: 99
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-0.5
       parent: 1
-  - uid: 85
+  - uid: 100
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-4.5
       parent: 1
-  - uid: 86
+  - uid: 101
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,-0.5
       parent: 1
-  - uid: 87
+  - uid: 102
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-4.5
       parent: 1
-  - uid: 88
+  - uid: 103
     components:
     - type: Transform
       pos: 3.5,-7.5
       parent: 1
-  - uid: 89
+  - uid: 104
     components:
     - type: Transform
       pos: 1.5,-7.5
       parent: 1
 - proto: RandomSpawner100
   entities:
-  - uid: 90
+  - uid: 105
     components:
     - type: Transform
       pos: 1.5,-5.5
       parent: 1
-  - uid: 91
+  - uid: 106
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 1
 - proto: ShuttersNormal
   entities:
-  - uid: 92
+  - uid: 107
     components:
     - type: Transform
       pos: 1.5,-8.5
       parent: 1
-  - uid: 93
+  - uid: 108
     components:
     - type: Transform
       pos: 2.5,-8.5
       parent: 1
-  - uid: 94
+  - uid: 109
     components:
     - type: Transform
       pos: 3.5,-8.5
       parent: 1
-  - uid: 95
+  - uid: 110
     components:
     - type: Transform
       pos: 4.5,-8.5
       parent: 1
 - proto: ShuttleWindow
   entities:
-  - uid: 96
+  - uid: 111
     components:
     - type: Transform
       pos: 1.5,2.5
       parent: 1
-  - uid: 97
+  - uid: 112
     components:
     - type: Transform
       pos: 2.5,2.5
       parent: 1
-  - uid: 98
+  - uid: 113
     components:
     - type: Transform
       pos: 3.5,2.5
       parent: 1
-  - uid: 99
+  - uid: 114
     components:
     - type: Transform
       pos: 4.5,2.5
       parent: 1
 - proto: SignalButton
   entities:
-  - uid: 100
+  - uid: 115
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -743,89 +829,89 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        95:
+        110:
         - Pressed: Toggle
-        94:
+        109:
         - Pressed: Toggle
-        93:
+        108:
         - Pressed: Toggle
-        92:
+        107:
         - Pressed: Toggle
 - proto: SpawnMobMouse
   entities:
-  - uid: 101
+  - uid: 116
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 1
-  - uid: 102
+  - uid: 117
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 1
-  - uid: 103
+  - uid: 118
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 1
-  - uid: 104
+  - uid: 119
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 1
-  - uid: 105
+  - uid: 120
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 1
-  - uid: 106
+  - uid: 121
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 1
-  - uid: 107
+  - uid: 122
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 1
-  - uid: 108
+  - uid: 123
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 1
-  - uid: 109
+  - uid: 124
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 1
-  - uid: 110
+  - uid: 125
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 1
-  - uid: 111
+  - uid: 126
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 1
-  - uid: 112
+  - uid: 127
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 1
-  - uid: 113
+  - uid: 128
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 1
-  - uid: 114
+  - uid: 129
     components:
     - type: Transform
       pos: 1.5,-3.5
       parent: 1
 - proto: SubstationWallBasic
   entities:
-  - uid: 115
+  - uid: 130
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -833,7 +919,7 @@ entities:
       parent: 1
 - proto: SuitStorageNTSRA
   entities:
-  - uid: 78
+  - uid: 93
     components:
     - type: Transform
       pos: 3.5,-1.5
@@ -866,9 +952,9 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 79
-          - 80
-  - uid: 81
+          - 94
+          - 95
+  - uid: 96
     components:
     - type: Transform
       pos: 1.5,-1.5
@@ -901,220 +987,218 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 83
-          - 82
+          - 98
+          - 97
 - proto: Table
   entities:
-  - uid: 116
+  - uid: 131
     components:
     - type: Transform
       pos: 1.5,0.5
       parent: 1
 - proto: Thruster
   entities:
-  - uid: 117
+  - uid: 132
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-8.5
       parent: 1
-  - uid: 118
+  - uid: 133
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 6.5,-8.5
       parent: 1
-  - uid: 119
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 6.5,-3.5
-      parent: 1
-    - type: Thruster
-      enabled: False
-  - uid: 120
+  - uid: 134
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-3.5
       parent: 1
-  - uid: 121
+  - uid: 135
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 6.5,-3.5
+      parent: 1
+  - uid: 136
     components:
     - type: Transform
       pos: -0.5,1.5
       parent: 1
-  - uid: 122
+  - uid: 137
     components:
     - type: Transform
       pos: 6.5,1.5
       parent: 1
 - proto: VisitorJanitorSpawner
   entities:
-  - uid: 123
+  - uid: 138
     components:
     - type: Transform
       pos: 2.5,0.5
       parent: 1
-  - uid: 124
+  - uid: 139
     components:
     - type: Transform
       pos: 3.5,0.5
       parent: 1
 - proto: WallShuttle
   entities:
-  - uid: 125
+  - uid: 140
     components:
     - type: Transform
       pos: 5.5,-5.5
       parent: 1
-  - uid: 126
+  - uid: 141
     components:
     - type: Transform
       pos: 1.5,1.5
       parent: 1
-  - uid: 127
+  - uid: 142
     components:
     - type: Transform
       pos: 0.5,1.5
       parent: 1
-  - uid: 128
+  - uid: 143
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
-  - uid: 129
+  - uid: 144
     components:
     - type: Transform
       pos: 0.5,-0.5
       parent: 1
-  - uid: 130
+  - uid: 145
     components:
     - type: Transform
       pos: 0.5,-1.5
       parent: 1
-  - uid: 131
+  - uid: 146
     components:
     - type: Transform
       pos: 0.5,-4.5
       parent: 1
-  - uid: 132
+  - uid: 147
     components:
     - type: Transform
       pos: 0.5,-2.5
       parent: 1
-  - uid: 133
+  - uid: 148
     components:
     - type: Transform
       pos: 0.5,-3.5
       parent: 1
-  - uid: 134
+  - uid: 149
     components:
     - type: Transform
       pos: 0.5,-5.5
       parent: 1
-  - uid: 135
+  - uid: 150
     components:
     - type: Transform
       pos: 0.5,-6.5
       parent: 1
-  - uid: 136
+  - uid: 151
     components:
     - type: Transform
       pos: 5.5,-6.5
       parent: 1
-  - uid: 137
+  - uid: 152
     components:
     - type: Transform
       pos: 5.5,-4.5
       parent: 1
-  - uid: 138
+  - uid: 153
     components:
     - type: Transform
       pos: 5.5,-2.5
       parent: 1
-  - uid: 139
+  - uid: 154
     components:
     - type: Transform
       pos: 5.5,-0.5
       parent: 1
-  - uid: 140
+  - uid: 155
     components:
     - type: Transform
       pos: 5.5,1.5
       parent: 1
-  - uid: 141
+  - uid: 156
     components:
     - type: Transform
       pos: 5.5,0.5
       parent: 1
-  - uid: 142
+  - uid: 157
     components:
     - type: Transform
       pos: 5.5,-1.5
       parent: 1
-  - uid: 143
+  - uid: 158
     components:
     - type: Transform
       pos: 5.5,-3.5
       parent: 1
-  - uid: 144
+  - uid: 159
     components:
     - type: Transform
       pos: 4.5,1.5
       parent: 1
-  - uid: 145
+  - uid: 160
     components:
     - type: Transform
       pos: 0.5,-8.5
       parent: 1
-  - uid: 146
+  - uid: 161
     components:
     - type: Transform
       pos: 0.5,-7.5
       parent: 1
-  - uid: 147
+  - uid: 162
     components:
     - type: Transform
       pos: 5.5,-7.5
       parent: 1
-  - uid: 148
+  - uid: 163
     components:
     - type: Transform
       pos: 5.5,-8.5
       parent: 1
 - proto: WallShuttleInterior
   entities:
-  - uid: 149
+  - uid: 164
     components:
     - type: Transform
       pos: 3.5,-6.5
       parent: 1
-  - uid: 150
+  - uid: 165
     components:
     - type: Transform
       pos: 3.5,-4.5
       parent: 1
-  - uid: 151
+  - uid: 166
     components:
     - type: Transform
       pos: 3.5,-2.5
       parent: 1
-  - uid: 152
+  - uid: 167
     components:
     - type: Transform
       pos: 3.5,-3.5
       parent: 1
-  - uid: 153
+  - uid: 168
     components:
     - type: Transform
       pos: 3.5,-5.5
       parent: 1
-  - uid: 154
+  - uid: 169
     components:
     - type: Transform
       pos: 1.5,-2.5
       parent: 1
-  - uid: 155
+  - uid: 170
     components:
     - type: Transform
       pos: 1.5,-6.5

--- a/Resources/Prototypes/_Funkystation/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/_Funkystation/GameRules/unknown_shuttles.yml
@@ -14,7 +14,7 @@
   components:
   - type: StationEvent
     maxOccurrences: 2 # should be the same as [copies] in shuttle_incoming_event.yml
-    weight: 5
+    weight: 8
   - type: LoadMapRule
     preloadedGrid: loneroboticist
 
@@ -25,7 +25,7 @@
   - type: StationEvent
     startAnnouncement: null #Silent
     maxOccurrences: 1 # should be the same as [copies] in shuttle_incoming_event.yml
-    weight: 5
+    weight: 8
   - type: LoadMapRule
     preloadedGrid: foamroid
 


### PR DESCRIPTION
Minor map changes / fixes

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed some issues with power getting to thrusters on mouseJumpscare.yml and loneroboticist.yml, swapped place of gravgen and air tank on loneroboticist.yml for easier tank swappage. Got rid of bugged blast doors on clownpatrol.yml

Altered the weights of loneroboticist and foamroid to be slightly higher but still uncommon to rare

## Why / Balance

Just makes the shuttles better and easier to play on and work with, should have done this since the beginning.

upped the rates because I hadn't seen any of the new shuttles outside of the most common ones for almost three days (at least in replay logs), may tweak further as time goes on

## Technical details
Changes to maps mouseJumpscare.yml, loneroboticist.yml, and clownpatrol.yml

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl:
- tweak: Shuttle fixes.

