### PR TITLE
bluespace gas vendor bug fix

### DIFF
--- a/Content.Server/_Funkystation/Atmos/EntitySystems/BluespaceVendorSystem.cs
+++ b/Content.Server/_Funkystation/Atmos/EntitySystems/BluespaceVendorSystem.cs
@@ -53,6 +53,17 @@ public sealed class BluespaceVendorSystem : EntitySystem
     {
         // Ensure container
         _slots.AddItemSlot(uid, vendor.TankContainerName, vendor.GasTankSlot);
+
+        // Check for linked sender
+        if (TryComp<BluespaceGasUtilizerComponent>(uid, out var utilizer) && utilizer.BluespaceSender != null)
+        {
+            if (TryComp<BluespaceSenderComponent>(utilizer.BluespaceSender.Value, out var sender))
+            {
+                vendor.BluespaceGasMixture = sender.BluespaceGasMixture;
+                vendor.BluespaceSenderConnected = true;
+            }
+        }
+
         DirtyUI(uid, vendor);
     }
 
@@ -132,7 +143,7 @@ public sealed class BluespaceVendorSystem : EntitySystem
     private void DirtyUI(EntityUid uid,
         BluespaceVendorComponent? vendor = null)
     {
-        if (!Resolve(uid, ref vendor))
+        if (!Resolve(uid, ref vendor) || !HasComp<MetaDataComponent>(uid))
             return;
 
         string? tankLabel = null;

--- a/Resources/Maps/_Funkystation/bagel.yml
+++ b/Resources/Maps/_Funkystation/bagel.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 247.2.0
   forkId: ""
   forkVersion: ""
-  time: 04/22/2025 22:25:22
-  entityCount: 27388
+  time: 04/14/2025 01:47:07
+  entityCount: 27380
 maps:
 - 3201
 grids:
@@ -11786,12 +11786,6 @@ entities:
     - type: Transform
       pos: 27.5,-5.5
       parent: 60
-    - type: Door
-      secondsUntilStateChange: -45.30895
-      state: Opening
-    - type: DeviceLinkSource
-      lastSignals:
-        DoorStatus: True
 - proto: AirlockArmoryGlassLocked
   entities:
   - uid: 1467
@@ -11888,7 +11882,7 @@ entities:
       pos: -29.5,37.5
       parent: 60
     - type: Door
-      secondsUntilStateChange: -52677.34
+      secondsUntilStateChange: -49741.348
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -17355,128 +17349,6 @@ entities:
       rot: 3.141592653589793 rad
       pos: -8.5,-14.5
       parent: 60
-- proto: BluespaceSender
-  entities:
-  - uid: 14701
-    components:
-    - type: Transform
-      pos: -29.5,41.5
-      parent: 60
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-    - type: Pullable
-      prevFixedRotation: True
-    - type: DeviceLinkSource
-      linkedPorts:
-        15158:
-        - BluespaceSender: BluespaceGasUtilizer
-        27384:
-        - BluespaceSender: BluespaceGasUtilizer
-        15162:
-        - BluespaceSender: BluespaceGasUtilizer
-        15569:
-        - BluespaceSender: BluespaceGasUtilizer
-        27387:
-        - BluespaceSender: BluespaceGasUtilizer
-        27382:
-        - BluespaceSender: BluespaceGasUtilizer
-        7576:
-        - BluespaceSender: BluespaceGasUtilizer
-        11337:
-        - BluespaceSender: BluespaceGasUtilizer
-        7577:
-        - BluespaceSender: BluespaceGasUtilizer
-- proto: BluespaceVendor
-  entities:
-  - uid: 7576
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 18.5,-14.5
-      parent: 60
-    - type: BluespaceVendor
-      bluespaceSenderConnected: True
-    - type: BluespaceGasUtilizer
-      bluespaceSender: 14701
-  - uid: 7577
-    components:
-    - type: Transform
-      pos: 4.5,-21.5
-      parent: 60
-    - type: BluespaceVendor
-      bluespaceSenderConnected: True
-    - type: BluespaceGasUtilizer
-      bluespaceSender: 14701
-  - uid: 11337
-    components:
-    - type: Transform
-      pos: 25.5,-3.5
-      parent: 60
-    - type: BluespaceVendor
-      bluespaceSenderConnected: True
-    - type: BluespaceGasUtilizer
-      bluespaceSender: 14701
-  - uid: 15158
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -35.5,-25.5
-      parent: 60
-    - type: BluespaceVendor
-      bluespaceSenderConnected: True
-    - type: BluespaceGasUtilizer
-      bluespaceSender: 14701
-  - uid: 15162
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 34.5,22.5
-      parent: 60
-    - type: BluespaceVendor
-      bluespaceSenderConnected: True
-    - type: BluespaceGasUtilizer
-      bluespaceSender: 14701
-  - uid: 15569
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 30.5,6.5
-      parent: 60
-    - type: BluespaceVendor
-      bluespaceSenderConnected: True
-    - type: BluespaceGasUtilizer
-      bluespaceSender: 14701
-  - uid: 27382
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -14.5,-56.5
-      parent: 60
-    - type: BluespaceVendor
-      bluespaceSenderConnected: True
-    - type: BluespaceGasUtilizer
-      bluespaceSender: 14701
-  - uid: 27384
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -30.5,6.5
-      parent: 60
-    - type: BluespaceVendor
-      bluespaceSenderConnected: True
-    - type: BluespaceGasUtilizer
-      bluespaceSender: 14701
-  - uid: 27387
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 46.5,-12.5
-      parent: 60
-    - type: BluespaceVendor
-      bluespaceSenderConnected: True
-    - type: BluespaceGasUtilizer
-      bluespaceSender: 14701
 - proto: BodyBag
   entities:
   - uid: 2049
@@ -77333,13 +77205,6 @@ entities:
     - type: Transform
       pos: 4.4056315,-9.4877825
       parent: 60
-- proto: Electrolyzer
-  entities:
-  - uid: 27388
-    components:
-    - type: Transform
-      pos: -30.5,41.5
-      parent: 60
 - proto: EmergencyLight
   entities:
   - uid: 4955
@@ -124414,6 +124279,11 @@ entities:
     - type: Transform
       pos: -23.5,-21.5
       parent: 60
+  - uid: 11337
+    components:
+    - type: Transform
+      pos: 4.5,-21.5
+      parent: 60
   - uid: 16443
     components:
     - type: Transform
@@ -129103,10 +128973,20 @@ entities:
     - type: Transform
       pos: 53.5,-4.5
       parent: 60
+  - uid: 15158
+    components:
+    - type: Transform
+      pos: -27.5,32.5
+      parent: 60
   - uid: 15159
     components:
     - type: Transform
       pos: -29.5,32.5
+      parent: 60
+  - uid: 15569
+    components:
+    - type: Transform
+      pos: -25.5,32.5
       parent: 60
   - uid: 16065
     components:
@@ -136320,6 +136200,16 @@ entities:
     - type: Transform
       pos: -57.47909,29.480463
       parent: 60
+  - uid: 14701
+    components:
+    - type: Transform
+      pos: -25.5,32.5
+      parent: 60
+  - uid: 15162
+    components:
+    - type: Transform
+      pos: -27.5,32.5
+      parent: 60
   - uid: 15200
     components:
     - type: Transform
@@ -136354,16 +136244,6 @@ entities:
     components:
     - type: Transform
       pos: -120.32988,15.381494
-      parent: 60
-  - uid: 27385
-    components:
-    - type: Transform
-      pos: -29.500172,32.503723
-      parent: 60
-  - uid: 27386
-    components:
-    - type: Transform
-      pos: -29.500172,32.503723
       parent: 60
 - proto: SheetUranium
   entities:

--- a/Resources/Maps/_Funkystation/bagel.yml
+++ b/Resources/Maps/_Funkystation/bagel.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 247.2.0
   forkId: ""
   forkVersion: ""
-  time: 04/14/2025 01:47:07
-  entityCount: 27380
+  time: 04/22/2025 22:25:22
+  entityCount: 27388
 maps:
 - 3201
 grids:
@@ -11786,6 +11786,12 @@ entities:
     - type: Transform
       pos: 27.5,-5.5
       parent: 60
+    - type: Door
+      secondsUntilStateChange: -45.30895
+      state: Opening
+    - type: DeviceLinkSource
+      lastSignals:
+        DoorStatus: True
 - proto: AirlockArmoryGlassLocked
   entities:
   - uid: 1467
@@ -11882,7 +11888,7 @@ entities:
       pos: -29.5,37.5
       parent: 60
     - type: Door
-      secondsUntilStateChange: -49741.348
+      secondsUntilStateChange: -52677.34
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -17349,6 +17355,128 @@ entities:
       rot: 3.141592653589793 rad
       pos: -8.5,-14.5
       parent: 60
+- proto: BluespaceSender
+  entities:
+  - uid: 14701
+    components:
+    - type: Transform
+      pos: -29.5,41.5
+      parent: 60
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+    - type: Pullable
+      prevFixedRotation: True
+    - type: DeviceLinkSource
+      linkedPorts:
+        15158:
+        - BluespaceSender: BluespaceGasUtilizer
+        27384:
+        - BluespaceSender: BluespaceGasUtilizer
+        15162:
+        - BluespaceSender: BluespaceGasUtilizer
+        15569:
+        - BluespaceSender: BluespaceGasUtilizer
+        27387:
+        - BluespaceSender: BluespaceGasUtilizer
+        27382:
+        - BluespaceSender: BluespaceGasUtilizer
+        7576:
+        - BluespaceSender: BluespaceGasUtilizer
+        11337:
+        - BluespaceSender: BluespaceGasUtilizer
+        7577:
+        - BluespaceSender: BluespaceGasUtilizer
+- proto: BluespaceVendor
+  entities:
+  - uid: 7576
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 18.5,-14.5
+      parent: 60
+    - type: BluespaceVendor
+      bluespaceSenderConnected: True
+    - type: BluespaceGasUtilizer
+      bluespaceSender: 14701
+  - uid: 7577
+    components:
+    - type: Transform
+      pos: 4.5,-21.5
+      parent: 60
+    - type: BluespaceVendor
+      bluespaceSenderConnected: True
+    - type: BluespaceGasUtilizer
+      bluespaceSender: 14701
+  - uid: 11337
+    components:
+    - type: Transform
+      pos: 25.5,-3.5
+      parent: 60
+    - type: BluespaceVendor
+      bluespaceSenderConnected: True
+    - type: BluespaceGasUtilizer
+      bluespaceSender: 14701
+  - uid: 15158
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -35.5,-25.5
+      parent: 60
+    - type: BluespaceVendor
+      bluespaceSenderConnected: True
+    - type: BluespaceGasUtilizer
+      bluespaceSender: 14701
+  - uid: 15162
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 34.5,22.5
+      parent: 60
+    - type: BluespaceVendor
+      bluespaceSenderConnected: True
+    - type: BluespaceGasUtilizer
+      bluespaceSender: 14701
+  - uid: 15569
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 30.5,6.5
+      parent: 60
+    - type: BluespaceVendor
+      bluespaceSenderConnected: True
+    - type: BluespaceGasUtilizer
+      bluespaceSender: 14701
+  - uid: 27382
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -14.5,-56.5
+      parent: 60
+    - type: BluespaceVendor
+      bluespaceSenderConnected: True
+    - type: BluespaceGasUtilizer
+      bluespaceSender: 14701
+  - uid: 27384
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -30.5,6.5
+      parent: 60
+    - type: BluespaceVendor
+      bluespaceSenderConnected: True
+    - type: BluespaceGasUtilizer
+      bluespaceSender: 14701
+  - uid: 27387
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: 46.5,-12.5
+      parent: 60
+    - type: BluespaceVendor
+      bluespaceSenderConnected: True
+    - type: BluespaceGasUtilizer
+      bluespaceSender: 14701
 - proto: BodyBag
   entities:
   - uid: 2049
@@ -77205,6 +77333,13 @@ entities:
     - type: Transform
       pos: 4.4056315,-9.4877825
       parent: 60
+- proto: Electrolyzer
+  entities:
+  - uid: 27388
+    components:
+    - type: Transform
+      pos: -30.5,41.5
+      parent: 60
 - proto: EmergencyLight
   entities:
   - uid: 4955
@@ -124279,11 +124414,6 @@ entities:
     - type: Transform
       pos: -23.5,-21.5
       parent: 60
-  - uid: 11337
-    components:
-    - type: Transform
-      pos: 4.5,-21.5
-      parent: 60
   - uid: 16443
     components:
     - type: Transform
@@ -128973,20 +129103,10 @@ entities:
     - type: Transform
       pos: 53.5,-4.5
       parent: 60
-  - uid: 15158
-    components:
-    - type: Transform
-      pos: -27.5,32.5
-      parent: 60
   - uid: 15159
     components:
     - type: Transform
       pos: -29.5,32.5
-      parent: 60
-  - uid: 15569
-    components:
-    - type: Transform
-      pos: -25.5,32.5
       parent: 60
   - uid: 16065
     components:
@@ -136200,16 +136320,6 @@ entities:
     - type: Transform
       pos: -57.47909,29.480463
       parent: 60
-  - uid: 14701
-    components:
-    - type: Transform
-      pos: -25.5,32.5
-      parent: 60
-  - uid: 15162
-    components:
-    - type: Transform
-      pos: -27.5,32.5
-      parent: 60
   - uid: 15200
     components:
     - type: Transform
@@ -136244,6 +136354,16 @@ entities:
     components:
     - type: Transform
       pos: -120.32988,15.381494
+      parent: 60
+  - uid: 27385
+    components:
+    - type: Transform
+      pos: -29.500172,32.503723
+      parent: 60
+  - uid: 27386
+    components:
+    - type: Transform
+      pos: -29.500172,32.503723
       parent: 60
 - proto: SheetUranium
   entities:

--- a/Resources/Prototypes/_Funkystation/Entities/Structures/Machines/BluespaceGas/bluespace_gas.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Structures/Machines/BluespaceGas/bluespace_gas.yml
@@ -6,15 +6,12 @@
   placement:
     mode: SnapgridCenter
   components:
-  - type: Physics
-    bodyType: Static
   - type: Transform
+    noRot: false
     anchored: true
-    noRot: true
   - type: Sprite
     sprite: _Funkystation/Structures/Piping/Atmospherics/bluespacegassender.rsi
     granularLayersRendering: true
-    snapCardinals: true
     layers:
     - state: off
       map: [ "enum.PowerDeviceVisualLayers.Powered" ]
@@ -120,6 +117,7 @@
           True: { state: on }
           False: { state: off }
   - type: WallMount
+    arc: 180
   - type: Destructible
     thresholds:
     - trigger:

--- a/runclient.bat
+++ b/runclient.bat
@@ -1,2 +1,3 @@
 @echo off
 dotnet run --project Content.Client
+pause

--- a/runclient.bat
+++ b/runclient.bat
@@ -1,3 +1,2 @@
 @echo off
 dotnet run --project Content.Client
-pause


### PR DESCRIPTION
## About the PR
This PR fixes an issue with the bluespace gas vendor that forced the game back to lobby on map load. The vendors can now be safely mapped in and linked to their sender before the map initializes. 

## Why / Balance
Bugfix

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None

**Changelog**
:cl:
- fix: Fixed issue with bluespace gas vendors forcing the game back to lobby.
