### PR TITLE
firefigher nozzle and backpack updates

### DIFF
--- a/Content.Shared/Tools/Components/FirefightingNozzleComponent.cs
+++ b/Content.Shared/Tools/Components/FirefightingNozzleComponent.cs
@@ -1,0 +1,47 @@
+// Assmos - Extinguisher Nozzle
+
+using Content.Shared.Chemistry.Components;
+using Content.Shared.Chemistry.Reagent;
+using Content.Shared.FixedPoint;
+using Content.Shared.Tools.Systems;
+using Robust.Shared.Audio;
+using Robust.Shared.GameStates;
+using Robust.Shared.Prototypes;
+using Content.Shared.Inventory; 
+using Content.Shared.Whitelist; 
+
+namespace Content.Shared.Tools.Components;
+
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState(true), Access(typeof(SharedToolSystem))]
+public sealed partial class FirefightingNozzleComponent : Component
+{
+    [DataField, AutoNetworkedField]
+    public bool Enabled;
+
+    /// <summary>
+    ///     Name of solution/>.
+    /// </summary>
+    [DataField]
+    public const string SolutionName = "tank";
+
+    /// <summary>
+    ///     Reagent that will be used as fuel for welding.
+    /// </summary>
+    [DataField]
+    public ProtoId<ReagentPrototype> TankReagent = "Water";
+
+    [ViewVariables(VVAccess.ReadWrite), DataField]
+    public SlotFlags TargetSlot;
+
+    [ViewVariables(VVAccess.ReadWrite), DataField]
+    public EntityWhitelist? ProviderWhitelist;
+
+    [ViewVariables(VVAccess.ReadWrite), DataField]
+    public bool ExternalContainer = false;
+
+    /// <summary>
+    ///     Sound played when refilling the welder.
+    /// </summary>
+    [DataField]
+    public SoundSpecifier FirefightingNozzleRefill = new SoundPathSpecifier("/Audio/Effects/refill.ogg");
+}

--- a/Content.Shared/Tools/Systems/SharedToolSystem.FirefightingNozzle.cs
+++ b/Content.Shared/Tools/Systems/SharedToolSystem.FirefightingNozzle.cs
@@ -1,0 +1,74 @@
+// Assmos - Extinguisher Nozzle
+
+using Content.Shared.Chemistry.Components;
+using Content.Shared.Chemistry.Components.SolutionManager;
+using Content.Shared.Database;
+using Content.Shared.DoAfter;
+using Content.Shared.Examine;
+using Content.Shared.FixedPoint;
+using Content.Shared.Interaction;
+using Content.Shared.Item.ItemToggle.Components;
+using Content.Shared.Tools.Components;
+using Content.Shared.Inventory; 
+using Content.Shared.Whitelist; 
+
+namespace Content.Shared.Tools.Systems;
+
+public abstract partial class SharedToolSystem
+{
+    [Dependency] private readonly InventorySystem _inventory = default!; 
+    [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!; 
+    public void InitializeFirefightingNozzle()
+    {
+        SubscribeLocalEvent<FirefightingNozzleComponent, AfterInteractEvent>(OnFirefightingNozzleAfterInteract);
+    }
+
+    private void OnFirefightingNozzleAfterInteract(Entity<FirefightingNozzleComponent> entity, ref AfterInteractEvent args)
+    {
+        var sprayOwner = entity.Owner;
+        var solutionName = FirefightingNozzleComponent.SolutionName;
+
+        if (args.Handled)
+            return;
+
+        if (args.Target is not { Valid: true } target || !args.CanReach)
+            return;
+
+        if (TryComp(target, out ReagentTankComponent? tank) && tank.TankType == ReagentTankType.Fuel)
+            return;
+
+        if (entity.Comp.ExternalContainer == true)
+        {
+            if (!_inventory.TryGetContainerSlotEnumerator(args.User, out var enumerator, entity.Comp.TargetSlot)) return;
+                while (enumerator.NextItem(out var item))
+                {
+                    if (_whitelistSystem.IsWhitelistFailOrNull(entity.Comp.ProviderWhitelist, item)) continue;
+                    sprayOwner = item;
+                    solutionName = FirefightingNozzleComponent.SolutionName;
+                }
+        }
+
+        if (SolutionContainerSystem.TryGetDrainableSolution(target, out var targetSoln, out var targetSolution)
+            && SolutionContainerSystem.TryGetSolution(sprayOwner, solutionName, out var solutionComp, out var atmosBackpackTankSolution))
+        {
+            var trans = FixedPoint2.Min(atmosBackpackTankSolution.AvailableVolume, targetSolution.Volume);
+            if (trans > 0)
+            {
+                var drained = SolutionContainerSystem.Drain(target, targetSoln.Value, trans);
+                SolutionContainerSystem.TryAddSolution(solutionComp.Value, drained);
+                _audioSystem.PlayPredicted(entity.Comp.FirefightingNozzleRefill, entity, user: args.User);
+                _popup.PopupClient(Loc.GetString("firefighter-nozzle-component-after-interact-refilled-message"), entity, args.User);
+            }
+            else if (atmosBackpackTankSolution.AvailableVolume <= 0)
+            {
+                _popup.PopupClient(Loc.GetString("firefighter-nozzle-component-already-full"), entity, args.User);
+            }
+            else
+            {
+                _popup.PopupClient(Loc.GetString("firefighter-nozzle-component-no-water-in-tank", ("owner", args.Target)), entity, args.User);
+            }
+
+            args.Handled = true;
+        }
+    }
+}

--- a/Content.Shared/Tools/Systems/SharedToolSystem.cs
+++ b/Content.Shared/Tools/Systems/SharedToolSystem.cs
@@ -41,6 +41,7 @@ public abstract partial class SharedToolSystem : EntitySystem
         InitializeMultipleTool();
         InitializeTile();
         InitializeWelder();
+        InitializeFirefightingNozzle(); // Assmos - Extinguisher Nozzle
         SubscribeLocalEvent<ToolComponent, ToolDoAfterEvent>(OnDoAfter);
         SubscribeLocalEvent<ToolComponent, ExaminedEvent>(OnExamine);
     }

--- a/Resources/Locale/en-US/tools/components/firefighter-nozzle-component.ftl
+++ b/Resources/Locale/en-US/tools/components/firefighter-nozzle-component.ftl
@@ -1,0 +1,3 @@
+firefighter-nozzle-component-no-water-in-tank = The {$owner} is empty.
+firefighter-nozzle-component-after-interact-refilled-message = Refilled!
+firefighter-nozzle-component-already-full = The backpack water tank is already full.

--- a/Resources/Prototypes/Entities/Clothing/Back/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/specific.yml
@@ -112,9 +112,6 @@
     solution: tank
   - type: ExaminableSolution
     solution: tank
-    whitelist:
-      tags:
-      - AtmosBackTank
   - type: ContainerFill
     containers:
       item:

--- a/Resources/Prototypes/Entities/Clothing/Back/specific.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/specific.yml
@@ -98,7 +98,7 @@
   - type: SolutionAmmoProvider
     solutionId: tank
     proto: AtmosResin
-    fireCost: 40
+    fireCost: 25
   - type: SolutionContainerManager
     solutions:
       tank:
@@ -106,36 +106,30 @@
         reagents:
         - ReagentId: Water
           Quantity: 1200
-  - type: SolutionTransfer
-    transferAmount: 50
-    maxTransferAmount: 100
-    minTransferAmount: 10
-    canChangeTransferAmount: true
-  - type: ContainerContainer
-    containers:
-      storagebase: !type:Container
-        ents: []
-  - type: UserInterface
-    interfaces:
-      enum.StorageUiKey.Key:
-        type: StorageBoundUserInterface
-      enum.TransferAmountUiKey.Key:
-        type: TransferAmountBoundUserInterface
   - type: DrawableSolution
-    solution: tank
-  - type: RefillableSolution
     solution: tank
   - type: DrainableSolution
     solution: tank
   - type: ExaminableSolution
     solution: tank
-  - type: Storage
-    grid:
-    - 0,0,1,1
     whitelist:
       tags:
       - AtmosBackTank
-  - type: StorageFill
-    contents:
-      - id: FirefighterNozzle
-
+  - type: ContainerFill
+    containers:
+      item:
+      - FirefighterNozzle
+  - type: ItemSlots
+    slots:
+      item:
+        name: FirefighterNozzle
+        whitelist:
+          tags:
+          - AtmosBackTank
+  - type: ItemMapper
+    mapLayers:
+      sheath-nozzle:
+        whitelist:
+          tags:
+          - AtmosBackTank
+  - type: FirefightingNozzle

--- a/Resources/Prototypes/Entities/Objects/Tools/firefightingnozzle.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/firefightingnozzle.yml
@@ -11,12 +11,18 @@
   - type: Item
     sprite: Objects/Weapons/Guns/Basic/extinguishernozzle.rsi
     size: Normal
+  - type: FirefightingNozzle
+    externalContainer: true
+    targetSlot: BACK
+    providerWhitelist:
+      tags:
+      - AtmosBackTank
   - type: Tag
     tags:
     - AtmosBackTank
     
   - type: Spray
-    transferAmount: 20
+    transferAmount: 15
     pushbackAmount: 60
     spraySound:
       path: /Audio/Effects/extinguish.ogg
@@ -67,4 +73,5 @@
   - type: ActiveTimerTrigger
     timeRemaining: 0.3
   - type: DeleteOnTrigger
+  
   


### PR DESCRIPTION
## About the PR
Rebalances water cost so that it's not all immediately eaten. 
Backpack can only be filled by water tanks and can no longer be used as an OP flamethrower
Adds a system for filling the backpack from the nozzle
Removes the inventory slot from the backpack. Nozzle is now removed with alt+click. 
Removes ability to add chems or fluid to backpack
Allows for filling containers from the backpack

Sinks are currently not capable of filling the backpack. They actually don't have as much water in them as you would think so I decided to avoid that issue entirely for now. Only water tanks can be used to fill the atmos backpack. 

## Why / Balance
It's way better

## Technical details
None

## Media
None

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None

**Changelog**
:cl:
- tweak: Atmos water tank backpack QOL changes
