### PR TITLE
Electrolyzer power fix

### DIFF
--- a/Content.Server/_Funkystation/Atmos/Portable/ElectrolyzerSystem.cs
+++ b/Content.Server/_Funkystation/Atmos/Portable/ElectrolyzerSystem.cs
@@ -18,9 +18,8 @@ public sealed class ElectrolyzerSystem : EntitySystem
     [Dependency] private readonly PowerReceiverSystem _power = default!;
     [Dependency] private readonly SharedAppearanceSystem _appearance = default!;
     [Dependency] private readonly GasTileOverlaySystem _gasOverlaySystem = default!;
-
-    private float _lastPowerLoad = 4000f;
-    private const float MaxPowerIncrease = 100f;
+    private float _lastPowerLoad = 100f;
+    private const float MaxPowerDecrease = 50f;
 
     public override void Initialize()
     {
@@ -79,10 +78,8 @@ public sealed class ElectrolyzerSystem : EntitySystem
         var temperature = mixture.Temperature;
         const float workingPower = 1.8f;
         const float powerEfficiency = 1f;
-        float powerLoad = 4000f;
-        float potentialPowerLoad = powerLoad;
+        float powerLoad = 100f;
         float activeLoad = (4200f * (3f * workingPower) * workingPower) / (powerEfficiency + workingPower);
-        float efficiencyFactor = 1f;
 
         if (initH2O > 0.05f)
         {
@@ -90,47 +87,32 @@ public sealed class ElectrolyzerSystem : EntitySystem
             var proportion = Math.Min(initH2O * 0.5f, maxProportion);
             var temperatureEfficiency = Math.Min(mixture.Temperature / 1123.15f * 0.75f, 0.75f);
 
-            potentialPowerLoad = Math.Max(activeLoad * (proportion / maxProportion * 2), potentialPowerLoad);
-
-            powerLoad = Math.Min(potentialPowerLoad, _lastPowerLoad + MaxPowerIncrease);
-            efficiencyFactor = potentialPowerLoad > 0 ? Math.Clamp(powerLoad / potentialPowerLoad, 0f, 1f) : 1f;
-
-            var h2oRemoved = proportion * 2f * efficiencyFactor;
-            var oxyProduced = proportion * temperatureEfficiency * efficiencyFactor;
-            var hydrogenProduced = proportion * 2f * temperatureEfficiency * efficiencyFactor;
+            var h2oRemoved = proportion * 2f;
+            var oxyProduced = proportion * temperatureEfficiency;
+            var hydrogenProduced = proportion * 2f * temperatureEfficiency;
 
             mixture.AdjustMoles(Gas.WaterVapor, -h2oRemoved);
             mixture.AdjustMoles(Gas.Oxygen, oxyProduced);
             mixture.AdjustMoles(Gas.Hydrogen, hydrogenProduced);
+
+            var heatCap = _atmosphereSystem.GetHeatCapacity(mixture, true);
+            powerLoad = Math.Max(activeLoad * (hydrogenProduced / (maxProportion * 2)), powerLoad);
         }
 
         if (initHyperNob > 0.01f && temperature < 150f)
         {
             var maxProportion = 1.5f * (float) Math.Pow(workingPower, 2);
             var proportion = Math.Min(initHyperNob, maxProportion);
-
-            potentialPowerLoad = Math.Max(activeLoad * (proportion / maxProportion), potentialPowerLoad);
-
-            powerLoad = Math.Min(potentialPowerLoad, _lastPowerLoad + MaxPowerIncrease);
-            efficiencyFactor = potentialPowerLoad > 0 ? Math.Clamp(powerLoad / potentialPowerLoad, 0f, 1f) : 1f;
-
-            proportion *= efficiencyFactor;
-
             mixture.AdjustMoles(Gas.HyperNoblium, -proportion);
             mixture.AdjustMoles(Gas.AntiNoblium, proportion * 0.5f);
+
+            var heatCap = _atmosphereSystem.GetHeatCapacity(mixture, true);
+            powerLoad = Math.Max(activeLoad * (proportion / maxProportion), powerLoad);
         }
 
         if (initBZ > 0.01f)
         {
             var proportion = Math.Min(initBZ * (1f - (float) Math.Pow(Math.E, -0.5f * temperature * workingPower / Atmospherics.FireMinimumTemperatureToExist)), initBZ);
-
-            potentialPowerLoad = Math.Max(activeLoad * Math.Min(proportion / 30f, 1), potentialPowerLoad);
-
-            powerLoad = Math.Min(potentialPowerLoad, _lastPowerLoad + MaxPowerIncrease);
-            efficiencyFactor = potentialPowerLoad > 0 ? Math.Clamp(powerLoad / potentialPowerLoad, 0f, 1f) : 1f;
-
-            proportion *= efficiencyFactor;
-
             mixture.AdjustMoles(Gas.BZ, -proportion);
             mixture.AdjustMoles(Gas.Oxygen, proportion * 0.2f);
             mixture.AdjustMoles(Gas.Halon, proportion * 2f);
@@ -139,8 +121,10 @@ public sealed class ElectrolyzerSystem : EntitySystem
             var heatCap = _atmosphereSystem.GetHeatCapacity(mixture, true);
             if (heatCap > Atmospherics.MinimumHeatCapacity)
                 mixture.Temperature = Math.Max((mixture.Temperature * heatCap + energyReleased) / heatCap, Atmospherics.TCMB);
+            powerLoad = Math.Max(activeLoad * Math.Min(proportion / 30f, 1), powerLoad);
         }
 
+        powerLoad = Math.Max(powerLoad, _lastPowerLoad - MaxPowerDecrease);
         receiver.Load = powerLoad;
         _lastPowerLoad = powerLoad;
 

--- a/Content.Server/_Funkystation/Atmos/Portable/ElectrolyzerSystem.cs
+++ b/Content.Server/_Funkystation/Atmos/Portable/ElectrolyzerSystem.cs
@@ -44,6 +44,7 @@ public sealed class ElectrolyzerSystem : EntitySystem
         if (!Resolve(uid, ref powerReceiver))
             return;
 
+        _lastPowerLoad = 100f;
         _power.TogglePower(uid);
 
         UpdateAppearance(uid);


### PR DESCRIPTION
## About the PR
Changes the electrolyzer's power consumption so that it will slowly ramp down in power, fixing issues with flickering. Turning off the electrolyzer will reset it's power draw to baseline. 

## Why / Balance
Unfortunately SS14 doesn't deal with varying power levels too well. This is the easiest solution for the problem at the moment. 

## Technical details
The electrolyzer powerload will only drop by 100kW per second. Might be a bit overkill but it protects against flickers even with setups that use a large amount of electrolyzers in a single chamber. The alternative is having them draw a consistently high power, so I find this is better. 

## Media
None

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None

**Changelog**
:cl:
- tweak: Electrolyzer powerload will now return to baseline more slowly, causing fewer power fluctuations.
