### PR TITLE
Make rogue ascended zombie immune

### DIFF
--- a/Resources/Prototypes/_Impstation/CosmicCult/Mobs/astralforms.yml
+++ b/Resources/Prototypes/_Impstation/CosmicCult/Mobs/astralforms.yml
@@ -133,6 +133,7 @@
   - type: MovementAlwaysTouching
   - type: CanMoveInAir
   - type: CombatMode
+  - type: ZombieImmune
   - type: Bloodstream
     bloodMaxVolume: 650
     bloodReagent: Entropy


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
The Rogue Ascended mid-round antag currently can currently be made into a zombie, this doesn't really make sense. This gives them the ZombieImmune component to prevent it.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl:
- fix: The Rogue Ascended can no longer be turned into a zombie.
