### PR TITLE
Rework hydrogen fires to make more sense

### DIFF
--- a/Content.Server/_Funkystation/Atmos/Portable/ElectrolyzerSystem.cs
+++ b/Content.Server/_Funkystation/Atmos/Portable/ElectrolyzerSystem.cs
@@ -83,7 +83,7 @@ public sealed class ElectrolyzerSystem : EntitySystem
         {
             var maxProportion = 2.5f * (float) Math.Pow(workingPower, 2);
             var proportion = Math.Min(initH2O * 0.5f, maxProportion);
-            var temperatureEfficiency = Math.Min(mixture.Temperature / 1123.15f * 0.75f, 0.75f);
+            var temperatureEfficiency = Math.Min(mixture.Temperature / 1123.15f * 0.8f, 0.8f); // To prevent closed loop burn systems, gases "evaporate" until we have another solution.
 
             var h2oRemoved = proportion * 2f;
             var oxyProduced = proportion * temperatureEfficiency;

--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -268,6 +268,7 @@ namespace Content.Shared.Atmos
         public const float PlasmaUpperTemperature = (1370f+T0C);
         public const float PlasmaOxygenFullburn = 10f;
         public const float PlasmaBurnRateDelta = 9f;
+        public const float HydrogenBurnRateDelta = 2f; // Assmos - /tg/ gases
 
         /// <summary>
         ///     This is calculated to help prevent singlecap bombs (Overpowered tritium/oxygen single tank bombs)


### PR DESCRIPTION
## About the PR
Completely redid the HydrogenFireReaction to more closely follow /tg/ hydrogen fires. This will make them far more consistent and solves an issue with water vapor being overproduced by the reaction in a far neater way than it currently is. 

This also slightly buffs the efficiency of electrolyzers when it comes to making hydrogen as the changes solve part of the reason for the efficiency cap.

## Why / Balance
Hydrogen fires are meant to act exactly like tritium fires but without the radioactive element, so when originally adding hydrogen, I just modified the existing tritium fire code thinking it was solidly written. I was wrong. Tritium fires just don't make a lot of sense in ss14. This will allow hydrogen fires to act more consistently and cleanly output an amount of heat and water vapor that actually makes sense.

## Technical details
Redid much of the HydrogenFireReaction

## Media
None

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None

**Changelog**
:cl:
- fix: Hydrogen fire reactions have been slightly reworked to more closely follow original mechanics
