### PR TITLE
Fix issue with round ending early for zombies and ruining CC roleplay…

### DIFF
--- a/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/ZombieRuleSystem.cs
@@ -140,7 +140,7 @@ public sealed class ZombieRuleSystem : GameRuleSystem<ZombieRuleComponent>
 
         // we include dead for this count because we don't want to end the round
         // when everyone gets on the shuttle.
-        if (GetInfectedFraction() >= 1) // Oops, all zombies
+        if (GetInfectedFraction() >= 1 && !_roundEnd.IsRoundEndRequested()) // Oops, all zombies
             _roundEnd.EndRound();
     }
 


### PR DESCRIPTION
… prep :(

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Made the check for 100% conversion also only trigger if there is not an active shuttle timer.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This is a self admitted mald PR. But for a good reason. Two rounds in a row CBurn/ CC roleplay has been ruined by this logic >:( 
And I think its not intentional behavior, and I disagree with it if its intended behavior. So I am fixing it.
My reasoning, if its intended and not a bug, is that CBurn being spawned at CentComm on zombie rounds is basically standard procedure, and if there is an active shuttle timer then the zombies should be allowed to make it to CC. It will potentially make some rounds longer if there is no CBurn spawned, but I think thats a valid trade off considering that when CBurn IS spawned but this bug happens it ruins a significant time investment and is just a huge disappointment for the CBurn agents and any others involved. It also makes it not possible for someone to hide off station while waiting for evac, then try to secure evac or stealth their way onto evac. So all of their prep ALSO goes out the window. Overall I just fully 100% disagree with the current logic of "All zombies? end round immediately, no questions asked". So now it will ask the question "Well, wait a sec, is there already a round end mechanic on the way?"

## Technical details
<!-- Summary of code changes for easier review. -->
The current logic was not checking if there was a current shuttle countdown to round end happening, so once everyone walked on the evac shuttle the round would end the next time CheckRoundEnd happened.


## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Uhh probably none from a technical stance? unless somewhere in the deep magiks (code) something else is borked.
Sometimes zombies might have to wait out a shuttle for the round to end, but to me that's a valid trade off to having legitimate role play / hard work thrown out a window.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: JoulesBerg
- fix: CBurn agents get to role play at centcomm now (zombie rounds should no longer end early if the shuttle has been called)