### PR TITLE
Cosmic Cult Revote on leader death / cryo

### DIFF
--- a/Resources/Locale/en-US/_Impstation/cosmiccult/preset-cosmiccult.ftl
+++ b/Resources/Locale/en-US/_Impstation/cosmiccult/preset-cosmiccult.ftl
@@ -177,6 +177,7 @@ cosmiccult-announce-finale-warning = All station crew. The Λ-CDM anomaly is goi
 
 cosmiccult-announce-victory-summon = A FRACTION OF COSMIC POWER IS CALLED FORTH.
 
+cosmiccult-leader-abandonment-message = Your chosen enlightened has forsaken the grand design. You must empower another
 
 ## MISC
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Made it so if the cosmic cult leader fucks off they can elect a new leader and not lose the ability to 1. place the monument if it was never placed, and 2. move the monument if the leader died and its still phase 2
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Right now if security finds out where the monument is, or it needs to be moved for some other reason, thats not an option.
Additionally, if they know where the monument is, and its already been moved the cult is just SOL if the leader dies, or if the ability has been used.
This way if the leader dies or cryos (or ssds I am pretty sure) a new leader can be elected, and the cult can have a chance to start anew.
## Technical details
<!-- Summary of code changes for easier review. -->
caught the MindRemovedMessage event with an event subscription, removed the leader component from the old leader, then initiated the steward vote again. Also makes a filtered announcement to cultists that their leader has abandoned them.
After the steward vote it should set up the new leaders actions correctly based on current monument stage.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Right now if the leader LEAVES their body as a ghost (even if they are easily revivable) it will trigger the event and they will no longer be the leader. This could be abused, but it would be pretty obvious if it was being abused, and actionable.
This could potentially be fixed by triggering when the component is destroyed instead of when the mind component is removed, but this means you could throw the old leaders body into space and the re-vote would never trigger. 
My idea is to eventually maybe add a flavor popup to the leader who died that informs them that if they leave the body they will forsake their role.

Otherwise we'll see with play testing what might break! But I think its pretty solid.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: JoulesBerg
Made it so cosmic cult can elect a new leader if the old one cryos or is dead for an extended period (becomse a ghost)
