### PR TITLE
BZ rework

### DIFF
--- a/Content.Server/_Funkystation/Atmos/Reactions/BZProductionReaction.cs
+++ b/Content.Server/_Funkystation/Atmos/Reactions/BZProductionReaction.cs
@@ -1,22 +1,23 @@
+using Content.Server.Atmos;
 using Content.Server.Atmos.EntitySystems;
 using Content.Shared.Atmos;
 using Content.Shared.Atmos.Reactions;
 using JetBrains.Annotations;
 
-namespace Content.Server.Atmos.Reactions;
+namespace Content.Server._Funkystation.Atmos.Reactions;
 
 /// <summary>
 ///     Assmos - /tg/ gases
 ///     Forms BZ from mixing Plasma and Nitrous Oxide at low pressure. Also decomposes Nitrous Oxide when there are more than 3 parts Plasma per N2O.
 /// </summary>
 [UsedImplicitly]
-public sealed partial class BZFormationReaction : IGasReactionEffect
+public sealed partial class BZProductionReaction : IGasReactionEffect
 {
     public ReactionResult React(GasMixture mixture, IGasMixtureHolder? holder, AtmosphereSystem atmosphereSystem, float heatScale)
     {
         if (mixture.Temperature > 20f && mixture.GetMoles(Gas.HyperNoblium) >= 5f)
             return ReactionResult.NoReaction;
-        
+
         var initN2O = mixture.GetMoles(Gas.NitrousOxide);
         var initPlasma = mixture.GetMoles(Gas.Plasma);
         var pressure = mixture.Pressure;
@@ -26,18 +27,18 @@ public sealed partial class BZFormationReaction : IGasReactionEffect
         var ratioEfficiency = Math.Min(initN2O / initPlasma, 1f); // less n2o than plasma gives lower rates
         var bzFormed = Math.Min(0.01f * ratioEfficiency * environmentEfficiency, Math.Min(initN2O * 2.5f, initPlasma * 1.25f));
 
-        var nitrousOxideDecomposed =  Math.Max(4f * (initPlasma / (initN2O + initPlasma) - 0.75f), 0);
+        var nitrousOxideDecomposed = Math.Max(4f * (initPlasma / (initN2O + initPlasma) - 0.75f), 0);
         var nitrogenAdded = 0f;
         var oxygenAdded = 0f;
-        if (nitrousOxideDecomposed > 0) 
+        if (nitrousOxideDecomposed > 0)
         {
             var amountDecomposed = 0.4f * bzFormed * nitrousOxideDecomposed;
             nitrogenAdded = amountDecomposed;
             oxygenAdded = 0.5f * amountDecomposed;
         }
-        var bzAdded = bzFormed * (1f-nitrousOxideDecomposed);
+        var bzAdded = bzFormed * (1f - nitrousOxideDecomposed);
         var n2oRemoved = 0.4f * bzFormed;
-        var plasmaRemoved = 0.8f * bzFormed * (1f-nitrousOxideDecomposed);
+        var plasmaRemoved = 0.8f * bzFormed * (1f - nitrousOxideDecomposed);
 
         if (n2oRemoved > initN2O || plasmaRemoved > initPlasma)
             return ReactionResult.NoReaction;
@@ -48,7 +49,7 @@ public sealed partial class BZFormationReaction : IGasReactionEffect
         mixture.AdjustMoles(Gas.Oxygen, oxygenAdded);
         mixture.AdjustMoles(Gas.BZ, bzAdded);
 
-        var energyReleased = bzFormed * (Atmospherics.BZFormationEnergy + nitrousOxideDecomposed);
+        var energyReleased = bzFormed * (Atmospherics.BZProductionEnergy + nitrousOxideDecomposed);
         var heatCap = atmosphereSystem.GetHeatCapacity(mixture, true);
         if (heatCap > Atmospherics.MinimumHeatCapacity)
             mixture.Temperature = Math.Max((mixture.Temperature * heatCap + energyReleased) / heatCap, Atmospherics.TCMB);

--- a/Content.Server/_Funkystation/EntityEffects/EffectConditions/LingCondition.cs
+++ b/Content.Server/_Funkystation/EntityEffects/EffectConditions/LingCondition.cs
@@ -13,7 +13,6 @@ public sealed partial class LingCondition : EntityEffectCondition
 
     public override string GuidebookExplanation(IPrototypeManager prototype)
     {
-        return Loc.GetString("reagent-effect-condition-guidebook-ling",
-            ("condition", Loc.GetString("reagent-effect-condition-guidebook-ling-condition")));
+        return Loc.GetString("reagent-effect-condition-guidebook-ling");
     }
 }

--- a/Content.Server/_Funkystation/EntityEffects/EffectConditions/LingCondition.cs
+++ b/Content.Server/_Funkystation/EntityEffects/EffectConditions/LingCondition.cs
@@ -1,0 +1,19 @@
+using Content.Shared.Changeling;
+using Content.Shared.EntityEffects;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._Funkystation.EntityEffects.EffectConditions;
+
+public sealed partial class LingCondition : EntityEffectCondition
+{
+    public override bool Condition(EntityEffectBaseArgs args)
+    {
+        return args.EntityManager.HasComponent<ChangelingComponent>(args.TargetEntity);
+    }
+
+    public override string GuidebookExplanation(IPrototypeManager prototype)
+    {
+        return Loc.GetString("reagent-effect-condition-guidebook-ling",
+            ("condition", Loc.GetString("reagent-effect-condition-guidebook-ling-condition")));
+    }
+}

--- a/Content.Server/_Funkystation/EntityEffects/Effects/AdjustLingChemicals.cs
+++ b/Content.Server/_Funkystation/EntityEffects/Effects/AdjustLingChemicals.cs
@@ -12,7 +12,7 @@ public sealed partial class AdjustLingChemicals : EntityEffect
     protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
         => Loc.GetString("reagent-effect-guidebook-adjust-ling-chemicals",
             ("chance", Probability),
-            ("amount", MathF.Abs(Amount)),
+            ("amount", Amount),
             ("deltasign", Amount >= 0 ? 1 : -1));
 
     public override void Effect(EntityEffectBaseArgs args)

--- a/Content.Server/_Funkystation/EntityEffects/Effects/AdjustLingChemicals.cs
+++ b/Content.Server/_Funkystation/EntityEffects/Effects/AdjustLingChemicals.cs
@@ -1,0 +1,36 @@
+using Content.Shared.Changeling;
+using Content.Shared.EntityEffects;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server._Funkystation.EntityEffects.Effects;
+
+public sealed partial class AdjustLingChemicals : EntityEffect
+{
+    [DataField]
+    public float Amount;
+
+    protected override string? ReagentEffectGuidebookText(IPrototypeManager prototype, IEntitySystemManager entSys)
+        => Loc.GetString("reagent-effect-guidebook-adjust-ling-chemicals",
+            ("chance", Probability),
+            ("amount", MathF.Abs(Amount)),
+            ("deltasign", Amount >= 0 ? 1 : -1));
+
+    public override void Effect(EntityEffectBaseArgs args)
+    {
+        if (!args.EntityManager.TryGetComponent<ChangelingComponent>(args.TargetEntity, out var lingComp))
+            return;
+
+        float scale = 1f;
+        if (args is EntityEffectReagentArgs reagentArgs)
+        {
+            scale = reagentArgs.Scale.Float();
+        }
+
+        float chemicalChange = Amount * scale;
+        lingComp.Chemicals = MathF.Max(0f, lingComp.Chemicals + chemicalChange);
+
+        lingComp.Chemicals = MathF.Min(lingComp.Chemicals, lingComp.MaxChemicals);
+
+        args.EntityManager.Dirty(args.TargetEntity, lingComp);
+    }
+}

--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -323,7 +323,7 @@ namespace Content.Shared.Atmos
         /// <summary>
         ///     The amount of energy 1 mole of BZ forming from N2O and plasma releases.
         /// </summary>
-        public const float BZFormationEnergy = 80e3f; // Assmos - /tg/ gases
+        public const float BZProductionEnergy = 80e3f; // Assmos - /tg/ gases
 
         /// <summary>
         ///     The amount of energy 1 mol of Healium forming from BZ and frezon releases.

--- a/Resources/Locale/en-US/guidebook/chemistry/conditions.ftl
+++ b/Resources/Locale/en-US/guidebook/chemistry/conditions.ftl
@@ -71,3 +71,5 @@ reagent-effect-condition-guidebook-blood-reagent-threshold =
     }
 
 reagent-effect-condition-guidebook-this-reagent = this reagent
+
+reagent-effect-condition-guidebook-ling = the target is a changeling

--- a/Resources/Locale/en-US/guidebook/chemistry/effects.ftl
+++ b/Resources/Locale/en-US/guidebook/chemistry/effects.ftl
@@ -420,3 +420,18 @@ reagent-effect-guidebook-add-to-chemicals =
         [1] to
         *[-1] from
     } the solution
+
+reagent-effect-guidebook-adjust-ling-chemicals =
+    { $chance ->
+        [1] { $deltasign ->
+                [1] Adds
+                *[-1] Removes
+            }
+        *[other] { $deltasign ->
+                    [1] add
+                    *[-1] remove
+                 }
+    } {NATURALFIXED($amount, 2)} units of changeling chemicals { $deltasign ->
+        [1] to
+        *[-1] from
+    } the metabolizer

--- a/Resources/Locale/en-US/reagents/meta/toxins.ftl
+++ b/Resources/Locale/en-US/reagents/meta/toxins.ftl
@@ -81,3 +81,6 @@ reagent-desc-lipolicide = A powerful toxin that will destroy fat cells, massivel
 
 reagent-name-mechanotoxin = mechanotoxin
 reagent-desc-mechanotoxin = A neurotoxin used as venom by some species of spider. Degrades movement when built up.
+
+reagent-name-bz-metabolites = BZ Metabolites
+reagent-desc-bz-metabolites = A byproduct of BZ that disrupts changeling chemical reserves.

--- a/Resources/Prototypes/Atmospherics/reactions.yml
+++ b/Resources/Prototypes/Atmospherics/reactions.yml
@@ -93,7 +93,7 @@
 
  # Assmos - /tg/ gases
 - type: gasReaction
-  id: bzFormation
+  id: bzProduction
   priority: 2
   maximumTemperature: 313.149 # Atmospherics.FireMinimumTemperatureToExist - 60
   minimumRequirements:
@@ -107,7 +107,7 @@
   - 10    # n2o
   - 0     # frezon
   effects:
-  - !type:BZFormationReaction {}
+  - !type:BZProductionReaction {}
 
 - type: gasReaction
   id: HealiumProduction

--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -400,7 +400,7 @@
         conditions:
         - !type:ReagentThreshold
           reagent: BZ
-          min: 0.5
+          min: 0.3
         - !type:OrganType
           type: Slime
           shouldHave: false
@@ -408,20 +408,19 @@
         ignoreResistances: true
         damage:
           types:
-            Asphyxiation: 10
-            Poison: 1.5
+            Cellular: 0.005
       - !type:GenericStatusEffect
         conditions:
         - !type:ReagentThreshold
           reagent: BZ
-          min: 0.3
+          min: 0.2
         - !type:OrganType
           type: Slime
           shouldHave: false
         key: SeeingRainbows
         component: SeeingRainbows
         type: Add
-        time: 165
+        time: 9
         refresh: false
       - !type:Emote
         conditions:
@@ -488,6 +487,13 @@
         component: ForcedSleeping
         time: 10
         type: Add
+      - !type:AddReagentToBlood
+        conditions:
+        - !type:ReagentThreshold
+          reagent: BZ
+          min: 0.2
+        reagent: BZMetabolites
+        amount: 1.8
 
 - type: reagent
   id: Healium

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -713,3 +713,22 @@
           shouldHave: false
         walkSpeedModifier: 0.4
         sprintSpeedModifier: 0.4
+
+# Assmos - /tg/ gases
+- type: reagent
+  id: BZMetabolites
+  name: reagent-name-bz-metabolites
+  group: Toxins
+  desc: reagent-desc-bz-metabolites
+  flavor: bitter
+  color: "#b19cd9"
+  physicalDesc: reagent-physical-desc-gaseous
+  metabolisms:
+    Poison:
+      effects:
+      - !type:AdjustLingChemicals
+        conditions:
+        - !type:ReagentThreshold
+          reagent: BZMetabolites
+          min: 0.2
+        amount: -8

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -722,12 +722,13 @@
   desc: reagent-desc-bz-metabolites
   flavor: bitter
   color: "#b19cd9"
-  physicalDesc: reagent-physical-desc-gaseous
+  physicalDesc: reagent-physical-desc-nondescript
   metabolisms:
     Poison:
       effects:
       - !type:AdjustLingChemicals
         conditions:
+        - !type:LingCondition {}
         - !type:ReagentThreshold
           reagent: BZMetabolites
           min: 0.2


### PR DESCRIPTION
## About the PR
This PR changes BZ to more closely follow the original ss13 concept. The only reason for BZ's current mechanics is that whateverusername0 was trying to get BZ accepted upstream, and after being asked to make several changes, ultimately had it denied. 

BZ will now be far less dangerous. Rather than asphyxiation and poison damage, it will now do very minor cell damage. It's seeing rainbows effects are also much weaker, but as it can be inhaled for longer periods of time without serious damage, it is much more viable for getting high, This aligns more with it's use for religious enlightenment. 

BZ is still a threat however to any ling's that happen to breathe it in. When even the slightest amount of BZ is inhaled by a changeling, it will create BZ metabolites in their blood, rapidly draining their chemicals. 

This PR also tidies up BZ code. 

## Why / Balance
The changes to BZ were arbitrary and not based on anything. They were just attempts to find something wrong with the original concept. This brings BZ back in line with what it originally was meant to be. 

## Technical details
Created a new entity effect and condition. The condition checks to see if the entity being affected is a changeling. The effect adjusts chemicals by the given amount. 

BZ has been changed to no longer cause asphyxiation and poison damage. It now causes very minor cellular damage and has a very minor seeing rainbows effect. 

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None

**Changelog**
:cl:
- tweak: BZ no longer causes asphyxiation and poison damage, instead causes minor cellular damage and rapidly drains ling's chemicals
