### PR TITLE
crystallizer ui tweaks and cap input rate

### DIFF
--- a/Content.Client/_Funkystation/Atmos/UI/CrystallizerWindow.xaml
+++ b/Content.Client/_Funkystation/Atmos/UI/CrystallizerWindow.xaml
@@ -76,7 +76,7 @@
                     <PanelContainer StyleClasses="LowDivider"/>
                     <PanelContainer Name="RecipePanel" MinSize="322 180" Margin="18 5 5 5" >
                         <PanelContainer.PanelOverride>
-                            <gfx:StyleBoxFlat BackgroundColor="#1B1B1E" />
+                            <gfx:StyleBoxFlat BackgroundColor="#222222" />
                         </PanelContainer.PanelOverride>
                         <BoxContainer Name="RequirementsContainer" Margin="5" Orientation="Vertical" Modulate="#808080">
                             <Label Text="Please select a recipe" />

--- a/Content.Server/_Funkystation/Atmos/EntitySystems/CrystallizerSystem.cs
+++ b/Content.Server/_Funkystation/Atmos/EntitySystems/CrystallizerSystem.cs
@@ -74,7 +74,7 @@ namespace Content.Server._Funkystation.Atmos.Systems
 
         private void OnSetGasInputMessage(EntityUid uid, CrystallizerComponent crystallizer, CrystallizerSetGasInputMessage args)
         {
-            crystallizer.GasInput = args.GasInput;
+            crystallizer.GasInput = Math.Clamp(args.GasInput, 0f, 250f);
             DirtyUI(uid, crystallizer);
         }
 


### PR DESCRIPTION
## About the PR
Adds a max limit of 250 mol/s to the crystallizer's input rate. The UI also now displays the recipes in order. 

## Why / Balance
The input rate should have been limited to a maximum of 250 mol/s in the first place, and UI changes are just for cosmetic reasons.

## Technical details
None

## Media
None

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- fix: The crystallizer's max input rate is now capped to 250 mol/s
