### PR TITLE
Add a recipe for making syrup from water and sugar

### DIFF
--- a/Resources/Prototypes/Recipes/Reactions/fun.yml
+++ b/Resources/Prototypes/Recipes/Reactions/fun.yml
@@ -245,3 +245,15 @@
     intensitySlope: 1
     maxTotalIntensity: 250
     tileBreakScale: 0.00001
+
+# funkystation
+- type: reaction
+  id: HomemadeSyrup
+  minTemp: 390
+  reactants:
+    Water:
+      amount: 1
+    Sugar:
+      amount: 1
+  products:
+    Syrup: 2


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
added a new recipe for Syrup

## Why / Balance
Syrup sucks to make, because the only source of it is draining Dionas from their sap - and realistically, mixing water and sugar should give you syrup.

## Technical details
adds a `HomemadeSyrup` recipe, with minimum temperature 390K (~120 Celsius, somewhat authentic),
and Water + Sugar as reagents

## Media

![image](https://github.com/user-attachments/assets/64c237f0-dc83-46a8-93c4-b93ed126ad2e)

![image](https://github.com/user-attachments/assets/5b6ed052-abb2-44cc-86ab-f72e97d29792)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- add: Added a recipe for homemade "vegan" syrup by mixing water and sugar.
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
