### PR TITLE
Fix 'Makeshift' header in Medicalpatches.xml

### DIFF
--- a/Resources/ServerInfo/_Goobstation/Guidebook/Medical/Medicalpatches.xml
+++ b/Resources/ServerInfo/_Goobstation/Guidebook/Medical/Medicalpatches.xml
@@ -25,7 +25,7 @@ Some medkits contain prefilled patches. These hold 30 units and transfers 0.25 u
 ### Large
 The large patch holds 60 units and transfers them one unit at a time. 
 However the large patch also transfers 15% of its chemicals upon use (10 units if full)
-=
+
 ### Makeshift
 The makeshift patch can hold 15 units and transfer 1 unit every 2 seconds.
 However it can be crafted by hand and filled manually without a chemmaster


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Very minor guidebook fix I noticed while reading the medical guidebook
<!-- ## Why / Balance
Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

<!-- ## Technical details
Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Before fix (current round):
![image](https://github.com/user-attachments/assets/185515ea-e192-4656-9c01-73d7e4ad512a)

After fix:
![image](https://github.com/user-attachments/assets/f2293ae2-fd9a-4b89-9da9-33a920e6edeb)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
too minor to warrent cl
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
