### PR TITLE
Cap drunk time to end permanent drunkeness

### DIFF
--- a/Content.Shared/Drunk/DrunkSystem.cs
+++ b/Content.Shared/Drunk/DrunkSystem.cs
@@ -1,6 +1,7 @@
 using Content.Shared.Speech.EntitySystems;
 using Content.Shared.StatusEffect;
 using Content.Shared.Traits.Assorted;
+using Robust.Shared.Timing;
 
 namespace Content.Shared.Drunk;
 
@@ -8,9 +9,11 @@ public abstract class SharedDrunkSystem : EntitySystem
 {
     [ValidatePrototypeId<StatusEffectPrototype>]
     public const string DrunkKey = "Drunk";
+    public const float maxDrunkTime = 1500; // Funky - caps drunk time to prevent permanent drunkeness. In seconds. 
 
     [Dependency] private readonly StatusEffectsSystem _statusEffectsSystem = default!;
     [Dependency] private readonly SharedSlurredSystem _slurredSystem = default!;
+    [Dependency] private readonly IGameTiming _timing = default!; // Funky - needed to calculate remaining status time. 
 
     public void TryApplyDrunkenness(EntityUid uid, float boozePower, bool applySlur = true,
         StatusEffectsComponent? status = null)
@@ -30,10 +33,21 @@ public abstract class SharedDrunkSystem : EntitySystem
         {
             _statusEffectsSystem.TryAddStatusEffect<DrunkComponent>(uid, DrunkKey, TimeSpan.FromSeconds(boozePower), true, status);
         }
-        else
+        // Funky modification starts here
+        else if (_statusEffectsSystem.TryGetTime(uid, DrunkKey, out var time))
         {
-            _statusEffectsSystem.TryAddTime(uid, DrunkKey, TimeSpan.FromSeconds(boozePower), status);
+            var timeLeft = (float) (time.Value.Item2 - _timing.CurTime).TotalSeconds;
+
+            if (timeLeft + boozePower > maxDrunkTime) 
+                _statusEffectsSystem.TrySetTime(uid, DrunkKey, TimeSpan.FromSeconds(maxDrunkTime), status);
+            else 
+                _statusEffectsSystem.TryAddTime(uid, DrunkKey, TimeSpan.FromSeconds(boozePower), status);
         }
+        // Funky modification ends
+        // else
+        // {
+        //     _statusEffectsSystem.TryAddTime(uid, DrunkKey, TimeSpan.FromSeconds(boozePower), status);
+        // }
     }
 
     public void TryRemoveDrunkenness(EntityUid uid)

--- a/runclient.bat
+++ b/runclient.bat
@@ -1,2 +1,3 @@
 @echo off
 dotnet run --project Content.Client
+pause

--- a/runclient.bat
+++ b/runclient.bat
@@ -1,3 +1,2 @@
 @echo off
 dotnet run --project Content.Client
-pause


### PR DESCRIPTION
## About the PR
Adds a cap of 25 minutes to the drunk status. 25 minutes should still allow players to experience the full effects of being drunk for a decent amount of time, while at the same time having an end in sight that will encourage players to sleep off or medicate away the effects. 

## Why / Balance
People were drunk for entire 2 hour shifts. 

## Technical details
DrunkSystem.cs has been modified to check remaining time on drunk status and only set status time up to a maxDrunkTime. 

## Media
None

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
Modifies Shared/Drunk/DrunkSystem.cs

**Changelog**
:cl:
- fix: Fixed permanent drunkeness
