### PR TITLE
Added "PhysicalComposition" to the fulton whitelist 

### DIFF
--- a/Content.Shared/Salvage/Fulton/FultonComponent.cs
+++ b/Content.Shared/Salvage/Fulton/FultonComponent.cs
@@ -40,7 +40,8 @@ public sealed partial class FultonComponent : Component
         Components = new[]
         {
             "Item",
-            "Anchorable"
+            "Anchorable",
+            "PhysicalComposition"
         }
     };
 


### PR DESCRIPTION
## About the PR
Added the "PhysicalComposition" component to the whitelist in FultonComponent.cs

## Why / Balance
I did this because the broken-down generators found by salvage couldn't be fultoned, despite the functional generators being able to. As it turns out, most items in the game are covered by the Item and Anchorable tags, and I haven't found anything like a mob that has the PhysicalComposition tag.

## Technical details
See #709 

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Fixed fultons not attaching to scrap generators
