### PR TITLE
Align items in job selector

### DIFF
--- a/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
+++ b/Content.Client/Lobby/UI/HumanoidProfileEditor.xaml.cs
@@ -952,7 +952,7 @@ namespace Content.Client.Lobby.UI
                     };
                     var jobIcon = _prototypeManager.Index(job.Icon);
                     icon.Texture = jobIcon.Icon.Frame0();
-                    selector.Setup(items, job.LocalizedName, 200, job.LocalizedDescription, icon, job.Guides);
+                    selector.Setup(items, job.LocalizedName, 220, job.LocalizedDescription, icon, job.Guides);
 
                     if (!_requirements.IsAllowed(job, (HumanoidCharacterProfile?) _preferencesManager.Preferences?.SelectedCharacter, out var reason))
                     {


### PR DESCRIPTION
## About the PR
Makes sure all current job names are aligned

## Why / Balance
Overlength Nanotrasen Representative name shifted the buttons to the right

## Technical details
Increased minimum width of the job name label in the job selector for character creation.

## Media
Before:
![job list before change, Nanotrasen Representative being indented more than the rest](https://github.com/user-attachments/assets/53ab24ec-5c59-4a58-a92e-aa8ac9172b5f)

After:
![job list after change, job names all lined up](https://github.com/user-attachments/assets/6938410e-e7c1-4b73-8624-a368a8572f64)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
none

**Changelog**
:cl:
- tweak: Aligned Nanotrasen Representative name with the rest of the job names
