### PR TITLE
Nukies fixes + accidental heretic fix????????

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -21,21 +21,9 @@
   - type: SubGamemodes
     rules:
     - id: Thief
-      prob: 0.5
-    - id: SubWizard
-      prob: 0.05
-    # TODO: figure out what is causing store issues
-    #- id: Heretic # goob edit
-    #  prob: 0.4 # funkystation - 20% of rounds can have a heretic as a treat
-
-- type: entity
-  parent: BaseGameRule
-  id: SubGamemodesRuleNoWizard
-  components:
-  - type: SubGamemodes
-    rules:
-    - id: Thief
-      prob: 0.5
+      prob: 0.75
+    - id: Heretic # goob edit
+      prob: 0.2 # funkystation - 20% of rounds can have a heretic as a treat
 
 - type: entity
   id: DeathMatch31
@@ -342,7 +330,6 @@
       - type: InitialInfected
       mindRoles:
       - MindRoleInitialInfected
-
 
 # event schedulers
 

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -116,6 +116,7 @@
     - prefRoles: [ NukeopsCommander ]
       fallbackRoles: [ Nukeops, NukeopsMedic ]
       spawnerPrototype: SpawnPointNukeopsCommander
+      max: 1
       startingGear: SyndicateCommanderGearFull
       roleLoadout:
       - RoleSurvivalNukie
@@ -133,6 +134,7 @@
     - prefRoles: [ NukeopsMedic ]
       fallbackRoles: [ Nukeops, NukeopsCommander ]
       spawnerPrototype: SpawnPointNukeopsMedic
+      max: 1
       startingGear: SyndicateOperativeMedicFull
       roleLoadout:
       - RoleSurvivalNukie


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Made it so there was 1 max commander and 1 max medic for nukie spawns. Also, apparently heretic was disabled. Heretic was re-enabled as a side effect because I cherry picked the vocaloid names commit again. I don't think it did anything else.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Hopefully it makes it so three nukie commanders don't spawn????

## Technical details
<!-- Summary of code changes for easier review. -->
Added "max: 1" field to the nukie commander and nukie agent/medic antagspawn components. Re-cherrypicked Vocaloid names, but I think they were already in anyways. I have no idea what's causing the issues on the server.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Made it so only one nukie commander and one nukie agent can spawn MAX.
- fix: Re-added heretic to sub-gamemodes