### PR TITLE
Fix an infinite water vapor bug

### DIFF
--- a/Content.Server/Atmos/Portable/ElectrolyzerSystem.cs
+++ b/Content.Server/Atmos/Portable/ElectrolyzerSystem.cs
@@ -83,9 +83,9 @@ public sealed class ElectrolyzerSystem : EntitySystem
         if (initH2O < 0.05f) return; 
 
         var porportion = Math.Min(initH2O * 0.5f, 2.5f);
-        var efficiency = Math.Min(mixture.Temperature / 1123.15f, 1f);
+        var efficiency = Math.Min(mixture.Temperature / 1123.15f * 0.75f, 0.75f);
 
-        var h2oRemoved = porportion * 2f * efficiency;
+        var h2oRemoved = porportion * 2f;
         var oxyProduced = porportion * efficiency;
         var hydrogenProduced = porportion * 2f * efficiency;
 

--- a/Content.Server/Atmos/Reactions/HydrogenFireReaction.cs
+++ b/Content.Server/Atmos/Reactions/HydrogenFireReaction.cs
@@ -43,7 +43,7 @@ namespace Content.Server.Atmos.Reactions
             {
                 energyReleased += (Atmospherics.FireHydrogenEnergyReleased * burnedFuel);
 
-                mixture.AdjustMoles(Gas.WaterVapor, burnedFuel);
+                mixture.AdjustMoles(Gas.WaterVapor, burnedFuel * 0.5f);
 
                 mixture.ReactionResults[(byte)GasReaction.Fire] += burnedFuel;
             }


### PR DESCRIPTION
## About the PR
Fixes the hydrogen fire reaction so that it only produces one mole of water vapor for every 2 moles of hydrogen burned, rather than 1:1.

## Why / Balance
In this house we obey the laws of thermodynamics.

## Technical details
Simply halved the amount of water vapor the hydrogen fire reaction creates. 

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None

**Changelog**
:cl:
- fix: Fixed infinite water vapor bug
