### PR TITLE
Fix nitrium decomposition temperature exceeding FireMinimumTemperatureToExist

### DIFF
--- a/Content.Server/Atmos/Reactions/NitriumDecompositionReaction.cs
+++ b/Content.Server/Atmos/Reactions/NitriumDecompositionReaction.cs
@@ -17,7 +17,7 @@ public sealed partial class NitriumDecompositionReaction : IGasReactionEffect
         var initNitrium = mixture.GetMoles(Gas.Nitrium);
         var initOxygen = mixture.GetMoles(Gas.Oxygen);
 
-        if (mixture.Temperature > Atmospherics.T0C + 70)
+        if (mixture.Temperature > Atmospherics.T0C + 70f)
             return ReactionResult.NoReaction;
 
         var efficiency = Math.Min(mixture.Temperature / 2984f, initNitrium);
@@ -36,7 +36,7 @@ public sealed partial class NitriumDecompositionReaction : IGasReactionEffect
         var energyReleased = efficiency * Atmospherics.NitriumDecompositionEnergy;
         var heatCap = atmosphereSystem.GetHeatCapacity(mixture, true);
         if (heatCap > Atmospherics.MinimumHeatCapacity)
-            mixture.Temperature = Math.Max((mixture.Temperature * heatCap + energyReleased) / heatCap, Atmospherics.TCMB);
+            mixture.Temperature = Math.Min(Atmospherics.T0C + 98.8f, Math.Max((mixture.Temperature * heatCap + energyReleased) / heatCap, Atmospherics.TCMB));
 
         return ReactionResult.Reacting;
     }


### PR DESCRIPTION
## About the PR
Prevents nitrium decomposition sometimes exceeding 100C. This prevents it from being used as an ignition source for tank bombs. 

## Why / Balance
It was never meant to exceed 70C for this reason, but is capable of going above that temperature at smaller scales. 

## Technical details
Changes NitriumDecompositionReaction so that it will not in any cases exceed 100C

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None

**Changelog**
:cl:
- fix: Fixed nitrium decomposition sometimes exceeding 100C
