### PR TITLE
Reduce map pool from 19 to 8

### DIFF
--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -6,7 +6,7 @@
   - FlandHighPop
   - Cluster
   - Omega
-  - Barratry
+  - Origin
   - Box
   - Bagel
 

--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -1,26 +1,13 @@
 - type: gameMapPool
   id: DefaultMapPool
   maps:
-  - Amber
-  - Atlas
-  - Bagel
-  - Box
-  - Cluster
-  #- Cog # Goobstation - cog is broken
-  - Core
-  - Elkridge
-  - Fland
-  - Marathon
-  - Meta
-  - Oasis
-  - Omega
-  - Origin
-  - Saltern
-  - Packed
-  #- Reach # funkystation - operation revive lrp
-  - roid_outpost
-  #- Train - Train is pain
+  - Reach # funky station - for lowpop enjoyers
+  - Barratry
   - FlandHighPop
-  - OasisHighPop
-  #- Barratry # Harmony - Barratry 2.0 - Funkystation - Barratrauma
-  - Kettle
+  - Cluster
+  - Omega
+  - Barratry
+  - Box
+  - Bagel
+
+


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This PR reduces the amount of maps in rotation, trying to offer a good mix between low, medium, and high pop maps.

## Why / Balance
The quality of maps is difficult to ensure when we have so many and so much custom content when compared to Wizden or other forks. We are also going to be including several roles that are not present in upstream and this is the best way to ensure that all maps can reach the same level of quality that is demanded.

Generally, our goal is to up the amount of maint tunnels in these maps and try to give antags more room to breathe, as we feel that a lack of maints tunnels and places to hide hinder the antag experience.

Below are my reasonings for picking these maps, other maintainers and members of the community are free to comment:

Reach: fun map for low pop and is only expected to be used on servers like Scarlet or Marisa

Barratry: Barratry has been ported over from Harmony, and is a usable map. Some things missing in this map are the NTR/BSO rooms, the SM, and other atmos goodies. These will be mapped in before this rotation is live.

Fland: Map with a good amount of maintenance, plenty of room for tiding and perfectly capable of supporting a higher population game.

Cluster: Great low-med pop map that includes all the necessary goodies. It does lack in maintenance tunnels, which will be expanded upon in later PR's.

Omega: Another great low-med pop map. Has more space to fuck around in than Cluster, but more maintenance and empty rooms would be nice for tider gimmicks.

Origin: Great high pop map that has by far the most maintenance tunnels on Funky Station. SS14 map viewer won't show that.

Bagel: Classic. My personal favorite map that is capable of supporting mid and high pop. With the recent maints expansions as well, it makes for a great map that gives antags plenty of room.

Box: Another classic. Funky Box has had its maints expanded and has been the preferred map to test antags like Cosmic and Blood cult, and gives departments plenty of breathing room to do fun stuff. Probably the most maints in a map by far.

## Technical details
proto `DefaultMapPool` now has 8 maps instead of 19.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: Reach, Barratry, Fland, Cluster, Omega, Origin, Bagel, and Box are now the only maps in rotation.