### PR TITLE
Add welding supplies lockers to Core

### DIFF
--- a/Resources/Maps/_Funkystation/core.yml
+++ b/Resources/Maps/_Funkystation/core.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 247.2.0
   forkId: ""
   forkVersion: ""
-  time: 03/28/2025 03:18:19
-  entityCount: 22449
+  time: 04/04/2025 13:52:48
+  entityCount: 22455
 maps:
 - 1
 grids:
@@ -62419,11 +62419,6 @@ entities:
           ent: null
 - proto: CrateTrashCartFilled
   entities:
-  - uid: 9129
-    components:
-    - type: Transform
-      pos: 5.5,-37.5
-      parent: 2
   - uid: 9130
     components:
     - type: Transform
@@ -104502,6 +104497,43 @@ entities:
           showEnts: False
           occludes: True
           ent: null
+- proto: LockerWeldingSuppliesFilled
+  entities:
+  - uid: 9129
+    components:
+    - type: Transform
+      pos: 5.5,-37.5
+      parent: 2
+  - uid: 22450
+    components:
+    - type: Transform
+      pos: -52.5,9.5
+      parent: 2
+  - uid: 22451
+    components:
+    - type: Transform
+      pos: -60.5,-30.5
+      parent: 2
+  - uid: 22452
+    components:
+    - type: Transform
+      pos: 15.5,6.5
+      parent: 2
+  - uid: 22453
+    components:
+    - type: Transform
+      pos: -5.5,36.5
+      parent: 2
+  - uid: 22454
+    components:
+    - type: Transform
+      pos: -19.5,-41.5
+      parent: 2
+  - uid: 22455
+    components:
+    - type: Transform
+      pos: 63.5,-30.5
+      parent: 2
 - proto: MachineAnomalyGenerator
   entities:
   - uid: 15255


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added seven welding supplies lockers to Core station, as follows:

- SW maints near "tider kitchen"
- East maints near board storage (replaced trash cart)
- Central maints north of maints entrance to engineering
- NW substation room "Evacuation Substation"
- N central maints behind sec near perma entrance
- SE maints near "tider chapel"
- SE substation room "Science Substation"

## Why / Balance
There were none at all before. This allows enterprising crew to acquire a welding mask.

## Technical details
No code changes.

## Media
![Screenshot 2025-04-04 160404](https://github.com/user-attachments/assets/f82c6eef-a3c6-4a80-80fe-1e59daca539a)
![Screenshot 2025-04-04 160348](https://github.com/user-attachments/assets/7555b69e-8e81-4299-adba-427a440718ce)
You get the idea. Not all pictured.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
I have no idea what any of this means.

**Changelog**
- add: Added welding supplies lockers to Core station