### PR TITLE
Blob Factories now actually produce more Pods when the originals die

### DIFF
--- a/Content.Server/_Goobstation/Blob/BlobFactorySystem.cs
+++ b/Content.Server/_Goobstation/Blob/BlobFactorySystem.cs
@@ -37,6 +37,14 @@ public sealed class BlobFactorySystem : EntitySystem
         {
             blobbernautComponent.Factory = null;
         }
+
+        foreach (EntityUid blobPod in component.BlobPods)
+        {
+            if (TryComp<BlobPodComponent>(blobPod, out var blobPodComponent))
+            {
+                blobPodComponent.Factory = null;
+            }
+        }
     }
 
     private void OnProduceBlobbernaut(EntityUid uid, BlobFactoryComponent component, ProduceBlobbernautEvent args)
@@ -152,6 +160,7 @@ public sealed class BlobFactorySystem : EntitySystem
         component.BlobPods.Add(pod);
         var blobPod = EnsureComp<BlobPodComponent>(pod);
         blobPod.Core = blobTileComponent.Core.Value;
+        blobPod.Factory = uid;
         FillSmokeGas((pod,blobPod), blobCoreComponent.CurrentChem);
 
         //smokeOnTrigger.SmokeColor = blobCoreComponent.ChemСolors[blobCoreComponent.CurrentChem];

--- a/Content.Server/_Goobstation/Blob/NPC/BlobPod/BlobPodSystem.cs
+++ b/Content.Server/_Goobstation/Blob/NPC/BlobPod/BlobPodSystem.cs
@@ -77,6 +77,12 @@ public sealed class BlobPodSystem : SharedBlobPodSystem
         {
             _explosionSystem.QueueExplosion(uid, blobCoreComponent.BlobExplosive, 4, 1, 2, maxTileBreak: 0);
         }
+
+        if (component.Factory == null || !TryComp<BlobFactoryComponent>(component.Factory, out var factoryComp))
+            return;
+        
+        factoryComp.BlobPods.Remove(uid);
+        factoryComp.SpawnedCount -= 1;
     }
 
     public bool Zombify(Entity<BlobPodComponent> ent, EntityUid target)

--- a/Content.Server/_Goobstation/Blob/ZombieBlobSystem.cs
+++ b/Content.Server/_Goobstation/Blob/ZombieBlobSystem.cs
@@ -1,4 +1,5 @@
-﻿using Content.Server.Atmos;
+﻿using Content.Server._Goobstation.Blob.Components;
+using Content.Server.Atmos;
 using Content.Server.Atmos.Components;
 using Content.Server.Body.Components;
 using Content.Server.Body.Systems;
@@ -202,6 +203,15 @@ public sealed class ZombieBlobSystem : SharedZombieBlobSystem
         }
         */
         _trigger.Trigger(component.BlobPodUid);
+        if (TryComp<BlobPodComponent>(component.BlobPodUid, out var podComp))
+        {
+            if (podComp.Factory != null && TryComp<BlobFactoryComponent>(podComp.Factory, out var factoryComp))
+            {
+                factoryComp.BlobPods.Remove(component.BlobPodUid);
+                factoryComp.SpawnedCount -= 1;
+            }
+        }
+
         QueueDel(component.BlobPodUid);
 
         EnsureComp<NpcFactionMemberComponent>(uid);

--- a/Content.Shared/_Goobstation/Blob/Components/BlobPodComponent.cs
+++ b/Content.Shared/_Goobstation/Blob/Components/BlobPodComponent.cs
@@ -21,6 +21,9 @@ public sealed partial class BlobPodComponent : Component
     [ViewVariables(VVAccess.ReadOnly)]
     public EntityUid? Core = null;
 
+    [ViewVariables(VVAccess.ReadOnly)]
+    public EntityUid? Factory = null;
+
     [ViewVariables(VVAccess.ReadWrite), DataField("zombifySoundPath")]
     public SoundSpecifier ZombifySoundPath = new SoundPathSpecifier("/Audio/Effects/Fluids/blood1.ogg");
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Blob Factories will now produce more Blob Pods to meet the cap (3) when its Blob Pods die

## Why / Balance
The factories just became useless after the Pods all died

## Technical details
When a Blob Pod dies (normal or as a Zombie) it will now decrement the Spawned counter on the Factory by 1 and remove itself from the Factory's list of produced Pods.

When a Blob Factory dies it will remove itself as the Blob Pods' parent factory so the Pods do not try to tell its dead parent anything when they also die.

## Media
Counter Decrement showcase, it will produce more Pods as a result

https://github.com/user-attachments/assets/2d18e6cb-ce59-4491-9e6a-b574168909ee

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl:
- tweak: Blob Factories will now resume production of Blob Pods when its previously produced Pods die.
