### PR TITLE
Revs: implanter draw changes, prevent rev self-mindshielding

### DIFF
--- a/Content.Shared/Implants/Components/ImplanterComponent.cs
+++ b/Content.Shared/Implants/Components/ImplanterComponent.cs
@@ -50,7 +50,7 @@ public sealed partial class ImplanterComponent : Component
     /// </summary>
     [ViewVariables(VVAccess.ReadWrite)]
     [DataField]
-    public float DrawTime = 60f;
+    public float DrawTime = 30f;
 
     /// <summary>
     /// Good for single-use injectors
@@ -90,13 +90,13 @@ public sealed partial class ImplanterComponent : Component
     public bool AllowDeimplantAll = false;
 
     /// <summary>
-    /// The subdermal implants that may be removed via this implanter
+    /// The subdermal implants that may be removed via this implanter.
     /// </summary>
     [DataField]
     public List<EntProtoId> DeimplantWhitelist = new();
 
     /// <summary>
-    /// The subdermal implants that may be removed via this implanter
+    /// The damage inflicted on a failed implant draw.
     /// </summary>
     [DataField]
     public DamageSpecifier DeimplantFailureDamage = new();
@@ -106,6 +106,12 @@ public sealed partial class ImplanterComponent : Component
     /// </summary>
     [AutoNetworkedField]
     public EntProtoId? DeimplantChosen = null;
+
+    /// <summary>
+    /// Whether or not drawing an implant deletes the implant.
+    /// </summary>
+    [DataField]
+    public bool DeimplantCrushes = false;
 
     public bool UiUpdateNeeded;
 }

--- a/Content.Shared/Implants/SharedImplanterSystem.cs
+++ b/Content.Shared/Implants/SharedImplanterSystem.cs
@@ -211,7 +211,7 @@ public abstract class SharedImplanterSystem : EntitySystem
                         continue;
                     }
 
-                    DrawImplantIntoImplanter(implanter, target, implant, implantContainer, implanterContainer, implantComp);
+                    DrawImplantIntoImplanter(implanter, target, implant, implantContainer, implanterContainer, implantComp, component);
                     permanentFound = implantComp.Permanent;
 
                     //Break so only one implant is drawn
@@ -246,11 +246,11 @@ public abstract class SharedImplanterSystem : EntitySystem
                     }
                     else
                     {
-                        DrawImplantIntoImplanter(implanter, target, implant.Value, implantContainer, implanterContainer, implantComp);
+                        DrawImplantIntoImplanter(implanter, target, implant.Value, implantContainer, implanterContainer, implantComp, component);
                         permanentFound = implantComp.Permanent;
                     }
 
-                    if (component.CurrentMode == ImplanterToggleMode.Draw && !component.ImplantOnly && !permanentFound)
+                    if (component.CurrentMode == ImplanterToggleMode.Draw && !component.ImplantOnly && !permanentFound && !component.DeimplantCrushes)
                         ImplantMode(implanter, component);
                 }
                 else
@@ -277,11 +277,13 @@ public abstract class SharedImplanterSystem : EntitySystem
         _popup.PopupEntity(failedPermanentMessage, target, user);
     }
 
-    private void DrawImplantIntoImplanter(EntityUid implanter, EntityUid target, EntityUid implant, BaseContainer implantContainer, ContainerSlot implanterContainer, SubdermalImplantComponent implantComp)
+    private void DrawImplantIntoImplanter(EntityUid implanter, EntityUid target, EntityUid implant, BaseContainer implantContainer, ContainerSlot implanterContainer, SubdermalImplantComponent implantComp, ImplanterComponent implanterComp)
     {
         _container.Remove(implant, implantContainer);
         implantComp.ImplantedEntity = null;
-        _container.Insert(implant, implanterContainer);
+
+        if (!implanterComp.DeimplantCrushes)
+            _container.Insert(implant, implanterContainer);
 
         var ev = new TransferDnaEvent { Donor = target, Recipient = implanter };
         RaiseLocalEvent(target, ref ev);

--- a/Content.Shared/Revolutionary/SharedRevolutionarySystem.cs
+++ b/Content.Shared/Revolutionary/SharedRevolutionarySystem.cs
@@ -1,8 +1,10 @@
 using Content.Shared.IdentityManagement;
+using Content.Shared.Implants;
 using Content.Shared.Mindshield.Components;
 using Content.Shared.Popups;
 using Content.Shared.Revolutionary.Components;
 using Content.Shared.Stunnable;
+using Content.Shared.Tag;
 using Robust.Shared.GameStates;
 using Robust.Shared.Player;
 using Content.Shared.Antag;
@@ -14,6 +16,7 @@ public abstract class SharedRevolutionarySystem : EntitySystem
 {
     [Dependency] private readonly SharedPopupSystem _popupSystem = default!;
     [Dependency] private readonly SharedStunSystem _sharedStun = default!;
+    [Dependency] private readonly TagSystem _tag = default!;
 
     public override void Initialize()
     {
@@ -25,6 +28,9 @@ public abstract class SharedRevolutionarySystem : EntitySystem
         SubscribeLocalEvent<RevolutionaryComponent, ComponentStartup>(DirtyRevComps);
         SubscribeLocalEvent<HeadRevolutionaryComponent, ComponentStartup>(DirtyRevComps);
         SubscribeLocalEvent<ShowAntagIconsComponent, ComponentStartup>(DirtyRevComps);
+
+        SubscribeLocalEvent<HeadRevolutionaryComponent, AddImplantAttemptEvent>(OnHeadRevImplantAttempt);
+        SubscribeLocalEvent<RevolutionaryComponent, AddImplantAttemptEvent>(OnRevImplantAttempt);
     }
 
     /// <summary>
@@ -86,6 +92,7 @@ public abstract class SharedRevolutionarySystem : EntitySystem
 
         return HasComp<ShowAntagIconsComponent>(uid);
     }
+    
     /// <summary>
     /// Dirties all the Rev components so they are sent to clients.
     ///
@@ -106,6 +113,39 @@ public abstract class SharedRevolutionarySystem : EntitySystem
         {
             Dirty(uid, comp);
         }
+    }
+
+    private void OnHeadRevImplantAttempt(Entity<HeadRevolutionaryComponent> headRev, ref AddImplantAttemptEvent args)
+    {
+        if (TryCancelSelfMindshield(args.User, args.Target, args.Implant))
+            args.Cancel();
+    }
+
+    private void OnRevImplantAttempt(Entity<RevolutionaryComponent> rev, ref AddImplantAttemptEvent args)
+    {
+        if (TryCancelSelfMindshield(args.User, args.Target, args.Implant))
+            args.Cancel();
+    }
+
+    /// <summary>
+    /// Prevents Revs from mindshielding themselves.
+    /// </summary>
+    /// <param name="user">Person using implanter</param>
+    /// <param name="target">Target of implanter</param>
+    /// <param name="implant">The implant</param>
+    /// <returns></returns>
+    private bool TryCancelSelfMindshield(EntityUid user, EntityUid target, EntityUid implant)
+    {
+        if (user != target)
+            return false;
+        
+        if (!TryComp<TagComponent>(implant, out var tagComp))
+            return false;
+
+        if (!_tag.HasTag(tagComp, "MindShield"))
+            return false;
+
+        return true;
     }
 
     // GoobStation

--- a/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/implanters.yml
@@ -48,7 +48,7 @@
       deimplantFailureDamage:
         types:
           Cellular: 50
-          Heat: 10
+          Heat: 40
     - type: Sprite
       sprite: Objects/Specific/Medical/implanter.rsi
       state: implanter0

--- a/Resources/Prototypes/_Goobstation/Entities/Objects/Misc/implanters.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Objects/Misc/implanters.yml
@@ -2,7 +2,7 @@
   id: BaseFastDrawImplanter
   parent: BaseImplanter
   name: fast draw implanter
-  description: A syringe with tools for quick implant removal. It has small gold stars on its body.
+  description: A syringe with tools for quick implant removal and implant crushing. It has small gold stars on its body.
   abstract: true
   components:
     - type: Sprite
@@ -16,7 +16,11 @@
           map: [ "implantOnly" ]
     - type: Implanter
       currentMode: Draw
-      drawTime: 30
+      drawTime: 15
+      deimplantFailureDamage:
+        types:
+          Heat: 20
+      deimplantCrushes: true
 
 - type: entity
   id: RevsFastDrawImplanter


### PR DESCRIPTION

## About the PR / Reasoning
Prevented Revs from Mind Shielding themselves, they should never be doing this anyway, and any circumstances of occurences are silly but highly consequential accidents or invalid actions roleplay-wise.

The Head Rev's fast draw implanter now crushes implants it removes, its purpose is removal of mind shields, and you shouldn't have to mind shield random station pets to be able to use it again.

Cut all implanter times in half, it took 5 years to draw before to prevent implant checking by Security, this problem has been highly mitigated by the specified implant draw system and self-damage on fail. As compensation for this however still, standard implanters will now deal 90 damage to the failed implanter, rather than 60, nearly critting them.

The Head Rev's fast draw implanter fail damage has been reduced to 20 heat, since nearly critting Head Revs for trying to un-mindshield people is silly when we want to encourage conversion.

## Technical details
Adds a boolean "DeimplantCrushes" to ImplanterComponent, this is false by default and only true for the fast draw implanter. SharedImplanterSystem checks this to determine draw behavior.

Revs and Head Revs will now cancel the AddImplantAttemptEvent if they are both the user and target of an implanter, and the implant in question is a Mind Shield.

## Media
Revs unable to mindshield themselves demo

https://github.com/user-attachments/assets/92291eb9-3668-49af-b62b-f75c73fd3f66

Fast Draw Implanter Crushing

https://github.com/user-attachments/assets/233edac9-5bdb-41e2-bfb6-347074ee7d5b

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl:
- tweak: Revolutionaries and Head Revolutionaries can no longer Mind Shield themselves.
- tweak: The revolutionaries' fast draw implanter now crushes any implants it draws, allowing for easier re-use.
- tweak: Implanter draw times have been cut in half. Implanters now take 30 seconds to draw, and Fast Draws now take 15 seconds to draw.
- tweak: The standard implanter now deals 90 damage on a failed draw, 50 genetic + 40 heat, instead of the previous 60.
- tweak: The fast draw implanter now only deals 20 heat damage on a failed draw, instead of the previous 60.

