### PR TITLE
tweak(antag): Adding light to special Blob Tiles

### DIFF
--- a/Resources/Prototypes/_Goobstation/Blob/blob_tiles.yml
+++ b/Resources/Prototypes/_Goobstation/Blob/blob_tiles.yml
@@ -97,6 +97,12 @@
     raffle:
       settings: default
   - type: GhostTakeoverAvailable
+  - type: PointLight
+    radius: 1.5
+    energy: 2
+    softness: 1
+    offset: "0, 0"
+    color: "#FFD800"
 
 - type: entity
   parent: BaseBlob
@@ -200,6 +206,12 @@
         - map: [ "enum.DamageStateVisualLayers.BaseUnshaded" ]
           state: blob_glow_special
 #          shader: unshaded
+    - type: PointLight
+      radius: 1.5
+      energy: 0.5
+      softness: 1
+      offset: "0, 0"
+      color: "#FFD800"
 
 - type: entity
   parent: BaseBlob
@@ -239,6 +251,12 @@
           state: blob_glow_special
 #          shader: unshaded
         - state: blob_resource_overlay
+    - type: PointLight
+      radius: 1.5
+      energy: 0.5
+      softness: 1
+      offset: "0, 0"
+      color: "#FFD800"
 
 - type: entity
   parent: BaseBlob
@@ -279,6 +297,12 @@
           state: blob_node_glow
 #          shader: unshaded
         - state: blob_node_overlay
+    - type: PointLight
+      radius: 1.5
+      energy: 0.5
+      softness: 1
+      offset: "0, 0"
+      color: "#FFD800"
 
 - type: entity
   parent: BaseBlob


### PR DESCRIPTION
## About the PR
Added a glowing effect to some blob tiles: Blob Core, Blob Factory tile, Blob Node tile and Blob Resource tile. Blob Core tile is more visible than the others.

## Why / Balance
Generally, blob is a lot more dangerous when it's already grown to medium sizes. Blobs often start in maintenance and dark places, where it's hard to see them. Fighting against that is too annoying. While the crew could throw flares and the like, you don't have an infinite supply of them. Now the crew doesn't have to worry about light and focus on the fight strategically - trying to hurt the blob where it hurts, while the Blob player(s) must account for defense, reinforcements and positioning. In theory, this should make the rounds more fun, give "clutch 1000 IQ plays" to the crewmembers, and remove possible boring stalemates.

## Technical details
Just added a new PointLight component. 

## Media
That's how this looks.
![Content Client_cSxI1Duwaq](https://github.com/user-attachments/assets/db61459b-6110-464b-b5e9-92a0b728896f)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**

:cl: AnjaSpiral

- tweak: Added a slight glow to blob tiles for better visibility.

