### PR TITLE
Added ability to change laws of borgs using a lawboard 

### DIFF
--- a/Content.Server/_Viva/Borgs/LawSwapSystem.cs
+++ b/Content.Server/_Viva/Borgs/LawSwapSystem.cs
@@ -31,6 +31,7 @@ public sealed class LawSwapSystem : EntitySystem
 
         TryComp<SiliconLawBoundComponent>(args.Used, out var lawBoundComp);
         TryComp<WiresPanelComponent>(args.Target, out var wirePanelComp);
+        
         if (lawBoundComp == null || wirePanelComp == null)
             return;
 

--- a/Content.Server/_Viva/Borgs/LawSwapSystem.cs
+++ b/Content.Server/_Viva/Borgs/LawSwapSystem.cs
@@ -27,9 +27,7 @@ public sealed class LawSwapSystem : EntitySystem
     private void WhenLawboardUsed(EntityUid uid, SiliconLawBoundComponent component, AfterInteractUsingEvent args)
     {
         if (args.Handled)
-        {
             return;
-        }
 
         TryComp<SiliconLawBoundComponent>(args.Used, out var lawBoundComp);
         TryComp<WiresPanelComponent>(args.Target, out var wirePanelComp);
@@ -43,10 +41,9 @@ public sealed class LawSwapSystem : EntitySystem
                 BreakOnMove = true,
                 NeedHand = true,
             };
+            
             if (_doAfterSystem.TryStartDoAfter(doafter))
-            {
                 args.Handled = true;
-            }
         }
         else
         {
@@ -60,16 +57,12 @@ public sealed class LawSwapSystem : EntitySystem
     private void WhenFinishedLawboard(EntityUid entity, SiliconLawBoundComponent component, DoAfterEvent args)
     {
         if (args.Handled || args.Cancelled || !args.Target.HasValue)
-        {
             return;
-        }
 
         TryComp<SiliconLawProviderComponent>(args.Used, out var lawBoardComp);
         TryComp<WiresPanelComponent>(args.Target, out var wirePanelComp);
         if (lawBoardComp == null || wirePanelComp == null)
-        {
             return;
-        }
 
         if (wirePanelComp.Open)
         {

--- a/Content.Server/_Viva/Borgs/LawSwapSystem.cs
+++ b/Content.Server/_Viva/Borgs/LawSwapSystem.cs
@@ -34,9 +34,7 @@ public sealed class LawSwapSystem : EntitySystem
         TryComp<SiliconLawBoundComponent>(args.Used, out var lawBoundComp);
         TryComp<WiresPanelComponent>(args.Target, out var wirePanelComp);
         if (lawBoundComp == null || wirePanelComp == null)
-        {
             return;
-        }
 
         if (wirePanelComp.Open)
         {

--- a/Content.Shared/_Viva/Silicon/LawboardDoAfterEvent.cs
+++ b/Content.Shared/_Viva/Silicon/LawboardDoAfterEvent.cs
@@ -1,0 +1,9 @@
+﻿using Content.Shared.DoAfter;
+using Robust.Shared.Serialization;
+
+namespace Content.Shared._Viva.Silicon;
+
+[Serializable, NetSerializable]
+public sealed partial class LawboardDoAfterEvent: SimpleDoAfterEvent
+{
+}

--- a/Content.Shared/_Viva/Silicon/LawboardDoAfterEvent.cs
+++ b/Content.Shared/_Viva/Silicon/LawboardDoAfterEvent.cs
@@ -4,6 +4,4 @@ using Robust.Shared.Serialization;
 namespace Content.Shared._Viva.Silicon;
 
 [Serializable, NetSerializable]
-public sealed partial class LawboardDoAfterEvent: SimpleDoAfterEvent
-{
-}
+public sealed partial class LawboardDoAfterEvent: SimpleDoAfterEvent;

--- a/Content.Shared/_Viva/Silicon/LawboardDoAfterEvent.cs
+++ b/Content.Shared/_Viva/Silicon/LawboardDoAfterEvent.cs
@@ -4,4 +4,4 @@ using Robust.Shared.Serialization;
 namespace Content.Shared._Viva.Silicon;
 
 [Serializable, NetSerializable]
-public sealed partial class LawboardDoAfterEvent: SimpleDoAfterEvent;
+public sealed partial class LawboardDoAfterEvent : SimpleDoAfterEvent;


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Borgs are now able to have their laws changed with a lawboard when their chassis is unlocked and opened. It has a 25 second doafter, to ensure you can't just run around zapping borgs with it.

Basically jank lawsync that uses way more manual labor.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The hope is that this would make borg gameplay significantly more varied by allowing it to have a similar degree of variety to AI, however, the increased probability for borgs that are hostile to zombies, nukies, etc could be a concern. Crew Borg weapons aren't particularly strong, but I think it should still be looked out for. 

## Technical details
<!-- Summary of code changes for easier review. -->
Added a new LawSwapSystem which listens for a AfterInteractUsingEvent that (I believe, documentation on AfterInteract vs AfterInteractUsing is a bit vague, either way it still works due to how borgs function) uses an item that has a SiliconLawProvider component. If it's a valid law-haver and they have a panel that is open, it then starts a 25 second doafter to reprogram the borg's laws.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

![borglawchange1](https://github.com/user-attachments/assets/92927aa0-aefb-4bf8-ac4d-36894b475000)
![borglawchange2](https://github.com/user-attachments/assets/09dbdc43-5af8-4aeb-b968-b46e2045dbc7)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
This *should* not affect the functionality of any other interactions.
**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: Ability to reprogram borg laws if their panels are open and you have the lawboard you wish to program them to. 
