### PR TITLE
make plushies injectable so they leak onto you while you hold them

### DIFF
--- a/Content.Server/_Funkystation/LeakyObject/LeakyObjectComponent.cs
+++ b/Content.Server/_Funkystation/LeakyObject/LeakyObjectComponent.cs
@@ -1,0 +1,19 @@
+using Content.Shared.FixedPoint;
+
+[RegisterComponent]
+public sealed partial class LeakyObjectComponent : Component
+{
+    [DataField]
+    public string SolutionName = "leaky";
+    [DataField]
+    public FixedPoint2 TransferAmount = FixedPoint2.New(0.5);
+    [DataField]
+    public float LeakEfficiency = 0.5f;
+    [DataField]
+    /// <summary>
+    /// how often the object should transfer sulution
+    /// </summary>
+    public float UpdateTime = 4f;
+    [DataField]
+    public TimeSpan NextUpdate = TimeSpan.Zero;
+}

--- a/Content.Server/_Funkystation/LeakyObject/LeakyObjectSystem.cs
+++ b/Content.Server/_Funkystation/LeakyObject/LeakyObjectSystem.cs
@@ -1,0 +1,55 @@
+
+using Content.Server.Body.Components;
+using Content.Server.Body.Systems;
+using Content.Shared.Chemistry;
+using Content.Shared.Chemistry.EntitySystems;
+using Robust.Shared.Containers;
+using Robust.Shared.Timing;
+
+public sealed class LeakyObjectSystem : EntitySystem
+{
+    [Dependency] private readonly IGameTiming _timing = default!;
+    [Dependency] private readonly SharedSolutionContainerSystem _solutionContainers = default!;
+    [Dependency] private readonly SharedContainerSystem _containers = default!;
+    [Dependency] private readonly ILogManager _logManager = default!;
+    [Dependency] private readonly ReactiveSystem _reactiveSystem = default!;
+    [Dependency] private readonly BloodstreamSystem _bloodstreamSystem = default!;
+    private ISawmill _sawmill = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        _sawmill = _logManager.GetSawmill("leaking");
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        if (!_timing.IsFirstTimePredicted)
+            return;
+
+        var query = EntityManager.EntityQueryEnumerator<LeakyObjectComponent>();
+
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            if (_timing.CurTime < comp.NextUpdate)
+                continue;
+            comp.NextUpdate = _timing.CurTime + TimeSpan.FromSeconds(comp.UpdateTime);
+
+            // unlike the opinion of whoever made the smoking system, this is fine actually
+            if (!_solutionContainers.TryGetSolution(uid, comp.SolutionName, out var soln, out var solution) ||
+                !_containers.TryGetContainingContainer((uid, null, null), out var container) ||
+                !TryComp(container.Owner, out BloodstreamComponent? bloodstream))
+            {
+                continue;
+            }
+
+            var leakedSolution = _solutionContainers.SplitSolution(soln.Value, comp.TransferAmount);
+            leakedSolution.ScaleSolution(comp.LeakEfficiency);
+
+            _reactiveSystem.DoEntityReaction(container.Owner, leakedSolution, ReactionMethod.Touch);
+            _bloodstreamSystem.TryAddToChemicals(container.Owner, leakedSolution, bloodstream);
+        }
+    }
+}

--- a/Resources/Prototypes/Entities/Objects/Fun/toys.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/toys.yml
@@ -53,6 +53,11 @@
         reagents:
         - ReagentId: Fiber
           Quantity: 10
+      leaky:
+        maxVol: 20
+  - type: InjectableSolution
+    solution: leaky
+  - type: LeakyObject
   - type: ContainerContainer
     containers:
       stash: !type:ContainerSlot {}
@@ -172,6 +177,8 @@
           Quantity: 5
         - ReagentId: Fiber
           Quantity: 5
+      leaky:
+        maxVol: 20
   - type: Clothing
     quickEquip: false
     sprite: Objects/Fun/toys.rsi
@@ -348,6 +355,8 @@
           Quantity: 10
         - ReagentId: JuiceThatMakesYouWeh
           Quantity: 10
+      leaky:
+        maxVol: 20
   - type: Clothing
     quickEquip: false
     sprite: Objects/Fun/toys.rsi
@@ -444,6 +453,8 @@
           Quantity: 10
         - ReagentId: JuiceThatMakesYouWeh
           Quantity: 10
+      leaky:
+        maxVol: 20
   - type: Clothing
     slots:
     - HEAD
@@ -497,6 +508,8 @@
           Quantity: 10
         - ReagentId: JuiceThatMakesYouHew
           Quantity: 10
+      leaky:
+        maxVol: 20
   - type: Clothing
     quickEquip: false
     sprite: Objects/Fun/toys.rsi
@@ -549,6 +562,8 @@
           reagents:
           - ReagentId: Fiber
             Quantity: 10
+        leaky:
+          maxVol: 20
 
     - type: RefillableSolution
       solution: plushie


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
you can now inject plushies with 20u of reagents, which will slowly leak into anyone wearing or holding it (0.25u every 4 seconds, it removes 0.5u from the buffer but only applies 0.25u because i don't want this to be too useful, we have medical patches and smokes smh (this is adjustable in the component))

feel free to point out all the ways this is very stupid! :3  
i just think it's funny

## Why / Balance
this shouldn't affect balance, i just think it would be really funny to make a plushie that makes you weh or maybe a cancer plushie

## Technical details
added a LeakyObject system and component, changed all the plushies (BaseToy and any plushies which derive from it that override SolutionContainerManager) such that they have the new functionaliy.

## Media
![image](https://github.com/user-attachments/assets/bc7ab060-0de8-4151-8e8f-cbe698f5a15d)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: plushies are now injectable, and reagents injected will slowly and lossily pass through the skin of anyone holding the plushie.
