### PR TITLE
Scrubber Quick Select/Deselect Buttons

### DIFF
--- a/Content.Client/Atmos/Monitor/UI/Widgets/ScrubberControl.xaml
+++ b/Content.Client/Atmos/Monitor/UI/Widgets/ScrubberControl.xaml
@@ -29,7 +29,18 @@
                 <Collapsible Margin="2 2 2 2">
                     <CollapsibleHeading Title="Gas filters" />
                     <CollapsibleBody Margin="20 0 0 0">
-                        <GridContainer HorizontalExpand="True" Name="CGasContainer" Columns="3" />
+                        <!-- Assmos changes start -->
+                        <BoxContainer Orientation="Vertical">
+                            <BoxContainer Orientation="Horizontal" HorizontalExpand="True" Margin="0 0 0 5">
+                                <GridContainer HorizontalExpand="True" Columns="3" Margin="0 5 0 0">
+                                    <Button Name="CSelectAllButton" HorizontalExpand="True" Text="{Loc 'Select All'}" />
+                                    <Button Name="CDeselectAllButton" HorizontalExpand="True" Text="{Loc 'Deselect All'}" />
+                                    <Control HorizontalExpand="True" />
+                                </GridContainer>
+                            </BoxContainer>
+                            <GridContainer HorizontalExpand="True" Name="CGasContainer" Columns="3" Margin="0 5 0 0" /> <!-- Revert to just this line to undo changes -->
+                        </BoxContainer>
+                        <!-- Assmos changes end -->
                     </CollapsibleBody>
                 </Collapsible>
             </BoxContainer>

--- a/Content.Client/Atmos/Monitor/UI/Widgets/ScrubberControl.xaml.cs
+++ b/Content.Client/Atmos/Monitor/UI/Widgets/ScrubberControl.xaml.cs
@@ -77,6 +77,11 @@ public sealed partial class ScrubberControl : BoxContainer
             ScrubberDataCopied?.Invoke(_data);
         };
 
+        // Assmos changes start here
+        CSelectAllButton.OnPressed += _ => SelectAllGases();
+        CDeselectAllButton.OnPressed += _ => DeselectAllGases();
+        // End of Assmos changes
+
         foreach (var value in Enum.GetValues<Gas>())
         {
             var gasButton = new Button
@@ -122,4 +127,26 @@ public sealed partial class ScrubberControl : BoxContainer
             _gasControls[value].Pressed = data.FilterGases.Contains(value);
         }
     }
+
+    // Assmos changes start here
+    private void SelectAllGases()
+    {
+        foreach (var (gas, button) in _gasControls)
+        {
+            button.Pressed = true;
+            _data.FilterGases.Add(gas);
+        }
+        ScrubberDataChanged?.Invoke(_address, _data);
+    }
+
+    private void DeselectAllGases()
+    {
+        foreach (var (_, button) in _gasControls)
+        {
+            button.Pressed = false;
+        }
+        _data.FilterGases.Clear();
+        ScrubberDataChanged?.Invoke(_address, _data);
+    }
+    // Assmos changes end
 }

--- a/Content.Client/Atmos/Monitor/UI/Widgets/ScrubberControl.xaml.cs
+++ b/Content.Client/Atmos/Monitor/UI/Widgets/ScrubberControl.xaml.cs
@@ -131,6 +131,7 @@ public sealed partial class ScrubberControl : BoxContainer
     // Assmos changes start here
     private void SelectAllGases()
     {
+        _data.FilterGases.Clear();
         foreach (var (gas, button) in _gasControls)
         {
             button.Pressed = true;

--- a/runclient.bat
+++ b/runclient.bat
@@ -1,2 +1,3 @@
 @echo off
 dotnet run --project Content.Client
+pause

--- a/runclient.bat
+++ b/runclient.bat
@@ -1,3 +1,2 @@
 @echo off
 dotnet run --project Content.Client
-pause


### PR DESCRIPTION
## About the PR
Added Select All and Deselect All buttons to air alarms gas filter settings for scrubbers. 

## Why / Balance
Quality of life

## Technical details
Adds buttons. Entirely client-side. 

## Media
![image](https://github.com/user-attachments/assets/fab31005-a9e2-4421-a302-35e0a7f59b9b)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None

**Changelog**
:cl: 
- tweak: Added 'select all' and 'deselect all' buttons to the gas filters drop down menu on air alarms
