### PR TITLE
general BSO tweaks.

### DIFF
--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
@@ -19,9 +19,18 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-ntr-centcom
   canBeAntag: false
-  accessGroups:
-  - AllAccess
   access:
+  - Security
+  - Brig
+  - External
+  - Cryogenics
+  - Cargo
+  - Maintenance
+  - Engineering
+  - Atmospherics
+  - Medical
+  - Research
+  - Command
   - CentralCommand
   special:
   - !type:AddImplantSpecial
@@ -42,6 +51,5 @@
     pocket1: UniqueBlueshieldOfficerLockerTeleporter
   storage:
     back:
-    - BoxSurvivalSlots
     - Flash
     - BluespaceLifelineImplanter #DeathAcidifierImplanter

--- a/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Jobs/Command/blueshield_officer.yml
@@ -19,16 +19,9 @@
   joinNotifyCrew: true
   supervisors: job-supervisors-ntr-centcom
   canBeAntag: false
+  accessGroups:
+  - AllAccess
   access:
-  - Security
-  - Brig
-  - External
-  - Cryogenics
-  - Maintenance
-  - Engineering
-  - Medical
-  - Research
-  - Command
   - CentralCommand
   special:
   - !type:AddImplantSpecial
@@ -44,7 +37,7 @@
     eyes: ClothingEyesGlassesMedSec
     gloves: ClothingHandsGlovesCombat
     id: ERTSecurityPDA
-    ears: ClothingHeadsetAltCommand
+    ears: ClothingHeadsetAltCentCom
     belt: ClothingBeltSecurityFilled
     pocket1: UniqueBlueshieldOfficerLockerTeleporter
   storage:


### PR DESCRIPTION
## About the PR
Gives the Blueshield Cargo and Atmos access, gives Blueshield a CentComm radio, removes Blueshield's extra survival box.

## Why / Balance
BSO's job is to protect command and CentralCommand VIPs. Currently they can't communicate with just the other centcomm employees, and they also can't access a lot of the station where Command members could be harmed. Ex: CE gets killed in atmos, and BSO slams their fists against the glass atmos airlock, sobbing while they watch the atmosians drag the CE into the burn chamber.

## Media
![{AC24ABF1-218C-4BA4-B969-1D190AE7BA84}](https://github.com/user-attachments/assets/0dc6e13c-35c5-4aa7-8af7-4fff47da2c5a)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Granted Blueshield extra access, and a centcomm overear headset.
- fix: Removed Blueshield's extra survival box.

