### PR TITLE
Headslug no longer has door bumper + can pilot Vim

### DIFF
--- a/Resources/Prototypes/_Goobstation/Changeling/Entities/Mobs/headcrab.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/Entities/Mobs/headcrab.yml
@@ -40,3 +40,6 @@
         - SmallMobMask
         layer:
         - SmallMobLayer
+  - type: Tag
+    tags:
+    - VimPilot


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Head Slug no longer attempts to open doors when passing under them. Also it can now pilot the Vim Mech.

## Why / Balance
The slugs are so loud for no reason because of the door bumper, and they pass under all doors anyway so they have no use for it.

It's also small enough that it should be able to pilot the Vim .

## Technical details
New TagComponent to overwrite SimpleMobBase (which has DoorBumpOpener), instead replaces with the VimPilot tag 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl:
- fix: Changeling Head Slugs no longer attempt to open doors they pass under.
- tweak: Changeling Head Slugs can now pilot the Vim.

