### PR TITLE
Update space law relating to mind shields, deconversion, red alert

### DIFF
--- a/Resources/ServerInfo/Funkystation/Guidebook/AlertLevel/RedAlert.xml
+++ b/Resources/ServerInfo/Funkystation/Guidebook/AlertLevel/RedAlert.xml
@@ -25,13 +25,13 @@
 
   [bold]General Crew:[/bold]
 
-  All personnel are required to maximize their Suit Sensors;
+  All personnel are required to maximize their Suit Sensors. Personnel in violation of this order may be charged with Endangerment;
 
-  Unless their job demands it, personnel are forbidden from entering maintenance tunnels. Personnel in violation of this order may be charged with trespassing;
+  Unless their job demands it, personnel are forbidden from entering maintenance tunnels. Personnel in violation of this order may be charged with Secure Trespassing;
 
   Visitors to the station (anyone with Civilian-level access) are to remain inside the Bar, Library or Dormitories for the duration of Code Red;
 
   Personnel are to follow the instructions of Security staff, so long as they are within the bounds of Space Law and are not acting against the general well-being of the station and its crew. Failure to do so may lead to their arrest for Creating a Workplace Hazard.
 
-  Crewmembers in maintenance without proper reason or authorization may be detained for trespassing.
+  Crewmembers in maintenance without proper reason or authorization may be detained for Secure Trespassing.
 </Document>

--- a/Resources/ServerInfo/Guidebook/Security/SpaceLaw.xml
+++ b/Resources/ServerInfo/Guidebook/Security/SpaceLaw.xml
@@ -25,7 +25,9 @@
 
   [bold]Mind Shields[/bold]: Mind Shields can be administered to any inmate who is clearly brainwashed. Unlike standard implantation, you may hold a prisoner until they are issued a Mind Shield, so long as it's done in a timely fashion. If a suspect refuses to cooperate or the implant fails to function they can be charged with Refusal of Mental Shielding.
 
-  A crewmate can refuse a Mind Shield if they are not imprisoned for committing a crime.
+  Under normal circumstances, a crewmate can refuse a Mind Shield if they are not imprisoned for committing a crime.
+
+  [bold]However, when there is a known threat to the station that utilizes mass brainwashing or mind control, crewmates must submit to a Mind Shield if ordered by Security. Failure to comply is to be treated as Refusal of Mental Shielding.[/bold]
 
   # Removal
 
@@ -39,6 +41,8 @@
   [bold]Accessory, Attempting, And Intention:[/bold] If someone intentionally, knowingly and substantially assists someone in enacting a crime they can be charged with the relevant crimes, such as an engineer giving someone tools, who says they are going to break into an area. Same goes for a clear and solid attempt at a crime, or a person who shows clear intent to act out a crime, such as a syndicate nuclear operative arming a nuke but getting arrested before it goes off, they can still be charged with terrorism. Does not apply to crimes that have an attempted listing already, like attempted murder.
 
   [bold]Stackable Crimes:[/bold] Crimes are to be considered 'stackable' in the sense that if you charge someone with two or more different crimes, you should combine the times you would give them for each crime.
+
+  [bold]External Influences:[/bold] Crimes committed while under the mental control of another individual or entity are to be pardoned once a clear and successful deconversion occurs.
 
   [bold]Executions:[/bold] Executions may be authorized by the Captain / acting Captain after a trial has been conducted. Executions may also be approved by CentComm, following formal contact.
 

--- a/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SpaceLaw.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/SpaceLaw/SpaceLaw.xml
@@ -25,7 +25,9 @@
 
   [bold]Mind Shields[/bold]: Mind Shields can be administered to any inmate who is clearly brainwashed. Unlike standard implantation, you may hold a prisoner until they are issued a Mind Shield, so long as it's done in a timely fashion. If a suspect refuses to cooperate or the implant fails to function they can be charged with Refusal of Mental Shielding.
 
-  A crewmate can refuse a Mind Shield if they are not imprisoned for committing a crime.
+  Under normal circumstances, a crewmate can refuse a Mind Shield if they are not imprisoned for committing a crime.
+
+  [bold]However, when there is a known threat to the station that utilizes mass brainwashing or mind control, crewmates must submit to a Mind Shield if ordered by Security. Failure to comply is to be treated as Refusal of Mental Shielding.[/bold]
 
   # Removal
 
@@ -39,6 +41,8 @@
   [bold]Accessory, Attempting, And Intention:[/bold] If someone intentionally, knowingly and substantially assists someone in enacting a crime they can be charged with the relevant crimes, such as an engineer giving someone tools, who says they are going to break into an area. Same goes for a clear and solid attempt at a crime, or a person who shows clear intent to act out a crime, such as a syndicate nuclear operative arming a nuke but getting arrested before it goes off, they can still be charged with terrorism. Does not apply to crimes that have an attempted listing already, like attempted murder.
 
   [bold]Stackable Crimes:[/bold] Crimes are to be considered 'stackable' in the sense that if you charge someone with two or more different crimes, you should combine the times you would give them for each crime.
+
+  [bold]External Influences:[/bold] Crimes committed while under the mental control of another individual or entity are to be pardoned once a clear and successful deconversion occurs.
 
   [bold]Executions:[/bold] Executions may be authorized by the Captain / acting Captain after a trial has been conducted. Executions may also be approved by CentComm, following formal contact.
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Space Law updates!

Under certain circumstances, Mind Shield Implantation is no longer deniable (a known threat is revealed that is committing mass brainwashing/mind control, such as Revs, Blood Cult, etc.)

Crew members that have been de-converted can no longer be sentenced for their crimes if a clear de-conversion takes place (Revs de-converting by dropping to the floor + remembering allegiance, Blood Cultists being de-converted by Chaplain Holy Water and losing the eyes/halo, etc). 

Trespassing in Maints during Red Alert is now Secure Trespassing, instead of Trespassing. Both so it is actually worth it time-wise for Security to enforce this order, and so maybe people actually respect this part of alert procedure.

Not having Suit Coords on Red now has a defined crime attached to it (Endangerment), rather than just being vague and hand-wavey about it.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl:
- tweak: Space Law | Specifically when a threat that utilizes mass brainwashing is revealed, Security may now lawfully Mind Shield anyone, regardless of if they have committed a crime.
- tweak: Space Law | Crew members are now officially pardoned of their crimes committed while brainwashed upon a successful de-conversion (Revs/Cult/etc)
- tweak: Alert Procedure | Maints Trespassing on Red Alert is now charged as Secure Trespassing, rather than Trespassing.
- tweak: Alert Procedure | Not having suit coordinates on during Red Alert now has a defined crime attached to it, Endangerment.
