### PR TITLE
Perma Blindness Trait Fix

### DIFF
--- a/Content.Server/_Shitmed/Body/Systems/EyesSystem.cs
+++ b/Content.Server/_Shitmed/Body/Systems/EyesSystem.cs
@@ -4,6 +4,7 @@ using Content.Shared.Body.Events;
 using Content.Shared._Shitmed.Body.Organ;
 using Content.Shared.Eye.Blinding.Components;
 using Content.Shared.Eye.Blinding.Systems;
+using Content.Shared.Traits.Assorted;
 
 namespace Content.Server.Body.Systems
 {
@@ -35,8 +36,17 @@ namespace Content.Server.Body.Systems
             if (!TryComp(oldEntity, out oldSight))
                 oldSight = EnsureComp<BlindableComponent>(oldEntity);
 
-            //give new sight all values of old sight
-            _blindableSystem.TransferBlindness(newSight, oldSight, newEntity);
+            if (TryComp<PermanentBlindnessComponent>(newEntity, out var permanentBlindnessComponent)
+                && permanentBlindnessComponent.Blindness == 0) // person has perma blindness quirk
+            {
+                var maxMagnitudeInt = (int) BlurryVisionComponent.MaxMagnitude;
+                _blindableSystem.SetMinDamage((newEntity, newSight), maxMagnitudeInt);
+            }
+            else
+            {
+                //give new sight all values of old sight
+                _blindableSystem.TransferBlindness(newSight, oldSight, newEntity);
+            }
 
             var hasOtherEyes = false;
             //check for other eye components on owning body and owning body organs (if old entity has a body)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Perma Blindness now works when you get your eyes removed. Only nearsightedness can be fixed with surgery.

Alternative ways should exist for players to treat blindness in-game, although the old way of replacing someones eyes with surgery should not be it.

## Why / Balance
Part of a series of patches to balance Quirks.

## Technical details
Code now checks for a PermanentBlindnessComponent. Also checks if its set to 0 (the max value there is).

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Permanent blindness is now un-treatable.