### PR TITLE
nitrium healium and bz buffs

### DIFF
--- a/Content.Server/Atmos/Reactions/NitriumProductionReaction.cs
+++ b/Content.Server/Atmos/Reactions/NitriumProductionReaction.cs
@@ -39,7 +39,7 @@ public sealed partial class NitriumProductionReaction : IGasReactionEffect
         var energyReleased = efficiency * Atmospherics.NitriumProductionEnergy;
         var heatCap = atmosphereSystem.GetHeatCapacity(mixture, true);
         if (heatCap > Atmospherics.MinimumHeatCapacity)
-            mixture.Temperature = Math.Max((mixture.Temperature * heatCap - energyReleased) / heatCap, Atmospherics.TCMB);
+            mixture.Temperature = Math.Max((mixture.Temperature * heatCap + energyReleased) / heatCap, Atmospherics.TCMB);
 
         return ReactionResult.Reacting;
     }

--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -298,7 +298,7 @@ namespace Content.Shared.Atmos
         /// <summary>
         ///     The amount of energy 1 mol of Nitrium forming from Tritium, Nitrogen and BZ releases.
         /// </summary>
-        public const float NitriumProductionEnergy = 100e3f; // Assmos - /tg/ gases
+        public const float NitriumProductionEnergy = -100e3f; // Assmos - /tg/ gases
 
         /// <summary>
         ///     The amount of energy 1 mol of Nitrium decomposing into nitrogen and water vapor releases.

--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -409,19 +409,19 @@
         damage:
           types:
             Asphyxiation: 10
-            Poison: 2.5
+            Poison: 1.5
       - !type:GenericStatusEffect
         conditions:
         - !type:ReagentThreshold
           reagent: BZ
-          min: 1
+          min: 0.3
         - !type:OrganType
           type: Slime
           shouldHave: false
         key: SeeingRainbows
         component: SeeingRainbows
         type: Add
-        time: 150
+        time: 165
         refresh: false
       - !type:Emote
         conditions:
@@ -503,7 +503,7 @@
         conditions:
         - !type:ReagentThreshold
           reagent: Healium
-          max: 15
+          max: 24
         scaleByQuantity: true
         ignoreResistances: true
         damage:
@@ -515,13 +515,13 @@
         conditions:
         - !type:ReagentThreshold
           reagent: Healium
-          min: 15
+          min: 24
         ignoreResistances: true
         damage:
           groups:
-            Burn: -12
-            Toxin: -25
-            Brute: -12
+            Burn: -20
+            Toxin: -50
+            Brute: -20
       - !type:PopupMessage
         conditions:
         - !type:ReagentThreshold
@@ -547,7 +547,7 @@
         time: 1
         type: Add
       - !type:Drunk
-        boozePower: 50
+        boozePower: 35
         conditions:
         - !type:ReagentThreshold
           reagent: Healium
@@ -591,9 +591,25 @@
         conditions:
         - !type:ReagentThreshold
           reagent: Nitrium
-          min: 3
+          min: 1
+          max: 8
         walkSpeedModifier: 1.25
         sprintSpeedModifier: 1.25
+      - !type:NitriumMovespeedModifier
+        conditions:
+        - !type:ReagentThreshold
+          reagent: Nitrium
+          min: 8
+          max: 12
+        walkSpeedModifier: 1.4
+        sprintSpeedModifier: 1.4
+      - !type:NitriumMovespeedModifier
+        conditions:
+        - !type:ReagentThreshold
+          reagent: Nitrium
+          min: 12
+        walkSpeedModifier: 1.6
+        sprintSpeedModifier: 1.6
       - !type:AddReagentToBlood
         conditions:
         - !type:ReagentThreshold


### PR DESCRIPTION
## About the PR
Pretty significantly buffed healium and nitrium. With so much new content now, the novelty of these gases have kind of worn off, and there isn't really much reason to make them when you can just build yourself robot legs or do maints surgery on yourself instead. 

Also made BZ a slightly more viable huffing drug as the original concept of BZ is that it should be available to crew who want to use it for religious reasons.

## Why / Balance
The things atmosians make take some of the most dedicated time and effort, and late game atmosians should be something to fear, the same way late game chemists, scientists, virologists and geneticists always have been. 

## Technical details
Increased max healing mols on healium and meticulously tested and balanced to make sure capped healing thresholds are accurate. Also slightly lowered booze power. 

Nitrium now has two higher tier speeds. This may need to be drawn back on depending on how widespread it's use becomes, but for the time being, nitrium is particularly hard to make and most people don't take the time to do it. 

BZ can trigger rainbow effects in incredibly low doses below it's poison trigger. Safe amounts could potentially be mixed into tanks for use throughout shifts. May need some further balancing. 

## Media
None

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None

**Changelog**
:cl:
- tweak: Buff Healium
- tweak: Buff Nitrium
- tweak: Buff BZ
