### PR TITLE
thaven job requirements + emag interaction

### DIFF
--- a/Content.Server/_Impstation/Thaven/ThavenMoodSystem.cs
+++ b/Content.Server/_Impstation/Thaven/ThavenMoodSystem.cs
@@ -21,6 +21,7 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Content.Shared._Impstation.CCVar;
 using Content.Shared.Mind;
+using Content.Shared.Mindshield.Components;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Utility;
 
@@ -154,17 +155,9 @@ public sealed partial class ThavenMoodsSystem : SharedThavenMoodSystem
                 continue; // Skip proto if it conflicts with an existing mood
 
             // begin funky
-            // note: idk how to do this so it doesnt work ^__^
             var conflictingJobs = moodProto.JobConflicts;
             if (conflictingJobs.Contains(department))
-            {
-                Debug.WriteLine($"entity's department is: {department}. skipping {moodId}");
                 continue; // Skip proto if it conflicts with the entity's department
-            }
-            else
-            {
-                Debug.WriteLine($"entity's department is: {department}. {moodId} does not conflict.");
-            }
             // end funky
 
             proto = moodProto;
@@ -434,7 +427,9 @@ public sealed partial class ThavenMoodsSystem : SharedThavenMoodSystem
     protected override void OnEmagged(EntityUid uid, ThavenMoodsBoundComponent comp, ref GotEmaggedEvent args)
     {
         base.OnEmagged(uid, comp, ref args);
-        TryAddRandomMood(uid, WildcardDataset, comp);
+
+        if (!HasComp<MindShieldComponent>(uid)) // funky: dont emag mindshielded thavens
+            TryAddRandomMood(uid, WildcardDataset, comp);
     }
 
     // Begin DeltaV: thaven mood upsets

--- a/Content.Server/_Impstation/Thaven/ThavenMoodSystem.cs
+++ b/Content.Server/_Impstation/Thaven/ThavenMoodSystem.cs
@@ -70,6 +70,7 @@ public sealed partial class ThavenMoodsSystem : SharedThavenMoodSystem
         SubscribeLocalEvent<ThavenMoodsBoundComponent, ComponentShutdown>(OnThavenMoodShutdown);
         SubscribeLocalEvent<ThavenMoodsBoundComponent, ToggleMoodsScreenEvent>(OnToggleMoodsScreen);
         SubscribeLocalEvent<ThavenMoodsBoundComponent, BoundUIOpenedEvent>(OnBoundUIOpened);
+        SubscribeLocalEvent<RulePlayerJobsAssignedEvent>(OnJobsAssigned); // funky
         SubscribeLocalEvent<RoundRestartCleanupEvent>((_) => NewSharedMoods());
     }
 
@@ -412,6 +413,7 @@ public sealed partial class ThavenMoodsSystem : SharedThavenMoodSystem
         if (comp.LifeStage != ComponentLifeStage.Starting)
             return;
 
+        /* funky: roll moods after jobs roll
         // "Yes, and" moods
         if (TryPick(YesAndDataset, out var mood, GetActiveMoods(uid, comp), null, GetMindDepartment(uid))) // funky - check for job conflicts
             TryAddMood(uid, mood, comp, true, false);
@@ -419,6 +421,7 @@ public sealed partial class ThavenMoodsSystem : SharedThavenMoodSystem
         // "No, and" moods
         if (TryPick(NoAndDataset, out mood, GetActiveMoods(uid, comp), null, GetMindDepartment(uid))) // funky - check for job conflicts
             TryAddMood(uid, mood, comp, true, false);
+        */
 
         comp.Action = _actions.AddAction(uid, ActionViewMoods);
     }
@@ -456,6 +459,22 @@ public sealed partial class ThavenMoodsSystem : SharedThavenMoodSystem
             return unknown;
 
         return departmentProto.ID;
+    }
+
+    private void OnJobsAssigned(RulePlayerJobsAssignedEvent args)
+    {
+        var query = EntityQueryEnumerator<ThavenMoodsBoundComponent>();
+
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            // "Yes, and" moods
+            if (TryPick(YesAndDataset, out var mood, GetActiveMoods(uid, comp), null, GetMindDepartment(uid)))
+                TryAddMood(uid, mood, comp, true, false);
+
+            // "No, and" moods
+            if (TryPick(NoAndDataset, out mood, GetActiveMoods(uid, comp), null, GetMindDepartment(uid)))
+                TryAddMood(uid, mood, comp, true, false);
+        }
     }
     // end funky
 }

--- a/Content.Shared/_Impstation/Thaven/SharedThavenMoodSystem.cs
+++ b/Content.Shared/_Impstation/Thaven/SharedThavenMoodSystem.cs
@@ -1,6 +1,5 @@
 using Content.Shared.Emag.Systems;
 using Content.Shared._Impstation.Thaven.Components;
-using Content.Shared.Mindshield.Components;
 
 namespace Content.Shared._Impstation.Thaven;
 

--- a/Content.Shared/_Impstation/Thaven/SharedThavenMoodSystem.cs
+++ b/Content.Shared/_Impstation/Thaven/SharedThavenMoodSystem.cs
@@ -14,9 +14,6 @@ public abstract class SharedThavenMoodSystem : EntitySystem
     }
     protected virtual void OnEmagged(EntityUid uid, ThavenMoodsBoundComponent comp, ref GotEmaggedEvent args)
     {
-        if (HasComp<MindShieldComponent>(uid))
-            return;
-
         args.Handled = true;
     }
 }

--- a/Content.Shared/_Impstation/Thaven/SharedThavenMoodSystem.cs
+++ b/Content.Shared/_Impstation/Thaven/SharedThavenMoodSystem.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Emag.Systems;
 using Content.Shared._Impstation.Thaven.Components;
+using Content.Shared.Mindshield.Components;
 
 namespace Content.Shared._Impstation.Thaven;
 
@@ -13,6 +14,9 @@ public abstract class SharedThavenMoodSystem : EntitySystem
     }
     protected virtual void OnEmagged(EntityUid uid, ThavenMoodsBoundComponent comp, ref GotEmaggedEvent args)
     {
+        if (HasComp<MindShieldComponent>(uid))
+            return;
+
         args.Handled = true;
     }
 }

--- a/Resources/Prototypes/_Impstation/Species/Thavens/Moods/no_and.yml
+++ b/Resources/Prototypes/_Impstation/Species/Thavens/Moods/no_and.yml
@@ -141,7 +141,7 @@
   conflicts:
   - VeryReligious
   jobConflicts:
-  - Service
+  - Civilian
 
 # Punctuality is impolite. You must walk slowly at all times, and be fashionably late to any obligations.
 - type: thavenMood

--- a/Resources/Prototypes/_Impstation/Species/Thavens/Moods/no_and.yml
+++ b/Resources/Prototypes/_Impstation/Species/Thavens/Moods/no_and.yml
@@ -5,18 +5,18 @@
   id: ThavenMoodsNoAnd
   values:
   - SecretMoods
-  #- NoModernMedicine # TODO job conflicts
+  - NoModernMedicine
   - DepartmentDisapproval
-  #- DontSpeakToCommand # TODO job conflicts
+  - DontSpeakToCommand
   - DisapproveOfDrugs
   - ExcessivelyDisorganized
-  #- DetestSilicons # TODO job conflicts
+  - DetestSilicons
   - DinnerFloor
   - HugBad
   - AlwaysAlone
   - Atheist
   - Procrastinator
-  #- NoRadio # TODO job conflicts
+  - NoRadio
   - ImproperStorage
   - Ferengi
   - ToolLicense
@@ -54,6 +54,9 @@
   moodDesc: thaven-mood-no-modern-medicine-desc
   jobConflicts:
   - Medical
+  - CentralCommandSpecial
+  - CentralCommand
+  - Command
 
 # You disapprove of [DEPARTMENT]
 - type: thavenMood
@@ -125,6 +128,10 @@
   moodDesc: thaven-mood-always-alone-desc
   conflicts:
   - NeverAlone
+  jobConflicts:
+  - CentralCommandSpecial
+  - CentralCommand
+  - Command
 
 # You do not approve of organized religion. It should be dismantled or disrupted wherever possible.
 - type: thavenMood
@@ -133,6 +140,8 @@
   moodDesc: thaven-mood-atheist-desc
   conflicts:
   - VeryReligious
+  jobConflicts:
+  - Service
 
 # Punctuality is impolite. You must walk slowly at all times, and be fashionably late to any obligations.
 - type: thavenMood

--- a/Resources/Prototypes/_Impstation/Species/Thavens/Moods/wildcard.yml
+++ b/Resources/Prototypes/_Impstation/Species/Thavens/Moods/wildcard.yml
@@ -1,7 +1,7 @@
 - type: dataset
   id: ThavenMoodsWildcard
   values:
-  #- CompulsiveLiar # TODO job conflicts
+  - CompulsiveLiar
   - CompulsiveBeliever
   - PlantPacifist
   - PuddleDrinker
@@ -9,11 +9,11 @@
   - Nocrastinator
   - Pope
   - Cannibal
-  #- Outlaw # TODO job conflicts
+  - Outlaw
   #- ExtremeDepartmentDisapproval
   - LoneActor
   - Immortal
-  #- Unknown # TODO job conflicts
+  - Unknown
   - Fairy
   - VampireTalisman
   - OutsideTheBox
@@ -128,6 +128,11 @@
   id: LoneActor
   moodName: thaven-mood-lone-actor-name
   moodDesc: thaven-mood-lone-actor-desc
+  jobConflicts:
+  - CentralCommandSpecial
+  - CentralCommand
+  - Command
+  - Security
 
 # You are the center of the universe, an immortal being with no sense of time or morality. Mere mortals are like insects, fleeting and insubstantial.
 - type: thavenMood
@@ -214,6 +219,10 @@
   id: StayDead
   moodName: thaven-mood-stay-dead-name
   moodDesc: thaven-mood-stay-dead-desc
+  jobConflicts:
+  - CentralCommandSpecial
+  - CentralCommand
+  - Command
 
 # Tourist: It is customary to follow people into their departments.
 - type: thavenMood

--- a/Resources/Prototypes/_Impstation/Species/Thavens/Moods/yes_and.yml
+++ b/Resources/Prototypes/_Impstation/Species/Thavens/Moods/yes_and.yml
@@ -8,13 +8,13 @@
   - ExcessivelyOrganized
   - MostImportant
   - LeastImportant
-  #- MustDoDrugs # TODO job conflicts
+  - MustDoDrugs
   - WorshipSilicons
   - DinnerEtiquette
   - HugGood
   - NeverAlone
   - VeryReligious
-  #- OnlySpeakToCommand # TODO job conflicts
+  - OnlySpeakToCommand
   - Scheduler
   - ProperStorage
   - TheftNeutral
@@ -39,7 +39,7 @@
   - ImposterSyndrome
   - YesMan
   - Centrist
-  #- PublicSector # TODO job conflicts
+  - PublicSector
   - SpeechRestriction
 
 # You are extremely possessive of your property. Refuse to relinquish it, and if it is misplaced or stolen, it must be retrieved at all costs.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
reimplemented some moods, with job requirements for who can roll them. moods are now rolled after jobs, so if the job event doesn't run (ex. initial launch into the dev map) then thavens won't get their initial moods. shouldn't be an issue in game. mainly command thavens cant roll certain moods that would fuck up the round. also prevented thavens from being emagged if they are mindshielded (though it is still very obvious if you tried). 

this is my first time using EQEs so hopefully its okay??? plz let me know if i need to change something

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: some more thaven moods have been added, though only certain jobs can roll them
- tweak: mindshielded thavens can no longer be emagged
