### PR TITLE
Nitrium move speed modifier minor fix

### DIFF
--- a/Content.Server/EntityEffects/Effects/NitriumMoveSpeedModifier.cs
+++ b/Content.Server/EntityEffects/Effects/NitriumMoveSpeedModifier.cs
@@ -54,18 +54,16 @@ public sealed partial class NitriumMovespeedModifier : EntityEffect
         status.WalkSpeedModifier = WalkSpeedModifier;
         status.SprintSpeedModifier = SprintSpeedModifier;
 
-        IncreaseTimer(status, StatusLifetime);
+        SetTimer(status, StatusLifetime);
 
         if (modified)
             args.EntityManager.System<MovementSpeedModifierSystem>().RefreshMovementSpeedModifiers(args.TargetEntity);
     }
-    public void IncreaseTimer(MovespeedModifierMetabolismComponent status, float time)
+    public void SetTimer(MovespeedModifierMetabolismComponent status, float time)
     {
         var gameTiming = IoCManager.Resolve<IGameTiming>();
 
-        var offsetTime = Math.Max(status.ModifierTimer.TotalSeconds, gameTiming.CurTime.TotalSeconds);
-
-        status.ModifierTimer = TimeSpan.FromSeconds(offsetTime + time);
+        status.ModifierTimer = TimeSpan.FromSeconds(gameTiming.CurTime.TotalSeconds + time);
         status.Dirty();
     }
 }


### PR DESCRIPTION
## About the PR
This PR fixes some unintended behavior with nitrium. Breathing nitrium now consistently grants 6 seconds of move speed enhancement each breath. Since you breathe every 4 seconds, it will consistently last until your next breath. You will no longer have effects last longer than 6 seconds after your last breath of nitrium. 

## Why / Balance
This is what nitrium was always supposed to do. 

## Technical details
Changes NitriumMoveSpeedModifier so that nitrium effects will no longer stack under any circumstances, and will consistently extend the effects 6 seconds from the time of your last breath. 

## Media
None

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None

**Changelog**
:cl:
- fix: Fixed nitrium move speed bug. Nitrium speed increase will always last 6 seconds from the moment you last breathe it in. 
