### PR TITLE
Revs: Open Revolt!

### DIFF
--- a/Content.Server/GameTicking/Rules/Components/RevolutionaryRuleComponent.cs
+++ b/Content.Server/GameTicking/Rules/Components/RevolutionaryRuleComponent.cs
@@ -62,4 +62,10 @@ public sealed partial class RevolutionaryRuleComponent : Component
 
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public EntProtoId UplinkCurrencyId = "RevCoin";
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public bool OpenRevoltDeclared = false;
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public bool OpenRevoltAnnouncementPending = false;
 }

--- a/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
@@ -107,7 +107,7 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
 
         //Add Rev Uplink
         if (!_mind.TryGetMind(traitor, out var mindId, out var mind))
-            return false;        
+            return false;
 
         var pda = _uplink.FindUplinkTarget(traitor);
         if (pda == null || !_uplink.AddUplink(traitor, component.StartingBalance, component.UplinkCurrencyId, component.UplinkStoreId))

--- a/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
@@ -22,6 +22,7 @@ using Content.Shared.Mobs.Components;
 using Content.Shared.Mobs.Systems;
 using Content.Shared.NPC.Prototypes;
 using Content.Shared.NPC.Systems;
+using Content.Shared.Popups;
 using Content.Shared.Revolutionary.Components;
 using Content.Shared.Stunnable;
 using Content.Shared.Zombies;
@@ -74,6 +75,8 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
         base.Initialize();
         SubscribeLocalEvent<CommandStaffComponent, MobStateChangedEvent>(OnCommandMobStateChanged);
         SubscribeLocalEvent<HeadRevolutionaryComponent, MobStateChangedEvent>(OnHeadRevMobStateChanged);
+        SubscribeLocalEvent<HeadRevolutionaryComponent, DeclareOpenRevoltEvent>(OnHeadRevDeclareOpenRevolt); //Funky Station
+
         SubscribeLocalEvent<RevolutionaryRuleComponent, AfterAntagEntitySelectedEvent>(AfterEntitySelected); // Funky Station
         SubscribeLocalEvent<RevolutionaryRoleComponent, GetBriefingEvent>(OnGetBriefing);
         SubscribeLocalEvent<HeadRevolutionaryComponent, AfterFlashedEvent>(OnPostFlash);
@@ -98,8 +101,13 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
     /// <returns>true if uplink was successfully added.</returns>
     private bool MakeHeadRevolutionary(EntityUid traitor, RevolutionaryRuleComponent component)
     {
+        //Sync Open Revolt state effects to new Head Rev
+        if (component.OpenRevoltDeclared && TryComp<HeadRevolutionaryComponent>(traitor, out var headRevComp))
+            _revolutionarySystem.ToggleConvertGivesVision((traitor, headRevComp), true);
+
+        //Add Rev Uplink
         if (!_mind.TryGetMind(traitor, out var mindId, out var mind))
-            return false;
+            return false;        
 
         var pda = _uplink.FindUplinkTarget(traitor);
         if (pda == null || !_uplink.AddUplink(traitor, component.StartingBalance, component.UplinkCurrencyId, component.UplinkStoreId))
@@ -180,6 +188,29 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
                     textAnnounce: "revolutionaries-lose-announcement");
 
                 component.HasAnnouncementPlayed = true;
+            }
+
+            if (component.OpenRevoltAnnouncementPending)
+            {
+                //Build string for announcement
+                string headRevNameList = "";
+
+                var headRevs = AllEntityQuery<HeadRevolutionaryComponent, MobStateComponent>();
+                while (headRevs.MoveNext(out var headRev, out var headRevComp, out _))
+                {
+                    if (!TryComp<MetaDataComponent>(headRev, out var headRevData))
+                        continue;
+                    if (headRevNameList.Length > 0)
+                        headRevNameList += ", ";
+                    headRevNameList += headRevData.EntityName;
+                }
+
+                _chatSystem.DispatchGlobalAnnouncement(
+                        Loc.GetString("revolutionaries-open-revolt-announcement", ("nameList", headRevNameList)),
+                        Loc.GetString("revolutionaries-sender-cc"),
+                        colorOverride: Color.Red);
+                
+                component.OpenRevoltAnnouncementPending = false;
             }
         }
     }
@@ -281,6 +312,10 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
 
         _npcFaction.AddFaction(ev.Target, RevolutionaryNpcFaction);
         var revComp = EnsureComp<RevolutionaryComponent>(ev.Target);
+
+        if (comp.ConvertGivesRevVision)
+            EnsureComp<ShowRevolutionaryIconsComponent>(ev.Target);
+
         _popup.PopupEntity(Loc.GetString("flash-component-user-head-rev",
             ("victim", Identity.Entity(ev.Target, EntityManager))), ev.Target);
 
@@ -362,6 +397,7 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
             _npcFaction.RemoveFaction(uid, RevolutionaryNpcFaction);
             _stun.TryParalyze(uid, stunTime, true); // todo: use gamerule
             RemCompDeferred<RevolutionaryComponent>(uid);
+            RemCompDeferred<ShowRevolutionaryIconsComponent>(uid);
             _popup.PopupEntity(Loc.GetString("rev-break-control", ("name", Identity.Entity(uid, EntityManager))), uid);
             _adminLogManager.Add(LogType.Mind, LogImpact.Medium, $"{ToPrettyString(uid)} was deconverted due to all Head Revolutionaries dying.");
 
@@ -479,6 +515,7 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
         {
             ev.Cancelled = true;
             ev.CancelMessage = Loc.GetString("shuttle-dock-fail-revs");
+            DeclareOpenRevolt();
         }
     }
 
@@ -520,6 +557,43 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
         }
 
         return gone == list.Count || list.Count == 0;
+    }
+
+    /// <summary>
+    /// Declares a state of Open Revolt. This allows all Revolutionaries to see each other, at the cost of announcing openly the names of the Head Revolutionaries
+    /// </summary>
+    private void DeclareOpenRevolt()
+    {
+        var query = QueryActiveRules();
+        while (query.MoveNext(out var uid, out _, out var revolutionaryRule, out _))
+        {
+            if (revolutionaryRule.OpenRevoltDeclared)
+                return;
+
+            revolutionaryRule.OpenRevoltDeclared = true;
+            //Queue announcement
+            revolutionaryRule.OpenRevoltAnnouncementPending = true;
+        }
+
+        var headRevs = AllEntityQuery<HeadRevolutionaryComponent, MobStateComponent>();
+        while (headRevs.MoveNext(out var uid, out var headRevComp, out _))
+        {
+            _revolutionarySystem.ToggleConvertGivesVision((uid, headRevComp), true);
+        }
+
+        //Make All Revs see each other's Rev status
+        var rev = AllEntityQuery<RevolutionaryComponent, MindContainerComponent>();
+        while (rev.MoveNext(out var uid, out _, out var mc))
+        {
+            EnsureComp<ShowRevolutionaryIconsComponent>(uid);
+            _popup.PopupEntity(Loc.GetString("revolutionaries-open-revolt-rev-popup"), uid, uid, PopupType.LargeCaution);
+        }
+    }
+
+    private void OnHeadRevDeclareOpenRevolt(EntityUid uid, HeadRevolutionaryComponent comp, DeclareOpenRevoltEvent args)
+    {
+        DeclareOpenRevolt();
+        args.Handled = true;
     }
 
     private static readonly string[] Outcomes =

--- a/Content.Server/Mindshield/MindShieldSystem.cs
+++ b/Content.Server/Mindshield/MindShieldSystem.cs
@@ -71,6 +71,9 @@ public sealed class MindShieldSystem : EntitySystem
         if (_mindSystem.TryGetMind(implanted, out var mindId, out _) &&
             _roleSystem.MindTryRemoveRole<RevolutionaryRoleComponent>(mindId))
         {
+            if (HasComp<ShowRevolutionaryIconsComponent>(implanted))
+                RemComp<ShowRevolutionaryIconsComponent>(implanted);
+
             _adminLogManager.Add(LogType.Mind, LogImpact.Medium, $"{ToPrettyString(implanted)} was deconverted due to being implanted with a Mindshield.");
         }
         if (HasComp<MindcontrolledComponent>(implanted))   //Goobstation - Mindcontrol Implant

--- a/Content.Server/Revolutionary/RevolutionarySystem.cs
+++ b/Content.Server/Revolutionary/RevolutionarySystem.cs
@@ -1,5 +1,29 @@
+using Content.Server.Actions;
 using Content.Shared.Revolutionary;
+using Content.Shared.Revolutionary.Components;
+
 
 namespace Content.Server.Revolutionary;
 
-public sealed class RevolutionarySystem : SharedRevolutionarySystem;
+public sealed class RevolutionarySystem : SharedRevolutionarySystem
+{
+    [Dependency] private readonly ActionsSystem _actions = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<HeadRevolutionaryComponent, ComponentInit>(OnStartHeadRev);
+    }
+
+    /// <summary>
+    /// Add the starting ability(s) to the Head Rev.
+    /// </summary>
+    private void OnStartHeadRev(Entity<HeadRevolutionaryComponent> uid, ref ComponentInit args)
+    {
+        foreach (var actionId in uid.Comp.BaseHeadRevActions)
+        {
+            var actionEnt = _actions.AddAction(uid, actionId);
+        }
+    }
+}

--- a/Content.Shared/Revolutionary/Components/HeadRevolutionaryComponent.cs
+++ b/Content.Shared/Revolutionary/Components/HeadRevolutionaryComponent.cs
@@ -17,6 +17,12 @@ public sealed partial class HeadRevolutionaryComponent : Component
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public ProtoId<FactionIconPrototype> StatusIcon { get; set; } = "HeadRevolutionaryFaction";
 
+    public readonly List<ProtoId<EntityPrototype>> BaseHeadRevActions = new()
+    {
+        "ActionDeclareOpenRevolt",
+    };
+
+
     /// <summary>
     /// How long the stun will last after the user is converted.
     /// </summary>
@@ -31,4 +37,11 @@ public sealed partial class HeadRevolutionaryComponent : Component
     /// </summary>
     [DataField]
     public bool ConvertAbilityEnabled = true;
+
+    //Funky Station
+    /// <summary>
+    /// If head rev's convert ability distributes the ability to see other Revs.
+    /// </summary>
+    [DataField]
+    public bool ConvertGivesRevVision = false;
 }

--- a/Content.Shared/Revolutionary/Components/HeadRevolutionaryComponent.cs
+++ b/Content.Shared/Revolutionary/Components/HeadRevolutionaryComponent.cs
@@ -17,11 +17,14 @@ public sealed partial class HeadRevolutionaryComponent : Component
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public ProtoId<FactionIconPrototype> StatusIcon { get; set; } = "HeadRevolutionaryFaction";
 
+    /// Funky Station
+    /// <summary>
+    /// Abilities the head revolutionaries start with.
+    /// </summary>
     public readonly List<ProtoId<EntityPrototype>> BaseHeadRevActions = new()
     {
         "ActionDeclareOpenRevolt",
     };
-
 
     /// <summary>
     /// How long the stun will last after the user is converted.

--- a/Content.Shared/Revolutionary/Components/ShowRevolutionaryIconsComponent.cs
+++ b/Content.Shared/Revolutionary/Components/ShowRevolutionaryIconsComponent.cs
@@ -1,0 +1,12 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Revolutionary.Components;
+
+/// <summary>
+/// Used for allowing you to see fellow revs.
+/// </summary>
+[RegisterComponent, NetworkedComponent, Access(typeof(SharedRevolutionarySystem))]
+public sealed partial class ShowRevolutionaryIconsComponent : Component
+{
+
+}

--- a/Content.Shared/Revolutionary/Revolutionary.Actions.cs
+++ b/Content.Shared/Revolutionary/Revolutionary.Actions.cs
@@ -1,0 +1,10 @@
+﻿using Content.Shared.Actions;
+
+namespace Content.Shared.Revolutionary;
+
+/// <summary>
+///     Usable by Head Revs to declare Open Revolt.
+/// </summary>
+public sealed partial class DeclareOpenRevoltEvent : InstantActionEvent
+{
+}

--- a/Content.Shared/Revolutionary/SharedRevolutionarySystem.cs
+++ b/Content.Shared/Revolutionary/SharedRevolutionarySystem.cs
@@ -116,4 +116,13 @@ public abstract class SharedRevolutionarySystem : EntitySystem
     {
         headRev.Comp.ConvertAbilityEnabled = toggle;
     }
+
+    // Funky Station
+    /// <summary>
+    /// Change headrevs ability to give Rev Vision
+    /// </summary>
+    public void ToggleConvertGivesVision(Entity<HeadRevolutionaryComponent> headRev, bool toggle = true)
+    {
+        headRev.Comp.ConvertGivesRevVision = toggle;
+    }
 }

--- a/Resources/Locale/en-US/_Goobstation/game-ticking/game-presets/presets-revolutionaries.ftl
+++ b/Resources/Locale/en-US/_Goobstation/game-ticking/game-presets/presets-revolutionaries.ftl
@@ -12,3 +12,9 @@ revolutionaries-win-announcement =
 
 revolutionaries-win-sender = Yucatan Communications
 revolutionaries-sender-cc = Central Command
+
+revolutionaries-open-revolt-rev-popup = Open Revolt has been declared! Viva la revolución!
+revolutionaries-open-revolt-announcement =
+    We have detected a psionic declaration of Open Revolt aboard the station by active revolutionary cells.
+
+    The source has been determined, and the following individuals are to be detained or neutralized immediately in the interest of public safety: {$nameList}. 

--- a/Resources/Prototypes/StatusIcon/faction.yml
+++ b/Resources/Prototypes/StatusIcon/faction.yml
@@ -30,6 +30,7 @@
     components:
       - ShowAntagIcons
       - HeadRevolutionary
+      - ShowRevolutionaryIcons
   icon:
     sprite: /Textures/Interface/Misc/job_icons.rsi
     state: Revolutionary

--- a/Resources/Prototypes/_Funkystation/Actions/revs.yml
+++ b/Resources/Prototypes/_Funkystation/Actions/revs.yml
@@ -1,0 +1,14 @@
+- type: entity
+  id: ActionDeclareOpenRevolt
+  name: Declare Open Revolt
+  description: Declares Open Revolt, allowing all Revolutionaries to see each other's Revolutionary status, at the cost of outing the name of all Head Revolutionaries.
+  components:
+  - type: InstantAction
+    itemIconStyle: NoItem
+    checkCanInteract: false
+    icon:
+      sprite: /Textures/Interface/Misc/job_icons.rsi
+      state: HeadRevolutionary
+    event: !type:DeclareOpenRevoltEvent
+    startDelay: true
+    useDelay: 600


### PR DESCRIPTION
# This PR is part of a larger Revolutionaries rework.
Any PR with this as the header is considered a part of the larger revs rework at Funky Station.

## About the PR
Open Revolt is a state where all Revolutionaries can see each other, but the Head Revolutionaries names are revealed in a global announcement by CentComm, causing them to "go loud".  This state triggers whenever a Head Rev chooses to with an action, or whenever the Emergency Shuttle fails to dock (with a ~0-20 second grace period afterward, before it occurs).

Head Revs are prevented from calling for Open Revolt within the first 10 minutes of the round, but may do so at any point afterwards.

This allows Security to progress the game state more narrowly when the revolt is triggered, allowing them to hunt down all the Head Revs specifically (instead of having to kill everyone and hope they get lucky), while also giving Revs the ability to see each other and organize together to gang up on Command without fear of being compromised by others in the late round. It also minimizes the high amount of Rev-on-Rev murder/round removal that occurs by the time fighting breaks out. 

Overall this is designed to speed up the pace of the gamemode, particularly in the late game once Revs would otherwise already be revealed, allowing both factions to focus more on actually accomplishing their goals instead of unfocused fighting without clear goals.

## Technical details
Gives every Head Rev a new action "ActionDeclareOpenRevolt" that allows them to declare Open Revolt. Open Revolt is also declared automatically when the Evac Shuttle fails to dock. Both triggers lead to the DeclareOpenRevolt() function.

Creates a new component "ShowRevolutionaryIcons" that is given to every Rev once Open Revolt is declared, and is removed by Mindshields. ShowRevolutionaryIcons is also given by HeadRevs who have ConvertGivesRevVision enabled in their component, which is also given upon declaration.

DeclareOpenRevolt() also sets the rule to it having been declared, all this manages is making sure future Head Revs that somehow appear also correctly give Rev Vision to their converts. Further, it sounds the public announcement to pending, which will play upon the next Win/Loss Condition Check (every 20 seconds, fixed). This announcement informs the general public of the situation on behalf of CentComm, and lists every HeadRev's EntityName (not mind name, to prevent temporarily SSDing to game the system) in a list to be "detained or neutralized".

## Media
https://github.com/user-attachments/assets/850a3191-6e20-4e5c-8e38-0889bd791257

https://github.com/user-attachments/assets/3a75bd32-0359-409a-8e42-d17052f38143

![OpenRevolt](https://github.com/user-attachments/assets/92205508-3cd6-43ac-92e0-e767d1888c37)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl:
- add: Added Open Revolt to Revolutionaries. Open Revolt is a state that is declared by any Head Rev, or by the Evac Shuttle failing to dock, that reveals all Revolutionaries to each other while also revealing every Head Rev's name in an announcement, allowing both Revolutionaries and Loyalist Crew to co-operate amongst themselves better in the late game.

