### PR TITLE
Make "reptilian food" bounty match all reptilian foods

### DIFF
--- a/Resources/Prototypes/_Funkystation/Catalog/Bounties/bountyCategories.yml
+++ b/Resources/Prototypes/_Funkystation/Catalog/Bounties/bountyCategories.yml
@@ -480,7 +480,9 @@
     rewardPer: 1400
     whitelist:
       tags:
+      - Fruit
       - ReptilianFood
+      - Meat
     blacklist:
       tags:
       - Slice


### PR DESCRIPTION
related to #681

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
as in the title

## Why / Balance
because otherwise the bounty doesn't make sense to anyone

## Technical details
basically, synced the tags from `OrganReptilianStomach`, excluding pills and crayons

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed "Reptilian food" bounty matching only a handful of items
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
