### PR TITLE
Allow Flatpacker to be linked to the Material Silo

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/flatpacker.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/flatpacker.yml
@@ -1,6 +1,6 @@
 ﻿- type: entity
   id: MachineFlatpacker
-  parent: [ BaseMachinePowered, ConstructibleMachine ]
+  parent: [ BaseMachinePowered, ConstructibleMachine, BaseSiloUtilizer ]
   name: Flatpacker 1001
   description: An industrial machine used for expediting machine construction across the station.
   components:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Now the Flatpacker can be linked to the Silo

## Why / Balance
Shuffling materials out of lathes and into the Flatpacker is annoying.

## Technical details


## Media

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl: Quantus
- add: Flatpacker 1001 can be linked to the silo.