### PR TITLE
disable changeling transform sting

### DIFF
--- a/Resources/Prototypes/_Goobstation/Changeling/Catalog/changeling_catalog.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/Catalog/changeling_catalog.yml
@@ -184,19 +184,19 @@
   - !type:ListingLimitedStockCondition
     stock: 1
 
-- type: listing
-  id: EvolutionMenuStingTransform
-  name: evolutionmenu-sting-transform-name
-  description: evolutionmenu-sting-transform-desc
-  icon: { sprite: _Goobstation/Changeling/changeling_abilities.rsi, state: sting_transform }
-  productAction: ActionStingTransform
-  cost:
-    EvolutionPoint: 6
-  categories:
-  - ChangelingAbilitySting
-  conditions:
-  - !type:ListingLimitedStockCondition
-    stock: 1
+#- type: listing
+#  id: EvolutionMenuStingTransform
+#  name: evolutionmenu-sting-transform-name
+#  description: evolutionmenu-sting-transform-desc
+#  icon: { sprite: _Goobstation/Changeling/changeling_abilities.rsi, state: sting_transform }
+#  productAction: ActionStingTransform
+#  cost:
+#    EvolutionPoint: 6
+#  categories:
+#  - ChangelingAbilitySting
+#  conditions:
+#  - !type:ListingLimitedStockCondition
+#    stock: 1
 
 # utility
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Removed the transform sting from the changeling catalog

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It's generally unenjoyable to get transformed at the start of the round and be stuck like that all round.

Ideally, this would be temporary or there would be a way to revert this, through Genetics or Chemistry. For the time being, it doesn't really fit Funky.

**Changelog**
:cl: Miiish
- remove: Removed transform sting from the changeling catalog
