### PR TITLE
Update CrystallizerSystem.cs to fix skipping temperature calculations

### DIFF
--- a/Content.Server/_Funkystation/Atmos/EntitySystems/CrystallizerSystem.cs
+++ b/Content.Server/_Funkystation/Atmos/EntitySystems/CrystallizerSystem.cs
@@ -322,7 +322,7 @@ namespace Content.Server._Funkystation.Atmos.Systems
             if (!GetRegulatorPipeMixture(uid, crystallizer, out var regulatorMix) || regulatorMix == null)
                 return;
 
-            if (regulatorMix.TotalMoles < 0.01 || crystalMix.TotalMoles <= 0)
+            if (crystalMix.TotalMoles <= 0)
                 return;
 
             float regulatorHeatCapacity = _atmos.GetHeatCapacity(regulatorMix, true);


### PR DESCRIPTION
## About the PR
Removes the minimum moles needed in the temperature regulator to perform temperature changing processes.

## Why / Balance
Fixes a bug

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None

:cl:
- fix: Crystallizer will no longer maintain temperature with a low amount of gas in it's regulator port. 
