### PR TITLE
Fixes IPC & Vulp emotes displaying for other species

### DIFF
--- a/Resources/Locale/en-US/chat/emotes.ftl
+++ b/Resources/Locale/en-US/chat/emotes.ftl
@@ -16,6 +16,7 @@ chat-emote-name-snap = Snap
 chat-emote-name-salute = Salute
 chat-emote-name-gasp = Gasp
 chat-emote-name-deathgasp = Deathgasp
+chat-emote-name-boop = Boop
 chat-emote-name-buzz = Buzz
 chat-emote-name-weh = Weh
 chat-emote-name-hew = Hew

--- a/Resources/Prototypes/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/Voice/speech_emotes.yml
@@ -336,6 +336,12 @@
 - type: emote
   id: Buzz
   name: chat-emote-name-buzz
+  whitelist:
+    tags:
+    - IPCEmotes
+    - HarpyEmotes
+    components:
+    - BorgChassis
   category: Vocal
   icon: Interface/Emotes/buzz.png
   chatMessages: ["chat-emote-msg-buzz"]
@@ -384,6 +390,12 @@
   id: Beep
   name: chat-emote-name-beep
   category: Vocal
+  whitelist:
+    tags:
+    - IPCEmotes
+    - HarpyEmotes
+    components:
+    - BorgChassis
   icon: Interface/Emotes/beep.png
   chatMessages: ["chat-emote-msg-beep"]
   chatTriggers:
@@ -395,6 +407,12 @@
 - type: emote
   id: Chime
   name: chat-emote-name-chime
+  whitelist:
+    tags:
+    - IPCEmotes
+    - HarpyEmotes
+    components:
+    - BorgChassis
   category: Vocal
   icon: Interface/Emotes/chime.png
   chatMessages: ["chat-emote-msg-chime"]
@@ -407,6 +425,12 @@
 - type: emote
   id: Buzz-Two
   name: chat-emote-name-buzztwo
+  whitelist:
+    tags:
+    - IPCEmotes
+    - HarpyEmotes
+    components:
+    - BorgChassis
   category: Vocal
   icon: Interface/Emotes/buzztwo.png
   chatMessages: ["chat-emote-msg-buzzestwo"]
@@ -425,6 +449,12 @@
 - type: emote
   id: Ping
   name: chat-emote-name-ping
+  whitelist:
+    tags:
+    - IPCEmotes
+    - HarpyEmotes
+    components:
+    - BorgChassis
   category: Vocal
   icon: Interface/Emotes/ping.png
   chatMessages: ["chat-emote-msg-ping"]
@@ -437,6 +467,10 @@
 - type: emote
   id: Yap
   name: chat-emote-name-yap
+  whitelist:
+    tags:
+    - VulpEmotes
+    - HarpyEmotes
   category: Vocal
   chatMessages: [ yaps ]
   chatTriggers:
@@ -446,7 +480,11 @@
 - type: emote
   id: Gekker
   name: chat-emote-name-gekker
-  category: Vocal  
+  whitelist:
+    tags:
+    - VulpEmotes
+    - HarpyEmotes
+  category: Vocal
   chatMessages: [ gekkers ]
   chatTriggers:
   - gekkers

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/vulpkanin.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/vulpkanin.yml
@@ -20,6 +20,7 @@
   - type: Speech
     speechSounds: Vulpkanin
     speechVerb: Vulpkanin
+    allowedEmotes: ['Yap', 'Gekker']
   - type: Sprite
     netsync: false
     noRot: true

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/ipc.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/ipc.yml
@@ -52,6 +52,12 @@
       Dead: BorgDead
   - type: TypingIndicator
     proto: robot
+  - type: Tag
+    tags:
+    - CanPilot
+    - FootstepSound
+    - DoorBumpOpener
+    - IPCEmotes
   - type: Destructible
     thresholds:
       - trigger:

--- a/Resources/Prototypes/_EinsteinEngines/Voice/speech_emotes.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Voice/speech_emotes.yml
@@ -1,6 +1,12 @@
 - type: emote
   id: SiliconDeathgasp
   name: chat-emote-name-deathgasp
+  whitelist:
+    tags:
+    - IPCEmotes
+    - HarpyEmotes
+    components:
+    - BorgChassis
   icon: Interface/Emotes/deathgasp.png
   chatMessages: ["chat-emote-msg-deathgasp-silicon"]
   chatTriggers:
@@ -9,6 +15,12 @@
 - type: emote
   id: Boop
   name: chat-emote-name-boop
+  whitelist:
+    tags:
+    - IPCEmotes
+    - HarpyEmotes
+    components:
+    - BorgChassis
   category: Vocal
   chatMessages: [ boops ]
   chatTriggers:
@@ -17,6 +29,12 @@
 - type: emote
   id: Whirr # uncategorized as it is generic
   name: chat-emote-name-whirr
+  whitelist:
+    tags:
+    - IPCEmotes
+    - HarpyEmotes
+    components:
+    - BorgChassis
   chatMessages: [ whirrs ]
   chatTriggers:
     - whirrs

--- a/Resources/Prototypes/_Funkystation/tags.yml
+++ b/Resources/Prototypes/_Funkystation/tags.yml
@@ -18,3 +18,6 @@
 
 - type: Tag
   id: SpecialWeapon
+
+- type: Tag
+  id: IPCEmotes


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixed other species' ability to click (and popping up on the emote wheel) IPC and vulp-exclusive emotes

They still work for Silicons and Harpies for the applicable emotes

## Technical details
<!-- Summary of code changes for easier review. -->
Added a new IPCEmotes tag, following what was done for Vulps, and whitelisted all relevant emotes

:cl: Miiish
- fix: Fixed IPC and Vulp emotes on the emote wheel