### PR TITLE
Hide DoAfter for Heretic influence draining

### DIFF
--- a/Content.Server/_Goobstation/Heretic/EntitySystems/EldritchInfluenceSystem.cs
+++ b/Content.Server/_Goobstation/Heretic/EntitySystems/EldritchInfluenceSystem.cs
@@ -33,7 +33,10 @@ public sealed partial class EldritchInfluenceSystem : EntitySystem
         {
             MagicItemActive = ev.Handled,
         };
-        var dargs = new DoAfterArgs(EntityManager, user, 10f, doAfter, influence, influence);
+        var dargs = new DoAfterArgs(EntityManager, user, 10f, doAfter, influence, influence)
+        {
+            Hidden = true,
+        };
         _popup.PopupEntity(Loc.GetString("heretic-influence-start"), influence, user);
         return _doafter.TryStartDoAfter(dargs);
     }


### PR DESCRIPTION
## About the PR
Heretic no longer shows their DoAfter to everyone when draining influence.

## Why / Balance
It is very easy to recognize a heretic draining an influence because of the DoAfter popup that spawns. The intention is to allow heretics to be sneaky when draining influence in the open space. You can still identify a heretic draining an influence if he chooses to carry his book open to gain more points.

## Technical details
Changed the bool Hidden of the DoAfter to true.

## Requirements
- [ X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- tweak: Heretic influence drain DoAfter are no longer visible to others.
