### PR TITLE
Cluster Medbay Changes

### DIFF
--- a/Resources/Maps/_Funkystation/cluster.yml
+++ b/Resources/Maps/_Funkystation/cluster.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 255.0.0
   forkId: ""
   forkVersion: ""
-  time: 05/23/2025 00:05:13
-  entityCount: 12851
+  time: 05/23/2025 00:14:05
+  entityCount: 12853
 maps:
 - 4494
 grids:
@@ -1108,7 +1108,6 @@ entities:
           decals:
             1308: -12,6
             1309: -12,7
-            1310: -12,10
             1316: -16,12
             1317: -16,13
             1318: -16,14
@@ -2457,7 +2456,6 @@ entities:
             color: '#52B4E996'
             id: MonoOverlay
           decals:
-            574: -11,10
             575: -11,6
             653: -10,7
             654: -9,7
@@ -6874,7 +6872,7 @@ entities:
       pos: 38.5,-1.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -13466.146
+      secondsUntilStateChange: -13577.571
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -8733,6 +8731,19 @@ entities:
     - type: Transform
       pos: -26.622076,24.452543
       parent: 2
+  - uid: 12852
+    components:
+    - type: Transform
+      pos: -15.657887,5.722499
+      parent: 2
+  - uid: 12853
+    components:
+    - type: Transform
+      pos: -15.340911,5.597907
+      parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
 - proto: BluespaceSender
   entities:
   - uid: 9972

--- a/Resources/Maps/_Funkystation/cluster.yml
+++ b/Resources/Maps/_Funkystation/cluster.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 255.0.0
   forkId: ""
   forkVersion: ""
-  time: 05/23/2025 00:14:05
-  entityCount: 12853
+  time: 05/23/2025 00:38:01
+  entityCount: 12854
 maps:
 - 4494
 grids:
@@ -6872,7 +6872,7 @@ entities:
       pos: 38.5,-1.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -13577.571
+      secondsUntilStateChange: -13780.771
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -8211,16 +8211,22 @@ entities:
     - type: Transform
       pos: 17.5,-3.5
       parent: 2
+    - type: SiloUtilizer
+      silo: 12735
   - uid: 442
     components:
     - type: Transform
       pos: 13.5,-20.5
       parent: 2
+    - type: SiloUtilizer
+      silo: 12735
   - uid: 443
     components:
     - type: Transform
       pos: -8.5,-0.5
       parent: 2
+    - type: SiloUtilizer
+      silo: 12735
 - proto: BananaPhoneInstrument
   entities:
   - uid: 444
@@ -27685,6 +27691,8 @@ entities:
     - type: Transform
       pos: -9.5,-0.5
       parent: 2
+    - type: SiloUtilizer
+      silo: 12735
 - proto: CleanerDispenser
   entities:
   - uid: 4129
@@ -34313,6 +34321,8 @@ entities:
     - type: Transform
       pos: -7.5,-15.5
       parent: 2
+    - type: SiloUtilizer
+      silo: 12735
 - proto: ExtinguisherCabinetFilled
   entities:
   - uid: 5192
@@ -58447,6 +58457,30 @@ entities:
         8824:
         - - MaterialSilo
           - MaterialSiloUtilizer
+        276:
+        - - MaterialSilo
+          - MaterialSiloUtilizer
+        9955:
+        - - MaterialSilo
+          - MaterialSiloUtilizer
+        4128:
+        - - MaterialSilo
+          - MaterialSiloUtilizer
+        9198:
+        - - MaterialSilo
+          - MaterialSiloUtilizer
+        443:
+        - - MaterialSilo
+          - MaterialSiloUtilizer
+        5191:
+        - - MaterialSilo
+          - MaterialSiloUtilizer
+        441:
+        - - MaterialSilo
+          - MaterialSiloUtilizer
+        442:
+        - - MaterialSilo
+          - MaterialSiloUtilizer
 - proto: MaterialWoodPlank
   entities:
   - uid: 8614
@@ -58520,6 +58554,8 @@ entities:
     - type: Transform
       pos: -24.5,6.5
       parent: 2
+    - type: SiloUtilizer
+      silo: 12735
 - proto: MedkitAdvancedFilled
   entities:
   - uid: 8624
@@ -58832,6 +58868,20 @@ entities:
       lastUseAttempt: 202.0865886
     - type: EmitSoundOnCollide
       nextSound: -29.979846
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
+  - uid: 12854
+    mapInit: true
+    paused: true
+    components:
+    - type: Transform
+      pos: -43.382027,-26.530535
+      parent: 2
+    - type: NetworkConfigurator
+      lastUseAttempt: 119.9994693
+    - type: EmitSoundOnCollide
+      nextSound: -13.7670636
     - type: Physics
       angularDamping: 0
       linearDamping: 0
@@ -62241,6 +62291,8 @@ entities:
     - type: Transform
       pos: -10.5,-0.5
       parent: 2
+    - type: SiloUtilizer
+      silo: 12735
 - proto: Rack
   entities:
   - uid: 7325
@@ -66382,6 +66434,8 @@ entities:
     - type: Transform
       pos: 36.5,10.5
       parent: 2
+    - type: SiloUtilizer
+      silo: 12735
 - proto: SeedExtractor
   entities:
   - uid: 9956

--- a/Resources/Maps/_Funkystation/cluster.yml
+++ b/Resources/Maps/_Funkystation/cluster.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 255.0.0
   forkId: ""
   forkVersion: ""
-  time: 05/23/2025 00:38:01
+  time: 05/23/2025 02:43:03
   entityCount: 12854
 maps:
 - 4494
@@ -70,7 +70,7 @@ entities:
           version: 6
         -1,0:
           ind: -1,0
-          tiles: eQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAABWQAAAAAAWQAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAADWQAAAAAAWQAAAAAAWQAAAAABWQAAAAADWQAAAAACWQAAAAADWQAAAAADWQAAAAACWQAAAAADWQAAAAAAWQAAAAACeQAAAAAALAAAAAAALAAAAAAAeQAAAAAAWQAAAAACWQAAAAACWQAAAAABWQAAAAAAWQAAAAABWQAAAAABWQAAAAABWQAAAAABWQAAAAABWQAAAAABWQAAAAAAWQAAAAADLAAAAAAALAAAAAAALAAAAAAALAAAAAAAWQAAAAACWQAAAAACWQAAAAADWQAAAAACWQAAAAABWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAABWQAAAAADWQAAAAAAWQAAAAABeQAAAAAALAAAAAAALAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAADWQAAAAACWQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAQAAAAAAAQAAAAAAeQAAAAAAbAAAAAAAbAAAAAADeQAAAAAAbQAAAAACbQAAAAADeQAAAAAAWQAAAAAAWQAAAAAAWQAAAAACeQAAAAAAdgAAAAACdgAAAAADdgAAAAACAQAAAAAAAQAAAAAAeQAAAAAAbAAAAAACbAAAAAACcQAAAAADbQAAAAABbQAAAAACeQAAAAAAWQAAAAAAWQAAAAAAWQAAAAABeQAAAAAAdgAAAAACdgAAAAABdgAAAAACeQAAAAAAcQAAAAAAeQAAAAAAbAAAAAACbAAAAAABeQAAAAAAcQAAAAABcQAAAAAAeQAAAAAAWQAAAAAAWQAAAAACWQAAAAABeQAAAAAAdgAAAAADdgAAAAADdgAAAAACbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAeQAAAAAAbAAAAAABbAAAAAABbAAAAAACWQAAAAACWQAAAAAAWQAAAAADDgAAAAADDgAAAAADDgAAAAABDgAAAAABbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAcQAAAAABbAAAAAACbAAAAAAAbAAAAAAAWQAAAAACWQAAAAAAWQAAAAACDgAAAAABDgAAAAABDgAAAAADDgAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAcQAAAAACbAAAAAABbAAAAAABbAAAAAAAWQAAAAAAWQAAAAAAWQAAAAADeQAAAAAAdgAAAAACdgAAAAACDgAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAeQAAAAAAbAAAAAAAbAAAAAAAbAAAAAABWQAAAAADWQAAAAAAWQAAAAAAeQAAAAAAeQAAAAAAdgAAAAACDgAAAAAAbAAAAAABeQAAAAAAeQAAAAAAcQAAAAACeQAAAAAAeQAAAAAAcQAAAAAAcQAAAAABeQAAAAAAWQAAAAABWQAAAAABWQAAAAAAWQAAAAAAeQAAAAAAeQAAAAAADgAAAAADbAAAAAACeQAAAAAAcAAAAAADcAAAAAABcAAAAAABcAAAAAABcAAAAAACcAAAAAADeQAAAAAAWQAAAAABWQAAAAAAWQAAAAADWQAAAAAAWQAAAAAAeQAAAAAAeQAAAAAAbAAAAAAAeQAAAAAAcAAAAAAAcAAAAAACcAAAAAAAcAAAAAADcAAAAAAAcAAAAAACeQAAAAAAWQAAAAABWQAAAAACWQAAAAAAWQAAAAACWQAAAAAAWQAAAAAAWQAAAAAAbAAAAAAAcQAAAAACcAAAAAABcAAAAAABcAAAAAAAcAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAAAWQAAAAABWQAAAAADWQAAAAAAWQAAAAACWQAAAAAB
+          tiles: eQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAABWQAAAAAAWQAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAADWQAAAAAAWQAAAAAAWQAAAAABWQAAAAADWQAAAAACWQAAAAADWQAAAAADWQAAAAACWQAAAAADWQAAAAAAWQAAAAACeQAAAAAALAAAAAAALAAAAAAAeQAAAAAAWQAAAAACWQAAAAACWQAAAAABWQAAAAAAWQAAAAABWQAAAAABWQAAAAABWQAAAAABWQAAAAABWQAAAAABWQAAAAAAWQAAAAADLAAAAAAALAAAAAAALAAAAAAALAAAAAAAWQAAAAACWQAAAAACWQAAAAADWQAAAAACWQAAAAABWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAABWQAAAAADWQAAAAAAWQAAAAABeQAAAAAALAAAAAAALAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAADWQAAAAACWQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAQAAAAAAAQAAAAAAeQAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAbQAAAAACbQAAAAADeQAAAAAAWQAAAAAAWQAAAAAAWQAAAAACeQAAAAAAdgAAAAACdgAAAAADdgAAAAACAQAAAAAAAQAAAAAAeQAAAAAAbQAAAAAAbQAAAAAAbQAAAAAAbQAAAAABbQAAAAACeQAAAAAAWQAAAAAAWQAAAAAAWQAAAAABeQAAAAAAdgAAAAACdgAAAAABdgAAAAACeQAAAAAAcQAAAAAAeQAAAAAAeQAAAAAAcQAAAAAAeQAAAAAAcQAAAAABcQAAAAAAeQAAAAAAWQAAAAAAWQAAAAACWQAAAAABeQAAAAAAdgAAAAADdgAAAAADdgAAAAACbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAeQAAAAAAbAAAAAABbAAAAAABbAAAAAACWQAAAAACWQAAAAAAWQAAAAADDgAAAAADDgAAAAADDgAAAAABDgAAAAABbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAcQAAAAABbAAAAAACbAAAAAAAbAAAAAAAWQAAAAACWQAAAAAAWQAAAAACDgAAAAABDgAAAAABDgAAAAADDgAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAcQAAAAACbAAAAAABbAAAAAABbAAAAAAAWQAAAAAAWQAAAAAAWQAAAAADeQAAAAAAdgAAAAACdgAAAAACDgAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAeQAAAAAAbAAAAAAAbAAAAAAAbAAAAAABWQAAAAADWQAAAAAAWQAAAAAAeQAAAAAAeQAAAAAAdgAAAAACDgAAAAAAbAAAAAABeQAAAAAAeQAAAAAAcQAAAAACeQAAAAAAeQAAAAAAcQAAAAAAcQAAAAABeQAAAAAAWQAAAAABWQAAAAABWQAAAAAAWQAAAAAAeQAAAAAAeQAAAAAADgAAAAADbAAAAAACeQAAAAAAcAAAAAADcAAAAAABcAAAAAABcAAAAAABcAAAAAACcAAAAAADeQAAAAAAWQAAAAABWQAAAAAAWQAAAAADWQAAAAAAWQAAAAAAeQAAAAAAeQAAAAAAbAAAAAAAeQAAAAAAcAAAAAAAcAAAAAACcAAAAAAAcAAAAAADcAAAAAAAcAAAAAACeQAAAAAAWQAAAAABWQAAAAACWQAAAAAAWQAAAAACWQAAAAAAWQAAAAAAWQAAAAAAbAAAAAAAcQAAAAACcAAAAAABcAAAAAABcAAAAAAAcAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAAAWQAAAAABWQAAAAADWQAAAAAAWQAAAAACWQAAAAAB
           version: 6
         -1,-1:
           ind: -1,-1
@@ -808,12 +808,11 @@ entities:
             color: '#96DAFFFF'
             id: BrickTileWhiteCornerNe
           decals:
-            1311: -12,11
             1321: -16,16
             1740: -18,6
             1741: -15,6
             1765: -21,7
-            1777: -14,10
+            1816: -12,11
         - node:
             color: '#9D9D97FF'
             id: BrickTileWhiteCornerNe
@@ -846,18 +845,17 @@ entities:
             color: '#52B4E9FF'
             id: BrickTileWhiteCornerNw
           decals:
-            659: -10,6
+            1863: -13,6
         - node:
             color: '#96DAFFFF'
             id: BrickTileWhiteCornerNw
           decals:
-            1320: -17,16
-            1336: -27,11
             1739: -19,6
             1745: -16,6
             1771: -23,7
-            1779: -15,10
-            1785: -27,24
+            1820: -17,16
+            1824: -27,11
+            1833: -27,24
         - node:
             color: '#9D9D97FF'
             id: BrickTileWhiteCornerNw
@@ -907,11 +905,10 @@ entities:
             color: '#96DAFFFF'
             id: BrickTileWhiteCornerSe
           decals:
-            1307: -12,5
             1746: -18,5
             1747: -15,5
             1748: -21,5
-            1775: -14,9
+            1852: -12,8
         - node:
             color: '#9D9D97FF'
             id: BrickTileWhiteCornerSe
@@ -956,7 +953,7 @@ entities:
             color: '#52B4E9FF'
             id: BrickTileWhiteCornerSw
           decals:
-            661: -10,5
+            1864: -13,5
         - node:
             color: '#96DAFFFF'
             id: BrickTileWhiteCornerSw
@@ -964,10 +961,8 @@ entities:
             1337: -27,9
             1742: -16,5
             1743: -19,5
-            1744: -13,5
             1763: -19,8
             1773: -23,5
-            1778: -15,9
         - node:
             color: '#9D9D97FF'
             id: BrickTileWhiteCornerSw
@@ -1002,7 +997,7 @@ entities:
             color: '#96DAFFFF'
             id: BrickTileWhiteInnerNe
           decals:
-            1315: -16,11
+            1819: -16,11
         - node:
             color: '#9FED5896'
             id: BrickTileWhiteInnerNe
@@ -1032,7 +1027,7 @@ entities:
             color: '#96DAFFFF'
             id: BrickTileWhiteInnerNw
           decals:
-            1326: -17,11
+            1818: -17,11
         - node:
             color: '#9FED5896'
             id: BrickTileWhiteInnerNw
@@ -1080,7 +1075,6 @@ entities:
             color: '#96DAFFFF'
             id: BrickTileWhiteInnerSw
           decals:
-            1756: -13,8
             1762: -19,9
         - node:
             color: '#9FED5896'
@@ -1106,17 +1100,15 @@ entities:
             color: '#96DAFFFF'
             id: BrickTileWhiteLineE
           decals:
-            1308: -12,6
-            1309: -12,7
             1316: -16,12
             1317: -16,13
             1318: -16,14
             1319: -16,15
             1751: -21,6
-            1752: -12,8
             1753: -12,9
-            1783: -23,23
-            1784: -23,22
+            1815: -12,10
+            1831: -23,22
+            1832: -23,23
         - node:
             color: '#9D9D97FF'
             id: BrickTileWhiteLineE
@@ -1162,25 +1154,28 @@ entities:
             id: BrickTileWhiteLineN
           decals:
             1537: -26,7
+            1857: -10,6
+            1858: -11,6
+            1859: -12,6
         - node:
             color: '#96DAFFFF'
             id: BrickTileWhiteLineN
           decals:
-            1312: -13,11
-            1313: -14,11
-            1314: -15,11
-            1327: -18,11
-            1328: -19,11
-            1329: -20,11
-            1330: -21,11
-            1331: -22,11
-            1332: -23,11
-            1333: -24,11
-            1334: -25,11
-            1335: -26,11
             1769: -22,7
-            1791: -24,24
-            1792: -25,24
+            1805: -24,11
+            1806: -23,11
+            1807: -22,11
+            1808: -21,11
+            1809: -20,11
+            1810: -18,11
+            1811: -19,11
+            1812: -15,11
+            1813: -14,11
+            1814: -13,11
+            1825: -26,11
+            1826: -25,11
+            1834: -25,24
+            1835: -24,24
         - node:
             color: '#9D9D97FF'
             id: BrickTileWhiteLineN
@@ -1256,6 +1251,9 @@ entities:
             135: 0,50
             136: 1,50
             1154: -4,-34
+            1860: -12,5
+            1861: -11,5
+            1862: -10,5
         - node:
             color: '#7C5C98FF'
             id: BrickTileWhiteLineS
@@ -1271,7 +1269,6 @@ entities:
             1341: -24,9
             1342: -23,9
             1356: -22,9
-            1357: -21,9
             1358: -20,9
             1757: -18,8
             1758: -17,8
@@ -1279,7 +1276,9 @@ entities:
             1760: -16,8
             1761: -14,8
             1770: -22,5
-            1786: -26,20
+            1827: -21,9
+            1830: -26,20
+            1855: -13,8
         - node:
             color: '#9D9D97FF'
             id: BrickTileWhiteLineS
@@ -1347,15 +1346,14 @@ entities:
             color: '#96DAFFFF'
             id: BrickTileWhiteLineW
           decals:
-            1323: -17,14
             1324: -17,13
             1325: -17,12
-            1338: -27,10
-            1754: -13,6
-            1755: -13,7
             1772: -23,6
-            1787: -27,21
-            1788: -27,23
+            1821: -17,15
+            1822: -17,14
+            1823: -27,10
+            1828: -27,23
+            1829: -27,21
         - node:
             color: '#9D9D97FF'
             id: BrickTileWhiteLineW
@@ -1571,11 +1569,12 @@ entities:
           decals:
             1535: -6,15
         - node:
-            color: '#B3B3B3FF'
+            cleanable: True
+            color: '#999999FF'
             id: DirtHeavy
           decals:
-            1793: -27,21
-            1797: -17,9
+            1836: -24,21
+            1850: -16,8
         - node:
             cleanable: True
             color: '#FFFFFFFF'
@@ -1598,7 +1597,6 @@ entities:
             1478: 0,-34
             1479: 2,-30
             1483: 11,-28
-            1536: -27,10
             1539: 18,8
             1540: 11,5
             1541: 11,6
@@ -1634,14 +1632,19 @@ entities:
             1679: 7,20
             1680: 9,20
         - node:
+            cleanable: True
+            color: '#999999FF'
+            id: DirtHeavyMonotile
+          decals:
+            1837: -27,21
+            1838: -25,24
+            1846: -26,8
+        - node:
             color: '#B3B3B3FF'
             id: DirtHeavyMonotile
           decals:
             1730: 27,25
             1731: 29,28
-            1794: -25,24
-            1795: -23,22
-            1800: -17,11
         - node:
             cleanable: True
             color: '#FFFFFFFF'
@@ -1695,7 +1698,6 @@ entities:
             1607: 14,-11
             1608: -5,-22
             1609: -5,-23
-            1660: -24,21
             1681: 9,23
             1682: 11,27
             1683: 11,24
@@ -1703,13 +1705,21 @@ entities:
             1685: 13,27
             1686: 16,25
         - node:
+            cleanable: True
+            color: '#999999FF'
+            id: DirtLight
+          decals:
+            1839: -27,24
+            1840: -26,22
+            1842: -24,24
+            1843: -16,16
+            1844: -26,10
+        - node:
+            cleanable: True
             color: '#B3B3B3FF'
             id: DirtLight
           decals:
-            1796: -26,22
-            1798: -24,10
-            1799: -13,8
-            1802: -22,6
+            1856: -12,8
         - node:
             cleanable: True
             color: '#FFFFFFFF'
@@ -1717,8 +1727,6 @@ entities:
           decals:
             1414: -30,3
             1415: -24,1
-            1421: -12,6
-            1423: -21,10
             1443: -27,-6
             1444: -28,-7
             1445: -26,-7
@@ -1797,7 +1805,14 @@ entities:
             1650: -3,28
             1651: -17,20
             1652: -14,18
-            1653: -17,14
+        - node:
+            cleanable: True
+            color: '#999999FF'
+            id: DirtMedium
+          decals:
+            1841: -26,20
+            1847: -17,11
+            1848: -13,11
         - node:
             color: '#B3B3B3FF'
             id: DirtMedium
@@ -1805,18 +1820,11 @@ entities:
             1728: 30,27
             1729: 33,25
         - node:
-            color: '#FFFFFFFF'
-            id: DirtMedium
-          decals:
-            1406: -26,6
-        - node:
             cleanable: True
             color: '#FFFFFFFF'
             id: DirtMedium
           decals:
             1422: -27,9
-            1425: -17,16
-            1426: -12,11
             1448: -15,-14
             1449: -17,-19
             1450: -21,-18
@@ -2456,7 +2464,6 @@ entities:
             color: '#52B4E996'
             id: MonoOverlay
           decals:
-            575: -11,6
             653: -10,7
             654: -9,7
             655: -13,12
@@ -5048,19 +5055,23 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
+      - 490
+      - 5457
+      - 5348
       - 5470
       - 5469
-      - 5456
-      - 5348
-      - 5457
-      - 8622
-      - 8989
       - 5466
       - 5459
       - 5458
-      - 5462
-      - 9246
+      - 8989
+      - 8622
+      - 12726
+      - 7498
+      - 7390
       - 1884
+      - 9246
+      - 6485
+      - 274
   - uid: 16
     components:
     - type: Transform
@@ -5674,19 +5685,6 @@ entities:
       - 8989
       - 7334
       - 8492
-  - uid: 9563
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -10.5,5.5
-      parent: 2
-    - type: DeviceList
-      devices:
-      - 5462
-      - 5461
-      - 5460
-      - 7498
-      - 7390
   - uid: 9627
     components:
     - type: Transform
@@ -5698,6 +5696,19 @@ entities:
       - 8622
       - 7098
       - 6501
+  - uid: 10189
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,4.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 7390
+      - 7498
+      - 5460
+      - 5461
+      - 12726
   - uid: 10752
     components:
     - type: Transform
@@ -6872,7 +6883,7 @@ entities:
       pos: 38.5,-1.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -13780.771
+      secondsUntilStateChange: -15893.701
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -7131,11 +7142,10 @@ entities:
       rot: 3.141592653589793 rad
       pos: -10.5,10.5
       parent: 2
-  - uid: 274
+  - uid: 7391
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,6.5
+      pos: -11.5,7.5
       parent: 2
   - uid: 12836
     components:
@@ -7164,7 +7174,9 @@ entities:
     - type: Transform
       pos: 22.5,4.5
       parent: 2
-  - uid: 7391
+- proto: AirlockMedicalMorgueLocked
+  entities:
+  - uid: 330
     components:
     - type: Transform
       pos: -23.5,12.5
@@ -7460,12 +7472,6 @@ entities:
       parent: 2
 - proto: APCBasic
   entities:
-  - uid: 330
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -10.5,7.5
-      parent: 2
   - uid: 331
     components:
     - type: Transform
@@ -7754,6 +7760,11 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 10.5,22.5
+      parent: 2
+  - uid: 451
+    components:
+    - type: Transform
+      pos: -10.5,7.5
       parent: 2
 - proto: APCElectronics
   entities:
@@ -8275,13 +8286,6 @@ entities:
     components:
     - type: Transform
       pos: 34.5,-13.5
-      parent: 2
-- proto: BassGuitarInstrument
-  entities:
-  - uid: 451
-    components:
-    - type: Transform
-      pos: -27.503199,41.532513
       parent: 2
 - proto: Beaker
   entities:
@@ -9046,8 +9050,11 @@ entities:
   - uid: 11313
     components:
     - type: Transform
-      pos: -23.646357,9.679266
+      pos: -9.97105,5.5313334
       parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
 - proto: BoxFolderGrey
   entities:
   - uid: 570
@@ -9108,16 +9115,6 @@ entities:
     - type: Physics
       angularDamping: 0
       linearDamping: 0
-  - uid: 5240
-    components:
-    - type: Transform
-      pos: -23.414852,9.528786
-      parent: 2
-  - uid: 12840
-    components:
-    - type: Transform
-      pos: -9.663411,5.766392
-      parent: 2
 - proto: BoxFolderYellow
   entities:
   - uid: 580
@@ -9341,6 +9338,13 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -23.582449,26.792467
+      parent: 2
+- proto: Brutepack
+  entities:
+  - uid: 12833
+    components:
+    - type: Transform
+      pos: -16.309944,8.716912
       parent: 2
 - proto: Bucket
   entities:
@@ -16027,8 +16031,11 @@ entities:
   - uid: 1938
     components:
     - type: Transform
-      pos: -2.3223429,44.45334
+      pos: -2.4367676,44.434708
       parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
   - uid: 1939
     components:
     - type: Transform
@@ -22966,8 +22973,11 @@ entities:
   - uid: 3323
     components:
     - type: Transform
-      pos: -2.5254679,44.593964
+      pos: -2.582878,44.594143
       parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
   - uid: 3324
     components:
     - type: Transform
@@ -23022,6 +23032,16 @@ entities:
       rot: 3.141592653589793 rad
       pos: -41.5,20.5
       parent: 2
+- proto: CandyBowl
+  entities:
+  - uid: 5240
+    components:
+    - type: Transform
+      pos: -9.374595,12.506701
+      parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
 - proto: CannabisSeeds
   entities:
   - uid: 3334
@@ -26898,27 +26918,15 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -28.5,11.5
       parent: 2
-  - uid: 12737
+  - uid: 5463
     components:
     - type: Transform
-      pos: -14.5,9.5
-      parent: 2
-  - uid: 12829
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -14.5,10.5
+      pos: -13.5,11.5
       parent: 2
   - uid: 12830
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -13.5,10.5
-      parent: 2
-  - uid: 12831
-    components:
-    - type: Transform
-      pos: -13.5,9.5
+      pos: -14.5,11.5
       parent: 2
 - proto: ChairCursed
   entities:
@@ -28628,13 +28636,6 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-- proto: ClothingNeckStethoscope
-  entities:
-  - uid: 12814
-    components:
-    - type: Transform
-      pos: -12.460064,5.608284
-      parent: 2
 - proto: ClothingNeckTieRed
   entities:
   - uid: 4279
@@ -33730,6 +33731,11 @@ entities:
       linearDamping: 0
 - proto: ElectricGuitarInstrument
   entities:
+  - uid: 489
+    components:
+    - type: Transform
+      pos: -32.454575,32.45926
+      parent: 2
   - uid: 5113
     components:
     - type: Transform
@@ -34230,17 +34236,22 @@ entities:
     - type: Transform
       pos: -1.5,47.5
       parent: 2
-- proto: EmergencyRollerBedSpawnFolded
+- proto: EmergencyMedipen
   entities:
-  - uid: 275
+  - uid: 12829
     components:
     - type: Transform
-      pos: -12.5,6.5
+      pos: -26.445654,9.440198
       parent: 2
-  - uid: 489
+  - uid: 12831
     components:
     - type: Transform
-      pos: -12.5,7.5
+      pos: -26.54306,9.617346
+      parent: 2
+  - uid: 12842
+    components:
+    - type: Transform
+      pos: -26.631613,9.794494
       parent: 2
 - proto: EncryptionKeyCargo
   entities:
@@ -34614,6 +34625,13 @@ entities:
       parent: 2
 - proto: FaxMachineBase
   entities:
+  - uid: 620
+    components:
+    - type: Transform
+      pos: -10.5,5.5
+      parent: 2
+    - type: FaxMachine
+      name: Medical
   - uid: 5241
     components:
     - type: Transform
@@ -34684,13 +34702,6 @@ entities:
       parent: 2
     - type: FaxMachine
       name: Nanorep Office
-  - uid: 11044
-    components:
-    - type: Transform
-      pos: -26.5,9.5
-      parent: 2
-    - type: FaxMachine
-      name: Medical
 - proto: FaxMachineCaptain
   entities:
   - uid: 5251
@@ -34893,17 +34904,19 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 5469
-      - 5456
       - 5348
-      - 5457
-      - 8622
-      - 8989
+      - 5470
+      - 5469
       - 5466
       - 5459
       - 5458
-      - 5462
-      - 5470
+      - 8989
+      - 8622
+      - 7498
+      - 5457
+      - 7390
+      - 490
+      - 12726
   - uid: 5266
     components:
     - type: Transform
@@ -35935,6 +35948,8 @@ entities:
       deviceLists:
       - 12846
       - 12623
+      - 5264
+      - 14
   - uid: 5387
     components:
     - type: Transform
@@ -36343,8 +36358,6 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 14
-      - 5264
       - 16
       - 5267
   - uid: 5457
@@ -36386,7 +36399,7 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 9563
+      - 10189
   - uid: 5461
     components:
     - type: Transform
@@ -36395,18 +36408,7 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 9563
-  - uid: 5462
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -10.5,6.5
-      parent: 2
-    - type: DeviceNetwork
-      deviceLists:
-      - 14
-      - 9563
-      - 5264
+      - 10189
   - uid: 5464
     components:
     - type: Transform
@@ -37116,6 +37118,17 @@ entities:
       - 5264
       - 9438
       - 14
+  - uid: 12726
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,7.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 5264
+      - 14
+      - 10189
 - proto: Fireplace
   entities:
   - uid: 5579
@@ -38864,6 +38877,13 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
+  - uid: 9563
+    components:
+    - type: Transform
+      pos: -14.5,10.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
 - proto: GasPipeStraight
   entities:
   - uid: 280
@@ -43585,14 +43605,6 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 6479
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -13.5,9.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 6481
     components:
     - type: Transform
@@ -48401,6 +48413,13 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
+  - uid: 9321
+    components:
+    - type: Transform
+      pos: -13.5,10.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 9622
     components:
     - type: Transform
@@ -48480,13 +48499,6 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 6485
-    components:
-    - type: Transform
-      pos: -14.5,10.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 7095
     components:
     - type: Transform
@@ -50017,6 +50029,14 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
+  - uid: 9435
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -13.5,9.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 9957
     components:
     - type: Transform
@@ -50250,6 +50270,16 @@ entities:
       open: False
 - proto: GasVentPump
   entities:
+  - uid: 274
+    components:
+    - type: Transform
+      pos: -13.5,11.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 14
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 5825
     components:
     - type: Transform
@@ -50658,7 +50688,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 9563
+      - 5264
+      - 14
+      - 10189
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 7392
@@ -51180,6 +51212,16 @@ entities:
       - 14
     - type: AtmosPipeColor
       color: '#990000FF'
+  - uid: 6485
+    components:
+    - type: Transform
+      pos: -14.5,11.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 14
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 7098
     components:
     - type: Transform
@@ -51588,7 +51630,9 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 9563
+      - 5264
+      - 14
+      - 10189
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 7499
@@ -55674,6 +55718,12 @@ entities:
       rot: 3.141592653589793 rad
       pos: -22.5,8.5
       parent: 2
+  - uid: 12840
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -12.5,7.5
+      parent: 2
 - proto: GrilleBroken
   entities:
   - uid: 8235
@@ -57822,10 +57872,10 @@ entities:
       parent: 2
 - proto: LockerParamedicFilled
   entities:
-  - uid: 12844
+  - uid: 12734
     components:
     - type: Transform
-      pos: -11.5,5.5
+      pos: -12.5,5.5
       parent: 2
 - proto: LockerQuarterMasterFilled
   entities:
@@ -58795,6 +58845,21 @@ entities:
       parent: 2
 - proto: Multitool
   entities:
+  - uid: 1904
+    mapInit: true
+    paused: true
+    components:
+    - type: Transform
+      pos: -2.1711133,44.70043
+      parent: 2
+    - type: NetworkConfigurator
+      lastUseAttempt: 1108.6654825
+      linkModeActive: False
+    - type: EmitSoundOnCollide
+      nextSound: -155.2665869
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
   - uid: 5923
     components:
     - type: Transform
@@ -58818,7 +58883,7 @@ entities:
     paused: true
     components:
     - type: Transform
-      pos: 46.643486,-0.56077194
+      pos: -2.1213434,44.569576
       parent: 2
     - type: NetworkConfigurator
       lastUseAttempt: -26.066932
@@ -58847,7 +58912,7 @@ entities:
     paused: true
     components:
     - type: Transform
-      pos: -1.9825712,27.530226
+      pos: -2.1354449,44.595135
       parent: 2
     - type: NetworkConfigurator
       lastUseAttempt: 79.7996583
@@ -58862,10 +58927,11 @@ entities:
     paused: true
     components:
     - type: Transform
-      pos: -3.114146,32.236465
+      pos: -3.131558,32.10774
       parent: 2
     - type: NetworkConfigurator
-      lastUseAttempt: 202.0865886
+      lastUseAttempt: 1635.2649559
+      linkModeActive: False
     - type: EmitSoundOnCollide
       nextSound: -29.979846
     - type: Physics
@@ -59000,11 +59066,10 @@ entities:
       linearDamping: 0
 - proto: Ointment
   entities:
-  - uid: 12833
+  - uid: 4254
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -12.630861,5.7497396
+      pos: -16.70973,8.47966
       parent: 2
 - proto: OperatingTable
   entities:
@@ -59629,36 +59694,6 @@ entities:
     - type: Transform
       pos: -9.640527,-12.015921
       parent: 2
-  - uid: 10189
-    components:
-    - type: Transform
-      pos: -23.00635,9.687412
-      parent: 2
-  - uid: 11575
-    components:
-    - type: Transform
-      pos: -22.953218,9.628363
-      parent: 2
-  - uid: 11576
-    components:
-    - type: Transform
-      pos: -22.88828,9.563408
-      parent: 2
-  - uid: 12841
-    components:
-    - type: Transform
-      pos: -9.498115,5.3884764
-      parent: 2
-  - uid: 12842
-    components:
-    - type: Transform
-      pos: -9.409563,5.477051
-      parent: 2
-  - uid: 12843
-    components:
-    - type: Transform
-      pos: -9.291494,5.5892444
-      parent: 2
 - proto: PartRodMetal
   entities:
   - uid: 8478
@@ -59852,12 +59887,14 @@ entities:
     - type: Transform
       pos: 13.536374,-23.518818
       parent: 2
-  - uid: 12547
+  - uid: 9051
     components:
     - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -22.375202,9.640173
+      pos: -9.811657,5.8369136
       parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
 - proto: PenCap
   entities:
   - uid: 8858
@@ -60668,11 +60705,6 @@ entities:
       parent: 2
 - proto: PowerCellRecharger
   entities:
-  - uid: 620
-    components:
-    - type: Transform
-      pos: -22.5,9.5
-      parent: 2
   - uid: 8990
     components:
     - type: Transform
@@ -60724,6 +60756,11 @@ entities:
     components:
     - type: Transform
       pos: -1.5,-20.5
+      parent: 2
+  - uid: 11575
+    components:
+    - type: Transform
+      pos: -23.5,9.5
       parent: 2
 - proto: PoweredDimSmallLight
   entities:
@@ -61118,14 +61155,6 @@ entities:
     components:
     - type: Transform
       pos: -22.5,11.5
-      parent: 2
-    - type: ApcPowerReceiver
-      powerLoad: 0
-  - uid: 9051
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -11.5,7.5
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
@@ -62063,6 +62092,18 @@ entities:
       rot: 3.141592653589793 rad
       pos: 18.5,-28.5
       parent: 2
+  - uid: 11576
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -12.5,6.5
+      parent: 2
+  - uid: 12046
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -10.5,5.5
+      parent: 2
   - uid: 12631
     components:
     - type: Transform
@@ -62074,12 +62115,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -15.5,6.5
-      parent: 2
-  - uid: 12726
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -9.5,5.5
       parent: 2
 - proto: PoweredlightLED
   entities:
@@ -62555,6 +62590,11 @@ entities:
     components:
     - type: Transform
       pos: -12.5,-11.5
+      parent: 2
+  - uid: 10496
+    components:
+    - type: Transform
+      pos: -12.5,6.5
       parent: 2
   - uid: 10711
     components:
@@ -63169,11 +63209,6 @@ entities:
     - type: Transform
       pos: -25.5,6.5
       parent: 2
-  - uid: 1904
-    components:
-    - type: Transform
-      pos: -12.5,8.5
-      parent: 2
   - uid: 4392
     components:
     - type: Transform
@@ -63576,11 +63611,6 @@ entities:
     components:
     - type: Transform
       pos: -11.5,2.5
-      parent: 2
-  - uid: 9435
-    components:
-    - type: Transform
-      pos: -11.5,6.5
       parent: 2
   - uid: 9436
     components:
@@ -63998,6 +64028,16 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 7.5,22.5
+      parent: 2
+  - uid: 12547
+    components:
+    - type: Transform
+      pos: -12.5,10.5
+      parent: 2
+  - uid: 12844
+    components:
+    - type: Transform
+      pos: -10.5,6.5
       parent: 2
 - proto: RandomVending
   entities:
@@ -66247,6 +66287,12 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 19.5,-29.5
       parent: 2
+  - uid: 12841
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -12.5,7.5
+      parent: 2
 - proto: ResearchAndDevelopmentServer
   entities:
   - uid: 9932
@@ -66274,6 +66320,18 @@ entities:
     components:
     - type: Transform
       pos: -4.5524483,48.349712
+      parent: 2
+- proto: RollerBedSpawnFolded
+  entities:
+  - uid: 6479
+    components:
+    - type: Transform
+      pos: -12.638912,6.8491607
+      parent: 2
+  - uid: 12814
+    components:
+    - type: Transform
+      pos: -12.396871,6.6011534
       parent: 2
 - proto: RPD
   entities:
@@ -66498,6 +66556,11 @@ entities:
     - type: Transform
       pos: -28.604006,22.484268
       parent: 2
+  - uid: 11044
+    components:
+    - type: Transform
+      pos: -26.319508,9.519247
+      parent: 2
 - proto: SheetPaper
   entities:
   - uid: 9967
@@ -66587,6 +66650,11 @@ entities:
     components:
     - type: Transform
       pos: -28.37981,22.482435
+      parent: 2
+  - uid: 12843
+    components:
+    - type: Transform
+      pos: -26.602873,9.802684
       parent: 2
 - proto: SheetSteel
   entities:
@@ -70619,6 +70687,11 @@ entities:
       parent: 2
 - proto: Table
   entities:
+  - uid: 275
+    components:
+    - type: Transform
+      pos: -10.5,5.5
+      parent: 2
   - uid: 5174
     components:
     - type: Transform
@@ -71711,10 +71784,11 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -18.5,5.5
       parent: 2
-  - uid: 10496
+  - uid: 5462
     components:
     - type: Transform
-      pos: -12.5,5.5
+      rot: 1.5707963267948966 rad
+      pos: -16.5,8.5
       parent: 2
   - uid: 10569
     components:
@@ -71767,6 +71841,12 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -22.5,9.5
+      parent: 2
+  - uid: 12832
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -13.5,8.5
       parent: 2
 - proto: TablePlasmaGlass
   entities:
@@ -79097,11 +79177,6 @@ entities:
     - type: Transform
       pos: -13.5,5.5
       parent: 2
-  - uid: 5463
-    components:
-    - type: Transform
-      pos: -10.5,5.5
-      parent: 2
   - uid: 5669
     components:
     - type: Transform
@@ -79416,11 +79491,6 @@ entities:
     components:
     - type: Transform
       pos: -27.5,13.5
-      parent: 2
-  - uid: 12046
-    components:
-    - type: Transform
-      pos: -10.5,4.5
       parent: 2
   - uid: 12047
     components:
@@ -81953,6 +82023,11 @@ entities:
     - type: Transform
       pos: 8.5,31.5
       parent: 2
+  - uid: 12737
+    components:
+    - type: Transform
+      pos: -10.5,4.5
+      parent: 2
 - proto: WallSolidRust
   entities:
   - uid: 12506
@@ -83091,17 +83166,6 @@ entities:
       parent: 2
 - proto: WindowDirectional
   entities:
-  - uid: 4254
-    components:
-    - type: Transform
-      pos: -14.5,10.5
-      parent: 2
-  - uid: 9321
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -13.5,9.5
-      parent: 2
   - uid: 12702
     components:
     - type: Transform
@@ -83113,17 +83177,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -11.5,20.5
-      parent: 2
-  - uid: 12734
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -14.5,9.5
-      parent: 2
-  - uid: 12832
-    components:
-    - type: Transform
-      pos: -13.5,10.5
       parent: 2
 - proto: WindowFrostedDirectional
   entities:

--- a/Resources/Maps/_Funkystation/cluster.yml
+++ b/Resources/Maps/_Funkystation/cluster.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 255.0.0
   forkId: ""
   forkVersion: ""
-  time: 05/23/2025 02:43:03
-  entityCount: 12854
+  time: 05/23/2025 21:41:22
+  entityCount: 12846
 maps:
 - 4494
 grids:
@@ -1273,12 +1273,17 @@ entities:
             1757: -18,8
             1758: -17,8
             1759: -15,8
-            1760: -16,8
             1761: -14,8
             1770: -22,5
             1827: -21,9
             1830: -26,20
             1855: -13,8
+        - node:
+            cleanable: True
+            color: '#96DAFFFF'
+            id: BrickTileWhiteLineS
+          decals:
+            1865: -16,8
         - node:
             color: '#9D9D97FF'
             id: BrickTileWhiteLineS
@@ -1574,7 +1579,6 @@ entities:
             id: DirtHeavy
           decals:
             1836: -24,21
-            1850: -16,8
         - node:
             cleanable: True
             color: '#FFFFFFFF'
@@ -6883,7 +6887,7 @@ entities:
       pos: 38.5,-1.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -15893.701
+      secondsUntilStateChange: -16727.467
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -9050,7 +9054,7 @@ entities:
   - uid: 11313
     components:
     - type: Transform
-      pos: -9.97105,5.5313334
+      pos: -9.863512,5.535693
       parent: 2
     - type: Physics
       angularDamping: 0
@@ -28620,13 +28624,6 @@ entities:
     - type: Transform
       pos: 41.60983,-24.521702
       parent: 2
-- proto: ClothingMaskSterile
-  entities:
-  - uid: 4271
-    components:
-    - type: Transform
-      pos: 23.509787,5.6575975
-      parent: 2
 - proto: ClothingNeckMantleHOP
   entities:
   - uid: 4275
@@ -28970,10 +28967,11 @@ entities:
       parent: 2
 - proto: ComputerCriminalRecords
   entities:
-  - uid: 4325
+  - uid: 4271
     components:
     - type: Transform
-      pos: 14.5,15.5
+      rot: 3.141592653589793 rad
+      pos: 14.5,12.5
       parent: 2
   - uid: 4326
     components:
@@ -29119,11 +29117,10 @@ entities:
       parent: 2
 - proto: ComputerSurveillanceCameraMonitor
   entities:
-  - uid: 4349
+  - uid: 4325
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 14.5,12.5
+      pos: 14.5,15.5
       parent: 2
   - uid: 4351
     components:
@@ -29447,10 +29444,10 @@ entities:
       parent: 2
 - proto: CrateLockBoxMedical
   entities:
-  - uid: 12845
+  - uid: 12630
     components:
     - type: Transform
-      pos: -24.5,7.5
+      pos: -11.5,5.5
       parent: 2
 - proto: CrateLockBoxScience
   entities:
@@ -29945,18 +29942,6 @@ entities:
     - type: Transform
       pos: -19.5,10.5
       parent: 2
-  - uid: 4460
-    components:
-    - type: Transform
-      pos: -9.5,10.5
-      parent: 2
-- proto: DefaultStationBeaconMedical
-  entities:
-  - uid: 1889
-    components:
-    - type: Transform
-      pos: -25.5,6.5
-      parent: 2
 - proto: DefaultStationBeaconMorgue
   entities:
   - uid: 4461
@@ -30034,11 +30019,6 @@ entities:
       parent: 2
 - proto: DefaultStationBeaconSurgery
   entities:
-  - uid: 5039
-    components:
-    - type: Transform
-      pos: -17.5,6.5
-      parent: 2
   - uid: 10182
     components:
     - type: Transform
@@ -34238,20 +34218,20 @@ entities:
       parent: 2
 - proto: EmergencyMedipen
   entities:
-  - uid: 12829
+  - uid: 6479
     components:
     - type: Transform
-      pos: -26.445654,9.440198
+      pos: -22.369707,9.494005
       parent: 2
-  - uid: 12831
+  - uid: 10539
     components:
     - type: Transform
-      pos: -26.54306,9.617346
+      pos: -22.517294,9.659344
       parent: 2
-  - uid: 12842
+  - uid: 11044
     components:
     - type: Transform
-      pos: -26.631613,9.794494
+      pos: -22.635363,9.806967
       parent: 2
 - proto: EncryptionKeyCargo
   entities:
@@ -52103,6 +52083,16 @@ entities:
       - 12623
     - type: AtmosPipeColor
       color: '#990000FF'
+- proto: Gauze
+  entities:
+  - uid: 12629
+    components:
+    - type: Transform
+      pos: -22.859692,9.517625
+      parent: 2
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
 - proto: GeneratorBasic15kW
   entities:
   - uid: 7556
@@ -58635,6 +58625,11 @@ entities:
     - type: Transform
       pos: -40.48545,-16.453053
       parent: 2
+  - uid: 12829
+    components:
+    - type: Transform
+      pos: -12.351614,6.287582
+      parent: 2
 - proto: MedkitBurnFilled
   entities:
   - uid: 8629
@@ -58646,6 +58641,11 @@ entities:
     components:
     - type: Transform
       pos: -25.402166,11.510829
+      parent: 2
+  - uid: 12814
+    components:
+    - type: Transform
+      pos: -12.623173,6.5119696
       parent: 2
 - proto: MedkitCombatFilled
   entities:
@@ -58930,7 +58930,7 @@ entities:
       pos: -3.131558,32.10774
       parent: 2
     - type: NetworkConfigurator
-      lastUseAttempt: 1635.2649559
+      lastUseAttempt: 1635.2649558
       linkModeActive: False
     - type: EmitSoundOnCollide
       nextSound: -29.979846
@@ -59890,7 +59890,7 @@ entities:
   - uid: 9051
     components:
     - type: Transform
-      pos: -9.811657,5.8369136
+      pos: -9.590872,5.5224066
       parent: 2
     - type: Physics
       angularDamping: 0
@@ -66321,17 +66321,17 @@ entities:
     - type: Transform
       pos: -4.5524483,48.349712
       parent: 2
-- proto: RollerBedSpawnFolded
+- proto: RollerBed
   entities:
-  - uid: 6479
+  - uid: 12620
     components:
     - type: Transform
-      pos: -12.638912,6.8491607
+      pos: -12.5,8.5
       parent: 2
-  - uid: 12814
+  - uid: 12628
     components:
     - type: Transform
-      pos: -12.396871,6.6011534
+      pos: -13.5,8.5
       parent: 2
 - proto: RPD
   entities:
@@ -66556,10 +66556,10 @@ entities:
     - type: Transform
       pos: -28.604006,22.484268
       parent: 2
-  - uid: 11044
+  - uid: 12625
     components:
     - type: Transform
-      pos: -26.319508,9.519247
+      pos: -24.307858,7.6231136
       parent: 2
 - proto: SheetPaper
   entities:
@@ -66651,10 +66651,10 @@ entities:
     - type: Transform
       pos: -28.37981,22.482435
       parent: 2
-  - uid: 12843
+  - uid: 12626
     components:
     - type: Transform
-      pos: -26.602873,9.802684
+      pos: -24.697483,7.599494
       parent: 2
 - proto: SheetSteel
   entities:
@@ -70692,6 +70692,11 @@ entities:
     - type: Transform
       pos: -10.5,5.5
       parent: 2
+  - uid: 4349
+    components:
+    - type: Transform
+      pos: -24.5,7.5
+      parent: 2
   - uid: 5174
     components:
     - type: Transform
@@ -70733,11 +70738,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -26.5,11.5
-      parent: 2
-  - uid: 10539
-    components:
-    - type: Transform
-      pos: -26.5,9.5
       parent: 2
   - uid: 10540
     components:
@@ -71841,12 +71841,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -22.5,9.5
-      parent: 2
-  - uid: 12832
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -13.5,8.5
       parent: 2
 - proto: TablePlasmaGlass
   entities:
@@ -73194,6 +73188,11 @@ entities:
     components:
     - type: Transform
       pos: 20.5,7.5
+      parent: 2
+  - uid: 12627
+    components:
+    - type: Transform
+      pos: -26.5,9.5
       parent: 2
 - proto: VendingMachineMediDrobe
   entities:
@@ -82723,46 +82722,6 @@ entities:
     components:
     - type: Transform
       pos: 0.5,18.5
-      parent: 2
-  - uid: 12620
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 12.5,-9.5
-      parent: 2
-  - uid: 12625
-    components:
-    - type: Transform
-      pos: -9.5,-4.5
-      parent: 2
-  - uid: 12626
-    components:
-    - type: Transform
-      pos: -8.5,-4.5
-      parent: 2
-  - uid: 12627
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,14.5
-      parent: 2
-  - uid: 12628
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 13.5,13.5
-      parent: 2
-  - uid: 12629
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 7.5,-21.5
-      parent: 2
-  - uid: 12630
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 7.5,-20.5
       parent: 2
 - proto: WindoorSecureCargoLocked
   entities:

--- a/Resources/Maps/_Funkystation/cluster.yml
+++ b/Resources/Maps/_Funkystation/cluster.yml
@@ -4,8 +4,8 @@ meta:
   engineVersion: 255.0.0
   forkId: ""
   forkVersion: ""
-  time: 05/17/2025 04:33:34
-  entityCount: 12803
+  time: 05/23/2025 00:05:13
+  entityCount: 12851
 maps:
 - 4494
 grids:
@@ -70,7 +70,7 @@ entities:
           version: 6
         -1,0:
           ind: -1,0
-          tiles: eQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAABWQAAAAAAWQAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAADWQAAAAAAWQAAAAAAWQAAAAABWQAAAAADWQAAAAACWQAAAAADWQAAAAADWQAAAAACWQAAAAADWQAAAAAAWQAAAAACeQAAAAAALAAAAAAALAAAAAAAeQAAAAAAWQAAAAACWQAAAAACWQAAAAABWQAAAAAAWQAAAAABWQAAAAABWQAAAAABWQAAAAABWQAAAAABWQAAAAABWQAAAAAAWQAAAAADLAAAAAAALAAAAAAALAAAAAAALAAAAAAAWQAAAAACWQAAAAACWQAAAAADWQAAAAACWQAAAAABWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAABWQAAAAADWQAAAAAAWQAAAAABeQAAAAAALAAAAAAALAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAADWQAAAAACWQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAbAAAAAAAbAAAAAADcQAAAAADbQAAAAACbQAAAAADeQAAAAAAWQAAAAAAWQAAAAAAWQAAAAACeQAAAAAAdgAAAAACdgAAAAADdgAAAAACAQAAAAAAAQAAAAAAAQAAAAAAbAAAAAACbAAAAAACcQAAAAADbQAAAAABbQAAAAACeQAAAAAAWQAAAAAAWQAAAAAAWQAAAAABeQAAAAAAdgAAAAACdgAAAAABdgAAAAACAQAAAAAAAQAAAAAAAQAAAAAAbAAAAAACbAAAAAABeQAAAAAAcQAAAAABcQAAAAAAeQAAAAAAWQAAAAAAWQAAAAACWQAAAAABeQAAAAAAdgAAAAADdgAAAAADdgAAAAACbAAAAAADbAAAAAAAbAAAAAADbAAAAAABbAAAAAACeQAAAAAAbAAAAAABbAAAAAABbAAAAAACWQAAAAACWQAAAAAAWQAAAAADDgAAAAADDgAAAAADDgAAAAABDgAAAAABbAAAAAAAbAAAAAACbAAAAAAAbAAAAAABbAAAAAABcQAAAAABbAAAAAACbAAAAAAAbAAAAAAAWQAAAAACWQAAAAAAWQAAAAACDgAAAAABDgAAAAABDgAAAAADDgAAAAAAbAAAAAACbAAAAAAAbAAAAAACbAAAAAADbAAAAAAAcQAAAAACbAAAAAABbAAAAAABbAAAAAAAWQAAAAAAWQAAAAAAWQAAAAADeQAAAAAAdgAAAAACdgAAAAACDgAAAAAAbAAAAAADbAAAAAADbAAAAAADbAAAAAABbAAAAAACeQAAAAAAbAAAAAAAbAAAAAAAbAAAAAABWQAAAAADWQAAAAAAWQAAAAAAeQAAAAAAeQAAAAAAdgAAAAACDgAAAAAAbAAAAAABeQAAAAAAeQAAAAAAcQAAAAACeQAAAAAAeQAAAAAAcQAAAAAAcQAAAAABeQAAAAAAWQAAAAABWQAAAAABWQAAAAAAWQAAAAAAeQAAAAAAeQAAAAAADgAAAAADbAAAAAACeQAAAAAAcAAAAAADcAAAAAABcAAAAAABcAAAAAABcAAAAAACcAAAAAADeQAAAAAAWQAAAAABWQAAAAAAWQAAAAADWQAAAAAAWQAAAAAAeQAAAAAAeQAAAAAAbAAAAAAAeQAAAAAAcAAAAAAAcAAAAAACcAAAAAAAcAAAAAADcAAAAAAAcAAAAAACeQAAAAAAWQAAAAABWQAAAAACWQAAAAAAWQAAAAACWQAAAAAAWQAAAAAAWQAAAAAAbAAAAAAAcQAAAAACcAAAAAABcAAAAAABcAAAAAAAcAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAAAWQAAAAABWQAAAAADWQAAAAAAWQAAAAACWQAAAAAB
+          tiles: eQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAABWQAAAAAAWQAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAADWQAAAAAAWQAAAAAAWQAAAAABWQAAAAADWQAAAAACWQAAAAADWQAAAAADWQAAAAACWQAAAAADWQAAAAAAWQAAAAACeQAAAAAALAAAAAAALAAAAAAAeQAAAAAAWQAAAAACWQAAAAACWQAAAAABWQAAAAAAWQAAAAABWQAAAAABWQAAAAABWQAAAAABWQAAAAABWQAAAAABWQAAAAAAWQAAAAADLAAAAAAALAAAAAAALAAAAAAALAAAAAAAWQAAAAACWQAAAAACWQAAAAADWQAAAAACWQAAAAABWQAAAAAAWQAAAAAAWQAAAAAAWQAAAAABWQAAAAADWQAAAAAAWQAAAAABeQAAAAAALAAAAAAALAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAADWQAAAAACWQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAQAAAAAAAQAAAAAAeQAAAAAAbAAAAAAAbAAAAAADeQAAAAAAbQAAAAACbQAAAAADeQAAAAAAWQAAAAAAWQAAAAAAWQAAAAACeQAAAAAAdgAAAAACdgAAAAADdgAAAAACAQAAAAAAAQAAAAAAeQAAAAAAbAAAAAACbAAAAAACcQAAAAADbQAAAAABbQAAAAACeQAAAAAAWQAAAAAAWQAAAAAAWQAAAAABeQAAAAAAdgAAAAACdgAAAAABdgAAAAACeQAAAAAAcQAAAAAAeQAAAAAAbAAAAAACbAAAAAABeQAAAAAAcQAAAAABcQAAAAAAeQAAAAAAWQAAAAAAWQAAAAACWQAAAAABeQAAAAAAdgAAAAADdgAAAAADdgAAAAACbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAeQAAAAAAbAAAAAABbAAAAAABbAAAAAACWQAAAAACWQAAAAAAWQAAAAADDgAAAAADDgAAAAADDgAAAAABDgAAAAABbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAcQAAAAABbAAAAAACbAAAAAAAbAAAAAAAWQAAAAACWQAAAAAAWQAAAAACDgAAAAABDgAAAAABDgAAAAADDgAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAcQAAAAACbAAAAAABbAAAAAABbAAAAAAAWQAAAAAAWQAAAAAAWQAAAAADeQAAAAAAdgAAAAACdgAAAAACDgAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAeQAAAAAAbAAAAAAAbAAAAAAAbAAAAAABWQAAAAADWQAAAAAAWQAAAAAAeQAAAAAAeQAAAAAAdgAAAAACDgAAAAAAbAAAAAABeQAAAAAAeQAAAAAAcQAAAAACeQAAAAAAeQAAAAAAcQAAAAAAcQAAAAABeQAAAAAAWQAAAAABWQAAAAABWQAAAAAAWQAAAAAAeQAAAAAAeQAAAAAADgAAAAADbAAAAAACeQAAAAAAcAAAAAADcAAAAAABcAAAAAABcAAAAAABcAAAAAACcAAAAAADeQAAAAAAWQAAAAABWQAAAAAAWQAAAAADWQAAAAAAWQAAAAAAeQAAAAAAeQAAAAAAbAAAAAAAeQAAAAAAcAAAAAAAcAAAAAACcAAAAAAAcAAAAAADcAAAAAAAcAAAAAACeQAAAAAAWQAAAAABWQAAAAACWQAAAAAAWQAAAAACWQAAAAAAWQAAAAAAWQAAAAAAbAAAAAAAcQAAAAACcAAAAAABcAAAAAABcAAAAAAAcAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAAAWQAAAAABWQAAAAADWQAAAAAAWQAAAAACWQAAAAAB
           version: 6
         -1,-1:
           ind: -1,-1
@@ -90,7 +90,7 @@ entities:
           version: 6
         -2,0:
           ind: -2,0
-          tiles: YAAAAAAAWQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAACWQAAAAACWQAAAAADWQAAAAACWQAAAAADWQAAAAAAWQAAAAACWQAAAAACWQAAAAACWQAAAAABWQAAAAAAWQAAAAAAWQAAAAADWQAAAAABWQAAAAABWQAAAAAAWQAAAAADWQAAAAABWQAAAAAAWQAAAAAAWQAAAAACWQAAAAABWQAAAAADWQAAAAABWQAAAAACWQAAAAABWQAAAAAAWQAAAAACWQAAAAACWQAAAAAAWQAAAAAAWQAAAAABWQAAAAAAWQAAAAADWQAAAAAAWQAAAAAAWQAAAAADWQAAAAADWQAAAAABWQAAAAADWQAAAAAAWQAAAAABWQAAAAABWQAAAAAAWQAAAAACWQAAAAADWQAAAAAAWQAAAAAAeQAAAAAAeQAAAAAAWQAAAAABWQAAAAADeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAdgAAAAABeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAbwAAAAAAbwAAAAADbwAAAAABbwAAAAADeQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAdgAAAAABeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAbwAAAAACbwAAAAABbwAAAAAAbwAAAAAAeQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAdgAAAAABeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAbwAAAAABbwAAAAADbwAAAAAAbwAAAAAAeQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAdgAAAAADeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAcQAAAAADeQAAAAAAeQAAAAAAbAAAAAAAbAAAAAACbAAAAAADbAAAAAACbAAAAAADbAAAAAACdgAAAAABeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAbAAAAAADbAAAAAACbAAAAAADbAAAAAACbAAAAAAAbAAAAAADbAAAAAADbAAAAAABbAAAAAADbAAAAAADbAAAAAABdgAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAbAAAAAACbAAAAAABbAAAAAADbAAAAAADbAAAAAACbAAAAAADbAAAAAADbAAAAAAAbAAAAAADbAAAAAADbAAAAAAAdgAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAbAAAAAAAbAAAAAABbAAAAAAAbAAAAAADbAAAAAABbAAAAAABbAAAAAABbAAAAAADbAAAAAAAbAAAAAABbAAAAAACeQAAAAAAeQAAAAAAaAAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAIgAAAAABeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAbAAAAAAAPgAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAHgAAAAABHgAAAAACHgAAAAACHgAAAAACHgAAAAADeQAAAAAAHQAAAAACHQAAAAABHQAAAAABeQAAAAAAbAAAAAADPgAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAHgAAAAABHgAAAAAAHgAAAAAAHgAAAAAAHgAAAAADeQAAAAAAHQAAAAADHQAAAAACHQAAAAAAeQAAAAAAbAAAAAACPgAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHgAAAAAAHgAAAAADHgAAAAAAHgAAAAADHgAAAAAAeQAAAAAAHQAAAAADHQAAAAADHQAAAAACIgAAAAAAbAAAAAAC
+          tiles: YAAAAAAAWQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAWQAAAAACWQAAAAACWQAAAAADWQAAAAACWQAAAAADWQAAAAAAWQAAAAACWQAAAAACWQAAAAACWQAAAAABWQAAAAAAWQAAAAAAWQAAAAADWQAAAAABWQAAAAABWQAAAAAAWQAAAAADWQAAAAABWQAAAAAAWQAAAAAAWQAAAAACWQAAAAABWQAAAAADWQAAAAABWQAAAAACWQAAAAABWQAAAAAAWQAAAAACWQAAAAACWQAAAAAAWQAAAAAAWQAAAAABWQAAAAAAWQAAAAADWQAAAAAAWQAAAAAAWQAAAAADWQAAAAADWQAAAAABWQAAAAADWQAAAAAAWQAAAAABWQAAAAABWQAAAAAAWQAAAAACWQAAAAADWQAAAAAAWQAAAAAAeQAAAAAAeQAAAAAAWQAAAAABWQAAAAADeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAdgAAAAABeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAeQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAeQAAAAAAAQAAAAAAAQAAAAAAeQAAAAAAdgAAAAABeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAeQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAeQAAAAAAAQAAAAAAAQAAAAAAeQAAAAAAdgAAAAABeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAbwAAAAAAbwAAAAAAbwAAAAAAeQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAeQAAAAAAeQAAAAAAcQAAAAAAeQAAAAAAdgAAAAADeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAcQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAcQAAAAAAeQAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAdgAAAAABeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAdgAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAdgAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAbAAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAcQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAbAAAAAAAPgAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAHgAAAAABHgAAAAACHgAAAAACHgAAAAACHgAAAAADeQAAAAAAHQAAAAACHQAAAAABHQAAAAABeQAAAAAAbAAAAAADPgAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAHgAAAAABHgAAAAAAHgAAAAAAHgAAAAAAHgAAAAADeQAAAAAAHQAAAAADHQAAAAACHQAAAAAAeQAAAAAAbAAAAAACPgAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAHgAAAAAAHgAAAAADHgAAAAAAHgAAAAADHgAAAAAAeQAAAAAAHQAAAAADHQAAAAADHQAAAAACIgAAAAAAbAAAAAAC
           version: 6
         1,0:
           ind: 1,0
@@ -102,7 +102,7 @@ entities:
           version: 6
         -2,1:
           ind: -2,1
-          tiles: PgAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAHgAAAAAAHgAAAAACHgAAAAABHgAAAAADHgAAAAAAeQAAAAAAHQAAAAAAHQAAAAABHQAAAAABeQAAAAAAbAAAAAABeQAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAcQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAaAAAAAAAaAAAAAAAeQAAAAAAbAAAAAADbAAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAbAAAAAADbAAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAaAAAAAAAeQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAbAAAAAACbAAAAAABaAAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAeQAAAAAAaAAAAAAAaAAAAAAAeQAAAAAAbAAAAAACbAAAAAACeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAAQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAaAAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAaAAAAAAAeAAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAA
+          tiles: PgAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAHgAAAAAAHgAAAAACHgAAAAABHgAAAAADHgAAAAAAeQAAAAAAHQAAAAAAHQAAAAABHQAAAAABeQAAAAAAbAAAAAABeQAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAcQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAaAAAAAAAaAAAAAAAeQAAAAAAbAAAAAADbAAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAbAAAAAADbAAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAAQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAbAAAAAACbAAAAAABaAAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAAQAAAAAAeQAAAAAAeQAAAAAAAQAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAaAAAAAAAeQAAAAAAbAAAAAACbAAAAAACeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAQAAAAAAeQAAAAAAeQAAAAAAAQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAAQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAQAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAAQAAAAAAeQAAAAAAAQAAAAAAAQAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAaAAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAaAAAAAAAeAAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAA
           version: 6
         0,2:
           ind: 0,2
@@ -190,7 +190,7 @@ entities:
           version: 6
         -3,1:
           ind: -3,1
-          tiles: AAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAeQAAAAAAWQAAAAACWQAAAAADWQAAAAADeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAIgAAAAADHQAAAAABPgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAWQAAAAABeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAeQAAAAAAWQAAAAABWQAAAAACYAAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAeQAAAAAAWQAAAAADWQAAAAABYAAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAWQAAAAABYAAAAAAAWQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAeQAAAAAAIgAAAAAAWQAAAAACWQAAAAABIgAAAAADIgAAAAAAIgAAAAADeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAeQAAAAAAIgAAAAAAYAAAAAAAWQAAAAABIgAAAAACIgAAAAABIgAAAAACeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAeQAAAAAAWQAAAAAAWQAAAAAAWQAAAAABIgAAAAABIgAAAAABIgAAAAABeQAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAIgAAAAAAIgAAAAAAIgAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAaAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAeQAAAAAAIgAAAAAAIgAAAAAAIgAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAIgAAAAAAIgAAAAAAIgAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAA
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAeQAAAAAAWQAAAAACWQAAAAADWQAAAAADeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAIgAAAAADHQAAAAABPgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAWQAAAAABeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAeQAAAAAAWQAAAAABWQAAAAACYAAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAeQAAAAAAWQAAAAADWQAAAAABYAAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAWQAAAAABYAAAAAAAWQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAeQAAAAAAIgAAAAAAWQAAAAACWQAAAAABIgAAAAADIgAAAAAAIgAAAAADeQAAAAAAeQAAAAAAaAAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAeQAAAAAAIgAAAAAAYAAAAAAAWQAAAAABIgAAAAACIgAAAAABIgAAAAACeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAeQAAAAAAWQAAAAAAWQAAAAAAWQAAAAABIgAAAAABIgAAAAABIgAAAAABeQAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAIgAAAAAAIgAAAAAAIgAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAaAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAeQAAAAAAIgAAAAAAIgAAAAAAIgAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAIgAAAAAAIgAAAAAAIgAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeQAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAeAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAeAAAAAAA
           version: 6
         -3,-2:
           ind: -3,-2
@@ -322,54 +322,6 @@ entities:
             1382: -17,-15
             1383: -17,-11
             1384: -17,-9
-        - node:
-            color: '#52B4E9FF'
-            id: BrickCornerOverlayNE
-          decals:
-            1343: -23,24
-        - node:
-            color: '#52B4E9FF'
-            id: BrickCornerOverlayNW
-          decals:
-            1280: -27,24
-        - node:
-            color: '#52B4E9FF'
-            id: BrickCornerOverlaySE
-          decals:
-            1281: -23,20
-        - node:
-            color: '#52B4E9FF'
-            id: BrickCornerOverlaySW
-          decals:
-            1282: -27,20
-        - node:
-            color: '#52B4E9FF'
-            id: BrickLineOverlayE
-          decals:
-            1292: -23,23
-            1293: -23,22
-            1294: -23,21
-        - node:
-            color: '#52B4E9FF'
-            id: BrickLineOverlayN
-          decals:
-            1289: -26,24
-            1290: -25,24
-            1291: -24,24
-        - node:
-            color: '#52B4E9FF'
-            id: BrickLineOverlayS
-          decals:
-            1283: -26,20
-            1284: -25,20
-            1285: -24,20
-        - node:
-            color: '#52B4E9FF'
-            id: BrickLineOverlayW
-          decals:
-            1286: -27,21
-            1287: -27,22
-            1288: -27,23
         - node:
             color: '#FFFFFFFF'
             id: BrickTileDarkCornerNe
@@ -858,7 +810,10 @@ entities:
           decals:
             1311: -12,11
             1321: -16,16
-            1345: -12,8
+            1740: -18,6
+            1741: -15,6
+            1765: -21,7
+            1777: -14,10
         - node:
             color: '#9D9D97FF'
             id: BrickTileWhiteCornerNe
@@ -898,7 +853,11 @@ entities:
           decals:
             1320: -17,16
             1336: -27,11
-            1344: -22,8
+            1739: -19,6
+            1745: -16,6
+            1771: -23,7
+            1779: -15,10
+            1785: -27,24
         - node:
             color: '#9D9D97FF'
             id: BrickTileWhiteCornerNw
@@ -949,7 +908,10 @@ entities:
             id: BrickTileWhiteCornerSe
           decals:
             1307: -12,5
-            1355: -12,9
+            1746: -18,5
+            1747: -15,5
+            1748: -21,5
+            1775: -14,9
         - node:
             color: '#9D9D97FF'
             id: BrickTileWhiteCornerSe
@@ -999,8 +961,13 @@ entities:
             color: '#96DAFFFF'
             id: BrickTileWhiteCornerSw
           decals:
-            1297: -22,5
             1337: -27,9
+            1742: -16,5
+            1743: -19,5
+            1744: -13,5
+            1763: -19,8
+            1773: -23,5
+            1778: -15,9
         - node:
             color: '#9D9D97FF'
             id: BrickTileWhiteCornerSw
@@ -1110,6 +1077,12 @@ entities:
           decals:
             168: 1,54
         - node:
+            color: '#96DAFFFF'
+            id: BrickTileWhiteInnerSw
+          decals:
+            1756: -13,8
+            1762: -19,9
+        - node:
             color: '#9FED5896'
             id: BrickTileWhiteInnerSw
           decals:
@@ -1140,6 +1113,11 @@ entities:
             1317: -16,13
             1318: -16,14
             1319: -16,15
+            1751: -21,6
+            1752: -12,8
+            1753: -12,9
+            1783: -23,23
+            1784: -23,22
         - node:
             color: '#9D9D97FF'
             id: BrickTileWhiteLineE
@@ -1185,7 +1163,6 @@ entities:
             id: BrickTileWhiteLineN
           decals:
             1537: -26,7
-            1538: -25,7
         - node:
             color: '#96DAFFFF'
             id: BrickTileWhiteLineN
@@ -1202,15 +1179,9 @@ entities:
             1333: -24,11
             1334: -25,11
             1335: -26,11
-            1346: -21,8
-            1347: -20,8
-            1348: -19,8
-            1349: -18,8
-            1350: -17,8
-            1351: -16,8
-            1352: -15,8
-            1353: -14,8
-            1354: -13,8
+            1769: -22,7
+            1791: -24,24
+            1792: -25,24
         - node:
             color: '#9D9D97FF'
             id: BrickTileWhiteLineN
@@ -1296,15 +1267,6 @@ entities:
             color: '#96DAFFFF'
             id: BrickTileWhiteLineS
           decals:
-            1298: -21,5
-            1299: -20,5
-            1300: -19,5
-            1301: -18,5
-            1302: -17,5
-            1303: -16,5
-            1304: -15,5
-            1305: -14,5
-            1306: -13,5
             1339: -26,9
             1340: -25,9
             1341: -24,9
@@ -1312,13 +1274,13 @@ entities:
             1356: -22,9
             1357: -21,9
             1358: -20,9
-            1359: -19,9
-            1360: -18,9
-            1361: -17,9
-            1362: -16,9
-            1363: -15,9
-            1364: -14,9
-            1365: -13,9
+            1757: -18,8
+            1758: -17,8
+            1759: -15,8
+            1760: -16,8
+            1761: -14,8
+            1770: -22,5
+            1786: -26,20
         - node:
             color: '#9D9D97FF'
             id: BrickTileWhiteLineS
@@ -1386,13 +1348,15 @@ entities:
             color: '#96DAFFFF'
             id: BrickTileWhiteLineW
           decals:
-            1295: -22,7
-            1296: -22,6
-            1322: -17,15
             1323: -17,14
             1324: -17,13
             1325: -17,12
             1338: -27,10
+            1754: -13,6
+            1755: -13,7
+            1772: -23,6
+            1787: -27,21
+            1788: -27,23
         - node:
             color: '#9D9D97FF'
             id: BrickTileWhiteLineW
@@ -1608,6 +1572,12 @@ entities:
           decals:
             1535: -6,15
         - node:
+            color: '#B3B3B3FF'
+            id: DirtHeavy
+          decals:
+            1793: -27,21
+            1797: -17,9
+        - node:
             cleanable: True
             color: '#FFFFFFFF'
             id: DirtHeavy
@@ -1659,7 +1629,6 @@ entities:
             1656: 4,3
             1657: 4,0
             1658: -3,2
-            1662: -24,24
             1676: 8,22
             1677: 7,24
             1678: 8,26
@@ -1671,6 +1640,9 @@ entities:
           decals:
             1730: 27,25
             1731: 29,28
+            1794: -25,24
+            1795: -23,22
+            1800: -17,11
         - node:
             cleanable: True
             color: '#FFFFFFFF'
@@ -1724,9 +1696,7 @@ entities:
             1607: 14,-11
             1608: -5,-22
             1609: -5,-23
-            1659: -27,23
             1660: -24,21
-            1661: -23,20
             1681: 9,23
             1682: 11,27
             1683: 11,24
@@ -1734,13 +1704,20 @@ entities:
             1685: 13,27
             1686: 16,25
         - node:
+            color: '#B3B3B3FF'
+            id: DirtLight
+          decals:
+            1796: -26,22
+            1798: -24,10
+            1799: -13,8
+            1802: -22,6
+        - node:
             cleanable: True
             color: '#FFFFFFFF'
             id: DirtLight
           decals:
             1414: -30,3
             1415: -24,1
-            1420: -17,9
             1421: -12,6
             1423: -21,10
             1443: -27,-6
@@ -1822,7 +1799,6 @@ entities:
             1651: -17,20
             1652: -14,18
             1653: -17,14
-            1654: -20,6
         - node:
             color: '#B3B3B3FF'
             id: DirtMedium
@@ -1840,7 +1816,6 @@ entities:
             id: DirtMedium
           decals:
             1422: -27,9
-            1424: -22,5
             1425: -17,16
             1426: -12,11
             1448: -15,-14
@@ -2334,7 +2309,7 @@ entities:
             color: '#52B4E9FF'
             id: MiniTileWhiteCornerNe
           decals:
-            563: -24,7
+            1766: -25,7
         - node:
             color: '#EF7241FF'
             id: MiniTileWhiteCornerNe
@@ -2355,7 +2330,7 @@ entities:
             color: '#52B4E9FF'
             id: MiniTileWhiteCornerSe
           decals:
-            564: -24,5
+            1767: -25,5
         - node:
             color: '#D381C9FF'
             id: MiniTileWhiteCornerSe
@@ -2406,7 +2381,7 @@ entities:
             color: '#52B4E9FF'
             id: MiniTileWhiteLineE
           decals:
-            556: -24,6
+            1768: -25,6
         - node:
             color: '#D381C9FF'
             id: MiniTileWhiteLineE
@@ -2438,7 +2413,6 @@ entities:
           decals:
             557: -26,5
             558: -26,5
-            559: -25,5
         - node:
             color: '#D381C9FF'
             id: MiniTileWhiteLineS
@@ -2485,19 +2459,12 @@ entities:
           decals:
             574: -11,10
             575: -11,6
-            576: -11,5
             653: -10,7
             654: -9,7
             655: -13,12
             656: -10,12
             657: -9,12
-            658: -15,15
             1158: -4,-35
-        - node:
-            color: '#52B4E9FF'
-            id: MonoOverlay
-          decals:
-            561: -25,8
         - node:
             color: '#70707093'
             id: MonoOverlay
@@ -3618,13 +3585,11 @@ entities:
           -5,0:
             0: 65520
           -4,1:
-            0: 65520
-          -5,1:
-            0: 65520
+            0: 43952
           -4,2:
             0: 65535
           -5,2:
-            0: 65535
+            0: 65534
           -4,3:
             0: 64985
           -5,3:
@@ -3634,7 +3599,7 @@ entities:
           -3,0:
             0: 65520
           -3,1:
-            0: 57328
+            0: 57296
           -3,2:
             0: 57341
           -3,3:
@@ -3836,7 +3801,7 @@ entities:
           -7,0:
             0: 65520
           -7,2:
-            0: 61416
+            0: 61412
           -7,-1:
             0: 65535
           -7,1:
@@ -3847,16 +3812,18 @@ entities:
             0: 3854
           -6,0:
             0: 65520
-          -6,1:
-            0: 56784
           -6,2:
-            0: 65532
+            0: 65528
           -6,3:
             0: 48049
+          -6,1:
+            0: 61152
           -6,4:
-            0: 40731
+            0: 36635
           -6,-1:
             0: 61166
+          -5,1:
+            0: 18016
           4,1:
             0: 18016
           5,0:
@@ -3961,7 +3928,7 @@ entities:
           -8,8:
             2: 65327
           -7,6:
-            0: 65294
+            0: 65358
           -7,7:
             0: 4084
           -7,5:
@@ -5083,27 +5050,19 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 5469
       - 5470
-      - 5457
-      - 5348
+      - 5469
       - 5456
+      - 5348
+      - 5457
+      - 8622
+      - 8989
+      - 5466
       - 5459
       - 5458
-      - 7390
-      - 7498
-      - 7342
-      - 7452
-  - uid: 15
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -22.5,7.5
-      parent: 2
-    - type: DeviceList
-      devices:
-      - 7451
-      - 7341
+      - 5462
+      - 9246
+      - 1884
   - uid: 16
     components:
     - type: Transform
@@ -5112,10 +5071,10 @@ entities:
       parent: 2
     - type: DeviceList
       devices:
-      - 7391
-      - 7500
       - 5456
       - 5347
+      - 7500
+      - 9623
   - uid: 17
     components:
     - type: Transform
@@ -5706,6 +5665,63 @@ entities:
       - 7553
       - 7449
       - 7554
+  - uid: 9438
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -13.5,6.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 8989
+      - 7334
+      - 8492
+  - uid: 9563
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -10.5,5.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 5462
+      - 5461
+      - 5460
+      - 7498
+      - 7390
+  - uid: 9627
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -16.5,6.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 8622
+      - 7098
+      - 6501
+  - uid: 10752
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -23.5,7.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 5457
+      - 5825
+      - 7451
+  - uid: 12623
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -19.5,6.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 10015
+      - 10077
+      - 490
 - proto: AirCanister
   entities:
   - uid: 55
@@ -6858,7 +6874,7 @@ entities:
       pos: 38.5,-1.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -6152.1772
+      secondsUntilStateChange: -13466.146
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -7042,6 +7058,11 @@ entities:
     - type: Transform
       pos: 9.5,28.5
       parent: 2
+  - uid: 8690
+    components:
+    - type: Transform
+      pos: -25.5,25.5
+      parent: 2
 - proto: AirlockMaintMedLocked
   entities:
   - uid: 264
@@ -7055,6 +7076,11 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -13.5,22.5
+      parent: 2
+  - uid: 279
+    components:
+    - type: Transform
+      pos: -23.5,17.5
       parent: 2
 - proto: AirlockMaintRnDLocked
   entities:
@@ -7113,39 +7139,36 @@ entities:
       rot: 3.141592653589793 rad
       pos: -10.5,6.5
       parent: 2
-  - uid: 275
+  - uid: 12836
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,5.5
+      pos: -25.5,8.5
       parent: 2
-  - uid: 276
+  - uid: 12837
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -24.5,8.5
+      pos: -20.5,8.5
+      parent: 2
+  - uid: 12838
+    components:
+    - type: Transform
+      pos: -17.5,7.5
+      parent: 2
+  - uid: 12839
+    components:
+    - type: Transform
+      pos: -14.5,7.5
       parent: 2
 - proto: AirlockMedicalLocked
   entities:
-  - uid: 277
-    components:
-    - type: Transform
-      pos: -23.5,19.5
-      parent: 2
   - uid: 278
     components:
     - type: Transform
       pos: 22.5,4.5
       parent: 2
-  - uid: 279
+  - uid: 7391
     components:
     - type: Transform
-      pos: -23.5,17.5
-      parent: 2
-  - uid: 280
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
       pos: -23.5,12.5
       parent: 2
 - proto: AirlockQuartermasterLocked
@@ -8474,20 +8497,20 @@ entities:
       parent: 2
 - proto: BedsheetMedical
   entities:
-  - uid: 488
+  - uid: 12603
     components:
     - type: Transform
-      pos: -15.5,5.5
+      pos: -21.5,11.5
       parent: 2
-  - uid: 489
+  - uid: 12621
     components:
     - type: Transform
-      pos: -17.5,5.5
+      pos: -19.5,11.5
       parent: 2
-  - uid: 490
+  - uid: 12622
     components:
     - type: Transform
-      pos: -20.5,5.5
+      pos: -17.5,11.5
       parent: 2
 - proto: BedsheetMime
   entities:
@@ -8743,39 +8766,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 3.5,-15.5
       parent: 2
-- proto: BodyBag
-  entities:
-  - uid: 522
-    components:
-    - type: Transform
-      pos: -23.819975,23.448257
-      parent: 2
-    - type: EntityStorage
-      air:
-        volume: 200
-        immutable: False
-        temperature: 75.31249
-        moles:
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
-        - 0
 - proto: BookRandom
   entities:
   - uid: 523
@@ -8940,11 +8930,6 @@ entities:
     - type: Transform
       pos: -22.477488,-1.5542104
       parent: 2
-  - uid: 552
-    components:
-    - type: Transform
-      pos: -19.242092,5.6206083
-      parent: 2
   - uid: 553
     components:
     - type: Transform
@@ -9041,6 +9026,11 @@ entities:
     - type: Transform
       pos: 44.420597,31.569736
       parent: 2
+  - uid: 11313
+    components:
+    - type: Transform
+      pos: -23.646357,9.679266
+      parent: 2
 - proto: BoxFolderGrey
   entities:
   - uid: 570
@@ -9101,6 +9091,16 @@ entities:
     - type: Physics
       angularDamping: 0
       linearDamping: 0
+  - uid: 5240
+    components:
+    - type: Transform
+      pos: -23.414852,9.528786
+      parent: 2
+  - uid: 12840
+    components:
+    - type: Transform
+      pos: -9.663411,5.766392
+      parent: 2
 - proto: BoxFolderYellow
   entities:
   - uid: 580
@@ -9317,12 +9317,13 @@ entities:
           - AutoClose
         - - Timer
           - Open
-- proto: Brutepack
+- proto: BrigTimerElectronics
   entities:
-  - uid: 611
+  - uid: 4272
     components:
     - type: Transform
-      pos: -13.973476,5.642187
+      rot: 3.141592653589793 rad
+      pos: -23.582449,26.792467
       parent: 2
 - proto: Bucket
   entities:
@@ -9412,37 +9413,22 @@ entities:
   - uid: 618
     components:
     - type: Transform
-      pos: -23.5,17.5
+      pos: -10.5,9.5
       parent: 2
   - uid: 619
     components:
     - type: Transform
       pos: -23.5,16.5
       parent: 2
-  - uid: 620
-    components:
-    - type: Transform
-      pos: -23.5,22.5
-      parent: 2
-  - uid: 621
-    components:
-    - type: Transform
-      pos: -23.5,21.5
-      parent: 2
   - uid: 622
     components:
     - type: Transform
-      pos: -23.5,20.5
-      parent: 2
-  - uid: 623
-    components:
-    - type: Transform
-      pos: -23.5,19.5
+      pos: -10.5,8.5
       parent: 2
   - uid: 624
     components:
     - type: Transform
-      pos: -23.5,18.5
+      pos: -10.5,11.5
       parent: 2
   - uid: 625
     components:
@@ -11029,16 +11015,6 @@ entities:
     - type: Transform
       pos: -11.5,7.5
       parent: 2
-  - uid: 942
-    components:
-    - type: Transform
-      pos: -11.5,8.5
-      parent: 2
-  - uid: 943
-    components:
-    - type: Transform
-      pos: -11.5,9.5
-      parent: 2
   - uid: 944
     components:
     - type: Transform
@@ -11073,11 +11049,6 @@ entities:
     components:
     - type: Transform
       pos: -15.5,8.5
-      parent: 2
-  - uid: 951
-    components:
-    - type: Transform
-      pos: -15.5,7.5
       parent: 2
   - uid: 952
     components:
@@ -15729,41 +15700,6 @@ entities:
     - type: Transform
       pos: -28.5,30.5
       parent: 2
-  - uid: 1883
-    components:
-    - type: Transform
-      pos: -29.5,23.5
-      parent: 2
-  - uid: 1884
-    components:
-    - type: Transform
-      pos: -29.5,22.5
-      parent: 2
-  - uid: 1885
-    components:
-    - type: Transform
-      pos: -29.5,21.5
-      parent: 2
-  - uid: 1886
-    components:
-    - type: Transform
-      pos: -29.5,20.5
-      parent: 2
-  - uid: 1887
-    components:
-    - type: Transform
-      pos: -29.5,19.5
-      parent: 2
-  - uid: 1888
-    components:
-    - type: Transform
-      pos: -29.5,18.5
-      parent: 2
-  - uid: 1889
-    components:
-    - type: Transform
-      pos: -29.5,17.5
-      parent: 2
   - uid: 1890
     components:
     - type: Transform
@@ -15829,16 +15765,6 @@ entities:
     - type: Transform
       pos: -28.5,27.5
       parent: 2
-  - uid: 1903
-    components:
-    - type: Transform
-      pos: -28.5,26.5
-      parent: 2
-  - uid: 1904
-    components:
-    - type: Transform
-      pos: -28.5,25.5
-      parent: 2
   - uid: 1905
     components:
     - type: Transform
@@ -15847,7 +15773,7 @@ entities:
   - uid: 1906
     components:
     - type: Transform
-      pos: -29.5,24.5
+      pos: -31.5,22.5
       parent: 2
   - uid: 1907
     components:
@@ -16004,6 +15930,11 @@ entities:
     - type: Transform
       pos: -14.5,27.5
       parent: 2
+  - uid: 4227
+    components:
+    - type: Transform
+      pos: -33.5,22.5
+      parent: 2
   - uid: 4340
     components:
     - type: Transform
@@ -16063,6 +15994,16 @@ entities:
     components:
     - type: Transform
       pos: 39.5,-23.5
+      parent: 2
+  - uid: 8418
+    components:
+    - type: Transform
+      pos: -23.5,17.5
+      parent: 2
+  - uid: 12624
+    components:
+    - type: Transform
+      pos: -15.5,7.5
       parent: 2
 - proto: CableApcStack
   entities:
@@ -23302,6 +23243,26 @@ entities:
       parent: 2
 - proto: CarpetBlue
   entities:
+  - uid: 277
+    components:
+    - type: Transform
+      pos: 0.5,20.5
+      parent: 2
+  - uid: 623
+    components:
+    - type: Transform
+      pos: -0.5,20.5
+      parent: 2
+  - uid: 942
+    components:
+    - type: Transform
+      pos: -1.5,20.5
+      parent: 2
+  - uid: 943
+    components:
+    - type: Transform
+      pos: -2.5,20.5
+      parent: 2
   - uid: 3372
     components:
     - type: Transform
@@ -23359,6 +23320,31 @@ entities:
     components:
     - type: Transform
       pos: -20.5,16.5
+      parent: 2
+  - uid: 10033
+    components:
+    - type: Transform
+      pos: 0.5,19.5
+      parent: 2
+  - uid: 12847
+    components:
+    - type: Transform
+      pos: 1.5,20.5
+      parent: 2
+  - uid: 12848
+    components:
+    - type: Transform
+      pos: 1.5,21.5
+      parent: 2
+  - uid: 12849
+    components:
+    - type: Transform
+      pos: 0.5,21.5
+      parent: 2
+  - uid: 12850
+    components:
+    - type: Transform
+      pos: -0.5,21.5
       parent: 2
 - proto: CarpetGreen
   entities:
@@ -26130,12 +26116,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -32.5,22.5
       parent: 2
-  - uid: 3869
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -34.5,23.5
-      parent: 2
   - uid: 3870
     components:
     - type: Transform
@@ -26454,13 +26434,6 @@ entities:
     components:
     - type: Transform
       pos: 27.5,-26.5
-      parent: 2
-- proto: Cautery
-  entities:
-  - uid: 3922
-    components:
-    - type: Transform
-      pos: -24.632475,20.505098
       parent: 2
 - proto: Chair
   entities:
@@ -26907,6 +26880,28 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -28.5,11.5
+      parent: 2
+  - uid: 12737
+    components:
+    - type: Transform
+      pos: -14.5,9.5
+      parent: 2
+  - uid: 12829
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -14.5,10.5
+      parent: 2
+  - uid: 12830
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -13.5,10.5
+      parent: 2
+  - uid: 12831
+    components:
+    - type: Transform
+      pos: -13.5,9.5
       parent: 2
 - proto: ChairCursed
   entities:
@@ -27687,6 +27682,13 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 16.5,-0.5
       parent: 2
+- proto: ClosetBombFilled
+  entities:
+  - uid: 10546
+    components:
+    - type: Transform
+      pos: 18.5,15.5
+      parent: 2
 - proto: ClosetChefFilled
   entities:
   - uid: 4130
@@ -28242,11 +28244,6 @@ entities:
     - type: Transform
       pos: -7.5,24.5
       parent: 2
-  - uid: 4227
-    components:
-    - type: Transform
-      pos: -34.5,21.5
-      parent: 2
 - proto: ClosetRadiationSuitFilled
   entities:
   - uid: 4228
@@ -28337,6 +28334,13 @@ entities:
     - type: Transform
       pos: -9.479882,-29.613472
       parent: 2
+- proto: ClothingBackpackDuffelSurgeryFilled
+  entities:
+  - uid: 12601
+    components:
+    - type: Transform
+      pos: -15.5,6.5
+      parent: 2
 - proto: ClothingBeltChampion
   entities:
   - uid: 4238
@@ -28370,11 +28374,6 @@ entities:
       parent: 2
 - proto: ClothingEyesGlasses
   entities:
-  - uid: 4243
-    components:
-    - type: Transform
-      pos: -18.474297,5.7612333
-      parent: 2
   - uid: 4244
     components:
     - type: Transform
@@ -28458,11 +28457,6 @@ entities:
     components:
     - type: Transform
       pos: 23.541037,5.5013475
-      parent: 2
-  - uid: 4254
-    components:
-    - type: Transform
-      pos: -25.418951,24.343168
       parent: 2
 - proto: ClothingHandsGlovesNitrile
   entities:
@@ -28606,11 +28600,6 @@ entities:
     - type: Transform
       pos: 23.509787,5.6575975
       parent: 2
-  - uid: 4272
-    components:
-    - type: Transform
-      pos: -25.575201,24.655668
-      parent: 2
 - proto: ClothingNeckMantleHOP
   entities:
   - uid: 4275
@@ -28620,19 +28609,12 @@ entities:
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-- proto: ClothingNeckScarfStripedBlue
-  entities:
-  - uid: 4277
-    components:
-    - type: Transform
-      pos: -19.618053,5.339943
-      parent: 2
 - proto: ClothingNeckStethoscope
   entities:
-  - uid: 4278
+  - uid: 12814
     components:
     - type: Transform
-      pos: -14.567226,5.579687
+      pos: -12.460064,5.608284
       parent: 2
 - proto: ClothingNeckTieRed
   entities:
@@ -29154,6 +29136,12 @@ entities:
       parent: 2
 - proto: ConveyorBelt
   entities:
+  - uid: 3869
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -34.5,23.5
+      parent: 2
   - uid: 4356
     components:
     - type: Transform
@@ -29240,29 +29228,17 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -34.5,25.5
       parent: 2
-  - uid: 4372
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -33.5,25.5
-      parent: 2
   - uid: 4373
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -33.5,24.5
+      pos: -34.5,22.5
       parent: 2
-  - uid: 4374
+  - uid: 9320
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -33.5,23.5
-      parent: 2
-  - uid: 4375
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -33.5,22.5
+      pos: -34.5,24.5
       parent: 2
 - proto: CorporateCircuitBoard
   entities:
@@ -29451,10 +29427,10 @@ entities:
       parent: 2
 - proto: CrateLockBoxMedical
   entities:
-  - uid: 8767
+  - uid: 12845
     components:
     - type: Transform
-      pos: -11.5,11.5
+      pos: -24.5,7.5
       parent: 2
 - proto: CrateLockBoxScience
   entities:
@@ -29479,10 +29455,15 @@ entities:
       parent: 2
 - proto: CrateMedicalSurgery
   entities:
-  - uid: 4397
+  - uid: 4492
     components:
     - type: Transform
-      pos: -22.5,24.5
+      pos: -26.5,23.5
+      parent: 2
+  - uid: 10753
+    components:
+    - type: Transform
+      pos: -18.5,6.5
       parent: 2
 - proto: CrateNPCCow
   entities:
@@ -29587,11 +29568,6 @@ entities:
       parent: 2
 - proto: CrowbarRed
   entities:
-  - uid: 4410
-    components:
-    - type: Transform
-      pos: -23.596352,6.739663
-      parent: 2
   - uid: 4411
     components:
     - type: Transform
@@ -29652,10 +29628,10 @@ entities:
       parent: 2
 - proto: CryoPod
   entities:
-  - uid: 4421
+  - uid: 10925
     components:
     - type: Transform
-      pos: -26.5,7.5
+      pos: -22.5,7.5
       parent: 2
 - proto: CryoPodMachineCircuitboard
   entities:
@@ -29663,6 +29639,13 @@ entities:
     components:
     - type: Transform
       pos: -3.3774533,-34.32878
+      parent: 2
+- proto: CryoxadoneBeakerSmall
+  entities:
+  - uid: 12834
+    components:
+    - type: Transform
+      pos: -21.638859,5.740759
       parent: 2
 - proto: Crystallizer
   entities:
@@ -29865,6 +29848,13 @@ entities:
     - type: Transform
       pos: 43.5,31.5
       parent: 2
+- proto: DefaultStationBeaconCryonics
+  entities:
+  - uid: 1888
+    components:
+    - type: Transform
+      pos: -20.5,7.5
+      parent: 2
 - proto: DefaultStationBeaconCryosleep
   entities:
   - uid: 4451
@@ -29930,10 +29920,22 @@ entities:
       parent: 2
 - proto: DefaultStationBeaconMedbay
   entities:
+  - uid: 1887
+    components:
+    - type: Transform
+      pos: -19.5,10.5
+      parent: 2
   - uid: 4460
     components:
     - type: Transform
       pos: -9.5,10.5
+      parent: 2
+- proto: DefaultStationBeaconMedical
+  entities:
+  - uid: 1889
+    components:
+    - type: Transform
+      pos: -25.5,6.5
       parent: 2
 - proto: DefaultStationBeaconMorgue
   entities:
@@ -30012,10 +30014,15 @@ entities:
       parent: 2
 - proto: DefaultStationBeaconSurgery
   entities:
-  - uid: 4472
+  - uid: 5039
     components:
     - type: Transform
-      pos: -23.5,21.5
+      pos: -17.5,6.5
+      parent: 2
+  - uid: 10182
+    components:
+    - type: Transform
+      pos: -14.5,6.5
       parent: 2
 - proto: DefaultStationBeaconTechVault
   entities:
@@ -30054,6 +30061,11 @@ entities:
       parent: 2
 - proto: DefibrillatorCabinetFilled
   entities:
+  - uid: 522
+    components:
+    - type: Transform
+      pos: -24.5,25.5
+      parent: 2
   - uid: 4400
     components:
     - type: Transform
@@ -30071,12 +30083,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -12.5,17.5
-      parent: 2
-  - uid: 4480
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -22.5,5.5
       parent: 2
   - uid: 4481
     components:
@@ -30139,12 +30145,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,25.5
-      parent: 2
-  - uid: 4492
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -21.5,23.5
       parent: 2
   - uid: 4493
     components:
@@ -30605,11 +30605,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 2.5,24.5
       parent: 2
-  - uid: 4574
-    components:
-    - type: Transform
-      pos: -16.5,11.5
-      parent: 2
   - uid: 4575
     components:
     - type: Transform
@@ -30682,6 +30677,12 @@ entities:
       parent: 2
 - proto: DisposalJunctionFlipped
   entities:
+  - uid: 4574
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -11.5,9.5
+      parent: 2
   - uid: 4587
     components:
     - type: Transform
@@ -30742,6 +30743,11 @@ entities:
       parent: 2
 - proto: DisposalPipe
   entities:
+  - uid: 4278
+    components:
+    - type: Transform
+      pos: -11.5,10.5
+      parent: 2
   - uid: 4597
     components:
     - type: Transform
@@ -31173,8 +31179,7 @@ entities:
   - uid: 4673
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -11.5,9.5
+      pos: -16.5,11.5
       parent: 2
   - uid: 4674
     components:
@@ -33154,12 +33159,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -14.5,-3.5
       parent: 2
-  - uid: 5014
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -17.5,11.5
-      parent: 2
   - uid: 5015
     components:
     - type: Transform
@@ -33203,12 +33202,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -29.5,4.5
-      parent: 2
-  - uid: 5023
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -33.5,22.5
       parent: 2
   - uid: 5024
     components:
@@ -33282,6 +33275,11 @@ entities:
     - type: Transform
       pos: 7.5,27.5
       parent: 2
+  - uid: 5173
+    components:
+    - type: Transform
+      pos: -11.5,11.5
+      parent: 2
 - proto: DisposalUnit
   entities:
   - uid: 5037
@@ -33293,11 +33291,6 @@ entities:
     components:
     - type: Transform
       pos: 13.5,-4.5
-      parent: 2
-  - uid: 5039
-    components:
-    - type: Transform
-      pos: -17.5,11.5
       parent: 2
   - uid: 5040
     components:
@@ -33434,6 +33427,11 @@ entities:
     - type: Transform
       pos: 7.5,27.5
       parent: 2
+  - uid: 10012
+    components:
+    - type: Transform
+      pos: -11.5,11.5
+      parent: 2
 - proto: DisposalYJunction
   entities:
   - uid: 5067
@@ -33512,11 +33510,6 @@ entities:
       parent: 2
 - proto: Drill
   entities:
-  - uid: 5078
-    components:
-    - type: Transform
-      pos: -26.392878,20.608793
-      parent: 2
   - uid: 5079
     components:
     - type: Transform
@@ -34218,29 +34211,17 @@ entities:
     - type: Transform
       pos: -1.5,47.5
       parent: 2
-- proto: EmergencyMedipen
+- proto: EmergencyRollerBedSpawnFolded
   entities:
-  - uid: 5171
+  - uid: 275
     components:
     - type: Transform
-      pos: -13.426601,5.751562
+      pos: -12.5,6.5
       parent: 2
-  - uid: 5172
+  - uid: 489
     components:
     - type: Transform
-      pos: -13.504726,5.517187
-      parent: 2
-- proto: EmergencyRollerBed
-  entities:
-  - uid: 5173
-    components:
-    - type: Transform
-      pos: -14.510358,11.588304
-      parent: 2
-  - uid: 5174
-    components:
-    - type: Transform
-      pos: -13.494733,11.588304
+      pos: -12.5,7.5
       parent: 2
 - proto: EncryptionKeyCargo
   entities:
@@ -34612,13 +34593,6 @@ entities:
       parent: 2
 - proto: FaxMachineBase
   entities:
-  - uid: 5240
-    components:
-    - type: Transform
-      pos: -22.5,11.5
-      parent: 2
-    - type: FaxMachine
-      name: Medical
   - uid: 5241
     components:
     - type: Transform
@@ -34689,6 +34663,13 @@ entities:
       parent: 2
     - type: FaxMachine
       name: Nanorep Office
+  - uid: 11044
+    components:
+    - type: Transform
+      pos: -26.5,9.5
+      parent: 2
+    - type: FaxMachine
+      name: Medical
 - proto: FaxMachineCaptain
   entities:
   - uid: 5251
@@ -34792,7 +34773,6 @@ entities:
       - 5484
       - 5485
       - 5486
-      - 5494
       - 5493
       - 5489
       - 5490
@@ -34893,18 +34873,16 @@ entities:
     - type: DeviceList
       devices:
       - 5469
-      - 5470
-      - 5457
-      - 5348
       - 5456
+      - 5348
+      - 5457
+      - 8622
+      - 8989
+      - 5466
       - 5459
       - 5458
-  - uid: 5265
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -22.5,6.5
-      parent: 2
+      - 5462
+      - 5470
   - uid: 5266
     components:
     - type: Transform
@@ -35345,6 +35323,24 @@ entities:
       - 5556
       - 5555
       - 5364
+  - uid: 10755
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -23.5,6.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 5457
+  - uid: 12846
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -19.5,7.5
+      parent: 2
+    - type: DeviceList
+      devices:
+      - 490
 - proto: FireAxeCabinetFilled
   entities:
   - uid: 5298
@@ -35649,12 +35645,20 @@ entities:
       rot: 3.141592653589793 rad
       pos: -23.5,16.5
       parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 16
+      - 5267
   - uid: 5348
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -26.5,10.5
       parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 14
+      - 5264
   - uid: 5349
     components:
     - type: Transform
@@ -35901,6 +35905,15 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 7
+  - uid: 490
+    components:
+    - type: Transform
+      pos: -20.5,8.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 12846
+      - 12623
   - uid: 5387
     components:
     - type: Transform
@@ -36307,48 +36320,72 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -23.5,12.5
       parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 14
+      - 5264
+      - 16
+      - 5267
   - uid: 5457
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -24.5,8.5
+      pos: -25.5,8.5
       parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 5264
+      - 14
+      - 10752
+      - 10755
   - uid: 5458
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,9.5
       parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 14
+      - 5264
   - uid: 5459
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,10.5
       parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 14
+      - 5264
   - uid: 5460
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -9.5,7.5
       parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 9563
   - uid: 5461
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -8.5,7.5
       parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 9563
   - uid: 5462
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -10.5,6.5
       parent: 2
-  - uid: 5463
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -10.5,5.5
-      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 14
+      - 9563
+      - 5264
   - uid: 5464
     components:
     - type: Transform
@@ -36367,6 +36404,10 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -12.5,12.5
       parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 14
+      - 5264
   - uid: 5467
     components:
     - type: Transform
@@ -36385,12 +36426,20 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -16.5,12.5
       parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 14
+      - 5264
   - uid: 5470
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -15.5,12.5
       parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 14
+      - 5264
   - uid: 5471
     components:
     - type: Transform
@@ -36508,6 +36557,10 @@ entities:
     - type: Transform
       pos: 32.5,15.5
       parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 4
+      - 5258
   - uid: 5491
     components:
     - type: Transform
@@ -36523,6 +36576,9 @@ entities:
     - type: Transform
       pos: 30.5,13.5
       parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 5258
   - uid: 5494
     components:
     - type: Transform
@@ -37019,6 +37075,26 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 49
+  - uid: 8622
+    components:
+    - type: Transform
+      pos: -17.5,7.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 5264
+      - 9627
+      - 14
+  - uid: 8989
+    components:
+    - type: Transform
+      pos: -14.5,7.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 5264
+      - 9438
+      - 14
 - proto: Fireplace
   entities:
   - uid: 5579
@@ -37101,6 +37177,14 @@ entities:
       parent: 2
 - proto: FloorDrain
   entities:
+  - uid: 4372
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -24.5,21.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
   - uid: 5592
     components:
     - type: Transform
@@ -37127,6 +37211,20 @@ entities:
     components:
     - type: Transform
       pos: -11.5,15.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+  - uid: 5829
+    components:
+    - type: Transform
+      pos: -14.5,5.5
+      parent: 2
+    - type: Fixtures
+      fixtures: {}
+  - uid: 6488
+    components:
+    - type: Transform
+      pos: -17.5,5.5
       parent: 2
     - type: Fixtures
       fixtures: {}
@@ -37593,11 +37691,11 @@ entities:
       parent: 2
 - proto: GasPipeBend
   entities:
-  - uid: 5669
+  - uid: 4410
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -18.5,7.5
+      rot: -1.5707963267948966 rad
+      pos: -14.5,6.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -38621,16 +38719,30 @@ entities:
       rot: 3.141592653589793 rad
       pos: 38.5,-1.5
       parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 6951
     components:
     - type: Transform
       pos: 19.5,-25.5
       parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 7312
     components:
     - type: Transform
       pos: 39.5,-1.5
       parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 8493
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -17.5,6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
 - proto: GasPipeFourway
   entities:
   - uid: 5810
@@ -38724,8 +38836,22 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
+  - uid: 7099
+    components:
+    - type: Transform
+      pos: -20.5,9.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
 - proto: GasPipeStraight
   entities:
+  - uid: 280
+    components:
+    - type: Transform
+      pos: -15.5,8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 1351
     components:
     - type: Transform
@@ -38755,14 +38881,6 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 5825
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -24.5,7.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 5826
     components:
     - type: Transform
@@ -38771,27 +38889,11 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 5827
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -21.5,10.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 5828
     components:
     - type: Transform
       pos: 39.5,-6.5
       parent: 2
-  - uid: 5829
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -20.5,9.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 5830
     components:
     - type: Transform
@@ -43470,14 +43572,6 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
-  - uid: 6480
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -15.5,9.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 6481
     components:
     - type: Transform
@@ -43510,14 +43604,6 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 6485
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -14.5,10.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
   - uid: 6486
     components:
     - type: Transform
@@ -43531,14 +43617,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -17.5,10.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 6488
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -19.5,10.5
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
@@ -43638,24 +43716,17 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 6501
-    components:
-    - type: Transform
-      pos: -23.5,10.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 6502
     components:
     - type: Transform
-      pos: -23.5,11.5
+      pos: -14.5,7.5
       parent: 2
     - type: AtmosPipeColor
-      color: '#0055CCFF'
+      color: '#990000FF'
   - uid: 6503
     components:
     - type: Transform
-      pos: -23.5,12.5
+      pos: -15.5,7.5
       parent: 2
     - type: AtmosPipeColor
       color: '#0055CCFF'
@@ -48245,12 +48316,114 @@ entities:
     - type: Transform
       pos: 39.5,-8.5
       parent: 2
+  - uid: 7212
+    components:
+    - type: Transform
+      pos: -14.5,8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 7338
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 39.5,-2.5
       parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 7622
+    components:
+    - type: Transform
+      pos: -14.5,9.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 8494
+    components:
+    - type: Transform
+      pos: -17.5,8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 8496
+    components:
+    - type: Transform
+      pos: -18.5,6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 8623
+    components:
+    - type: Transform
+      pos: -17.5,7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 8689
+    components:
+    - type: Transform
+      pos: -21.5,9.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 8717
+    components:
+    - type: Transform
+      pos: -21.5,8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 8723
+    components:
+    - type: Transform
+      pos: -23.5,11.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 9622
+    components:
+    - type: Transform
+      pos: -23.5,10.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 10099
+    components:
+    - type: Transform
+      pos: -23.5,12.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 10635
+    components:
+    - type: Transform
+      pos: -18.5,7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 10927
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -20.5,7.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 10931
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -20.5,8.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 10943
+    components:
+    - type: Transform
+      pos: -15.5,6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 12606
     components:
     - type: Transform
@@ -48259,11 +48432,40 @@ entities:
       parent: 2
 - proto: GasPipeTJunction
   entities:
+  - uid: 951
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -22.5,6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 5827
+    components:
+    - type: Transform
+      pos: -21.5,10.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 5918
     components:
     - type: Transform
       pos: 37.5,-4.5
       parent: 2
+  - uid: 6480
+    components:
+    - type: Transform
+      pos: -15.5,9.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 6485
+    components:
+    - type: Transform
+      pos: -14.5,10.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 7095
     components:
     - type: Transform
@@ -48288,20 +48490,6 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 7098
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -26.5,6.5
-      parent: 2
-  - uid: 7099
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -24.5,6.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 7100
     components:
     - type: Transform
@@ -49107,14 +49295,6 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
-  - uid: 7212
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -23.5,9.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 7213
     components:
     - type: Transform
@@ -49809,6 +49989,29 @@ entities:
       parent: 2
     - type: AtmosPipeColor
       color: '#990000FF'
+  - uid: 7315
+    components:
+    - type: Transform
+      pos: -19.5,10.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 9957
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -23.5,9.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 10571
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -20.5,6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 12733
     components:
     - type: Transform
@@ -49880,6 +50083,14 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 39.5,-6.5
       parent: 2
+  - uid: 552
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -21.5,6.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 5640
     components:
     - type: Transform
@@ -49921,14 +50132,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 39.5,-14.5
       parent: 2
-  - uid: 7315
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -25.5,6.5
-      parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
   - uid: 7317
     components:
     - type: Transform
@@ -49984,17 +50187,19 @@ entities:
       color: '#0055CCFF'
 - proto: GasThermoMachineFreezer
   entities:
-  - uid: 7334
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -26.5,5.5
-      parent: 2
   - uid: 7337
     components:
     - type: Transform
       pos: 34.5,-6.5
       parent: 2
+  - uid: 10942
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -22.5,5.5
+      parent: 2
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
 - proto: GasThermoMachineHeater
   entities:
   - uid: 7108
@@ -50018,10 +50223,34 @@ entities:
       rot: 3.141592653589793 rad
       pos: 39.5,-3.5
       parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
     - type: GasValve
       open: False
 - proto: GasVentPump
   entities:
+  - uid: 5825
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -24.5,7.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 10752
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 6501
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -18.5,6.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 9627
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
   - uid: 7340
     components:
     - type: Transform
@@ -50031,28 +50260,6 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 50
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 7341
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -23.5,6.5
-      parent: 2
-    - type: DeviceNetwork
-      deviceLists:
-      - 15
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 7342
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -17.5,8.5
-      parent: 2
-    - type: DeviceNetwork
-      deviceLists:
-      - 14
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 7343
@@ -50428,13 +50635,9 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -9.5,6.5
       parent: 2
-    - type: AtmosPipeColor
-      color: '#0055CCFF'
-  - uid: 7391
-    components:
-    - type: Transform
-      pos: -23.5,13.5
-      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 9563
     - type: AtmosPipeColor
       color: '#0055CCFF'
   - uid: 7392
@@ -50899,8 +51102,85 @@ entities:
       - 51
     - type: AtmosPipeColor
       color: '#0055CCFF'
+  - uid: 8492
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -15.5,5.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 9438
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 9246
+    components:
+    - type: Transform
+      pos: -20.5,10.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 14
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 9623
+    components:
+    - type: Transform
+      pos: -23.5,13.5
+      parent: 2
+    - type: DeviceNetwork
+      configurators:
+      - invalid
+      deviceLists:
+      - 16
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
+  - uid: 10015
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -20.5,5.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 12623
+    - type: AtmosPipeColor
+      color: '#0055CCFF'
 - proto: GasVentScrubber
   entities:
+  - uid: 1884
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -19.5,9.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 14
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 7098
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -18.5,5.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 9627
+    - type: AtmosPipeColor
+      color: '#990000FF'
+  - uid: 7334
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -15.5,6.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 9438
+    - type: AtmosPipeColor
+      color: '#990000FF'
   - uid: 7450
     components:
     - type: Transform
@@ -50916,18 +51196,7 @@ entities:
       parent: 2
     - type: DeviceNetwork
       deviceLists:
-      - 15
-    - type: AtmosPipeColor
-      color: '#990000FF'
-  - uid: 7452
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -17.5,7.5
-      parent: 2
-    - type: DeviceNetwork
-      deviceLists:
-      - 14
+      - 10752
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 7453
@@ -51296,6 +51565,9 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -9.5,5.5
       parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 9563
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 7499
@@ -51310,6 +51582,9 @@ entities:
     - type: Transform
       pos: -24.5,13.5
       parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 16
     - type: AtmosPipeColor
       color: '#990000FF'
   - uid: 7501
@@ -51646,6 +51921,8 @@ entities:
       rot: 3.141592653589793 rad
       pos: 19.5,-26.5
       parent: 2
+    - type: AtmosPipeColor
+      color: '#990000FF'
     - type: DeviceNetwork
       deviceLists:
       - 49
@@ -51750,6 +52027,17 @@ entities:
       - 50
     - type: AtmosPipeColor
       color: '#990000FF'
+  - uid: 10077
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -21.5,7.5
+      parent: 2
+    - type: DeviceNetwork
+      deviceLists:
+      - 12623
+    - type: AtmosPipeColor
+      color: '#990000FF'
 - proto: GeneratorBasic15kW
   entities:
   - uid: 7556
@@ -51799,6 +52087,11 @@ entities:
     components:
     - type: Transform
       pos: -19.5,-1.5
+      parent: 2
+  - uid: 5171
+    components:
+    - type: Transform
+      pos: -15.5,7.5
       parent: 2
   - uid: 7560
     components:
@@ -52066,37 +52359,7 @@ entities:
   - uid: 7613
     components:
     - type: Transform
-      pos: -25.5,8.5
-      parent: 2
-  - uid: 7614
-    components:
-    - type: Transform
-      pos: -14.5,4.5
-      parent: 2
-  - uid: 7615
-    components:
-    - type: Transform
-      pos: -15.5,4.5
-      parent: 2
-  - uid: 7616
-    components:
-    - type: Transform
-      pos: -12.5,4.5
-      parent: 2
-  - uid: 7617
-    components:
-    - type: Transform
-      pos: -11.5,4.5
-      parent: 2
-  - uid: 7618
-    components:
-    - type: Transform
-      pos: -17.5,4.5
-      parent: 2
-  - uid: 7619
-    components:
-    - type: Transform
-      pos: -18.5,4.5
+      pos: -24.5,8.5
       parent: 2
   - uid: 7620
     components:
@@ -52107,11 +52370,6 @@ entities:
     components:
     - type: Transform
       pos: -21.5,4.5
-      parent: 2
-  - uid: 7622
-    components:
-    - type: Transform
-      pos: -23.5,8.5
       parent: 2
   - uid: 7623
     components:
@@ -55349,10 +55607,21 @@ entities:
     - type: Transform
       pos: 10.5,24.5
       parent: 2
+  - uid: 8667
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -21.5,8.5
+      parent: 2
   - uid: 8825
     components:
     - type: Transform
       pos: 19.5,-25.5
+      parent: 2
+  - uid: 9056
+    components:
+    - type: Transform
+      pos: -18.5,7.5
       parent: 2
   - uid: 9962
     components:
@@ -55371,6 +55640,18 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 21.5,-29.5
+      parent: 2
+  - uid: 10754
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -22.5,4.5
+      parent: 2
+  - uid: 10920
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -22.5,8.5
       parent: 2
 - proto: GrilleBroken
   entities:
@@ -56020,13 +56301,6 @@ entities:
     - type: Transform
       pos: -18.5,-50.5
       parent: 2
-- proto: Hemostat
-  entities:
-  - uid: 8356
-    components:
-    - type: Transform
-      pos: -24.643688,20.826443
-      parent: 2
 - proto: HighSecArmoryLocked
   entities:
   - uid: 8755
@@ -56304,12 +56578,19 @@ entities:
     - type: Transform
       pos: -11.5,14.5
       parent: 2
-- proto: HolopadMedicalMedbay
+- proto: HolopadMedicalCryopods
   entities:
-  - uid: 12814
+  - uid: 9941
     components:
     - type: Transform
-      pos: -16.5,7.5
+      pos: -20.5,6.5
+      parent: 2
+- proto: HolopadMedicalMedbay
+  entities:
+  - uid: 7616
+    components:
+    - type: Transform
+      pos: -15.5,10.5
       parent: 2
 - proto: HolopadMedicalMorgue
   entities:
@@ -56317,6 +56598,13 @@ entities:
     components:
     - type: Transform
       pos: -23.5,15.5
+      parent: 2
+- proto: HolopadMedicalVirology
+  entities:
+  - uid: 9605
+    components:
+    - type: Transform
+      pos: -15.5,19.5
       parent: 2
 - proto: HolopadScienceAnomaly
   entities:
@@ -56763,12 +57051,6 @@ entities:
     - type: Transform
       pos: -22.5,17.5
       parent: 2
-  - uid: 8418
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -27.5,21.5
-      parent: 2
 - proto: IntercomScience
   entities:
   - uid: 8419
@@ -57114,6 +57396,22 @@ entities:
     - type: Physics
       angularDamping: 0
       linearDamping: 0
+- proto: LockableButtonMedical
+  entities:
+  - uid: 9437
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -10.5,8.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        272:
+        - - Pressed
+          - Open
+        273:
+        - - Pressed
+          - Open
 - proto: LockerAtmosphericsFilledHardsuit
   entities:
   - uid: 8271
@@ -57479,32 +57777,34 @@ entities:
       parent: 2
 - proto: LockerMedicalFilled
   entities:
-  - uid: 8492
+  - uid: 4421
     components:
     - type: Transform
-      pos: -26.5,9.5
+      pos: -26.5,7.5
       parent: 2
-  - uid: 8493
+  - uid: 7341
     components:
     - type: Transform
-      pos: -25.5,9.5
-      parent: 2
-  - uid: 8494
-    components:
-    - type: Transform
-      pos: -23.5,9.5
+      pos: -26.5,6.5
       parent: 2
 - proto: LockerMedicineFilled
   entities:
-  - uid: 8496
+  - uid: 11038
     components:
     - type: Transform
-      pos: -19.5,11.5
+      pos: -20.5,11.5
       parent: 2
-  - uid: 8497
+  - uid: 11039
     components:
     - type: Transform
       pos: -18.5,11.5
+      parent: 2
+- proto: LockerParamedicFilled
+  entities:
+  - uid: 12844
+    components:
+    - type: Transform
+      pos: -11.5,5.5
       parent: 2
 - proto: LockerQuarterMasterFilled
   entities:
@@ -58110,11 +58410,6 @@ entities:
     - type: Transform
       pos: -22.5,26.5
       parent: 2
-  - uid: 8611
-    components:
-    - type: Transform
-      pos: -28.5,23.5
-      parent: 2
 - proto: MaterialCloth
   entities:
   - uid: 8612
@@ -58157,16 +58452,6 @@ entities:
       parent: 2
 - proto: MedicalBed
   entities:
-  - uid: 8616
-    components:
-    - type: Transform
-      pos: -17.5,5.5
-      parent: 2
-  - uid: 8617
-    components:
-    - type: Transform
-      pos: -15.5,5.5
-      parent: 2
   - uid: 8618
     components:
     - type: Transform
@@ -58187,10 +58472,20 @@ entities:
     - type: Transform
       pos: -10.5,21.5
       parent: 2
-  - uid: 8622
+  - uid: 10961
     components:
     - type: Transform
-      pos: -20.5,5.5
+      pos: -21.5,11.5
+      parent: 2
+  - uid: 11036
+    components:
+    - type: Transform
+      pos: -19.5,11.5
+      parent: 2
+  - uid: 11037
+    components:
+    - type: Transform
+      pos: -17.5,11.5
       parent: 2
 - proto: MedicalBiofabricator
   entities:
@@ -58209,10 +58504,10 @@ entities:
       parent: 2
 - proto: MedicalTechFab
   entities:
-  - uid: 8623
+  - uid: 276
     components:
     - type: Transform
-      pos: -23.5,7.5
+      pos: -24.5,6.5
       parent: 2
 - proto: MedkitAdvancedFilled
   entities:
@@ -58293,11 +58588,6 @@ entities:
     components:
     - type: Transform
       pos: 44.521946,6.5499096
-      parent: 2
-  - uid: 8638
-    components:
-    - type: Transform
-      pos: -26.512701,21.421293
       parent: 2
 - proto: MedkitO2
   entities:
@@ -58520,13 +58810,20 @@ entities:
     - type: Physics
       angularDamping: 0
       linearDamping: 0
-- proto: NetworkConfigurator
-  entities:
-  - uid: 8667
+  - uid: 12851
+    mapInit: true
+    paused: true
     components:
     - type: Transform
-      pos: -23.518227,6.599038
+      pos: -3.114146,32.236465
       parent: 2
+    - type: NetworkConfigurator
+      lastUseAttempt: 202.0865886
+    - type: EmitSoundOnCollide
+      nextSound: -29.979846
+    - type: Physics
+      angularDamping: 0
+      linearDamping: 0
 - proto: NitrogenCanister
   entities:
   - uid: 8668
@@ -58642,17 +58939,28 @@ entities:
       linearDamping: 0
 - proto: Ointment
   entities:
-  - uid: 8689
+  - uid: 12833
     components:
     - type: Transform
-      pos: -14.567226,5.626562
+      rot: 1.5707963267948966 rad
+      pos: -12.630861,5.7497396
       parent: 2
 - proto: OperatingTable
   entities:
-  - uid: 8690
+  - uid: 8611
     components:
     - type: Transform
-      pos: -24.5,22.5
+      pos: -24.5,21.5
+      parent: 2
+  - uid: 12595
+    components:
+    - type: Transform
+      pos: -17.5,5.5
+      parent: 2
+  - uid: 12596
+    components:
+    - type: Transform
+      pos: -14.5,5.5
       parent: 2
 - proto: OreProcessor
   entities:
@@ -58795,12 +59103,6 @@ entities:
       parent: 2
 - proto: Paper
   entities:
-  - uid: 8717
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -18.320217,5.3706083
-      parent: 2
   - uid: 8718
     components:
     - type: Transform
@@ -58825,12 +59127,6 @@ entities:
     components:
     - type: Transform
       pos: -40.011135,-5.7034664
-      parent: 2
-  - uid: 8723
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -18.820217,5.4643583
       parent: 2
 - proto: PaperBin10
   entities:
@@ -59272,6 +59568,36 @@ entities:
     - type: Transform
       pos: -9.640527,-12.015921
       parent: 2
+  - uid: 10189
+    components:
+    - type: Transform
+      pos: -23.00635,9.687412
+      parent: 2
+  - uid: 11575
+    components:
+    - type: Transform
+      pos: -22.953218,9.628363
+      parent: 2
+  - uid: 11576
+    components:
+    - type: Transform
+      pos: -22.88828,9.563408
+      parent: 2
+  - uid: 12841
+    components:
+    - type: Transform
+      pos: -9.498115,5.3884764
+      parent: 2
+  - uid: 12842
+    components:
+    - type: Transform
+      pos: -9.409563,5.477051
+      parent: 2
+  - uid: 12843
+    components:
+    - type: Transform
+      pos: -9.291494,5.5892444
+      parent: 2
 - proto: PartRodMetal
   entities:
   - uid: 8478
@@ -59464,6 +59790,12 @@ entities:
     components:
     - type: Transform
       pos: 13.536374,-23.518818
+      parent: 2
+  - uid: 12547
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -22.375202,9.640173
       parent: 2
 - proto: PenCap
   entities:
@@ -59804,6 +60136,11 @@ entities:
     components:
     - type: Transform
       pos: 35.5,5.5
+      parent: 2
+  - uid: 9006
+    components:
+    - type: Transform
+      pos: -28.5,23.5
       parent: 2
 - proto: PortableGeneratorPacman
   entities:
@@ -60270,10 +60607,10 @@ entities:
       parent: 2
 - proto: PowerCellRecharger
   entities:
-  - uid: 8989
+  - uid: 620
     components:
     - type: Transform
-      pos: -21.5,11.5
+      pos: -22.5,9.5
       parent: 2
   - uid: 8990
     components:
@@ -60327,8 +60664,27 @@ entities:
     - type: Transform
       pos: -1.5,-20.5
       parent: 2
+- proto: PoweredDimSmallLight
+  entities:
+  - uid: 10685
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -23.5,20.5
+      parent: 2
+  - uid: 10686
+    components:
+    - type: Transform
+      pos: -23.5,24.5
+      parent: 2
 - proto: Poweredlight
   entities:
+  - uid: 15
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -22.5,6.5
+      parent: 2
   - uid: 9001
     components:
     - type: Transform
@@ -60362,11 +60718,6 @@ entities:
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
-  - uid: 9006
-    components:
-    - type: Transform
-      pos: -24.5,24.5
-      parent: 2
   - uid: 9007
     components:
     - type: Transform
@@ -60745,14 +61096,6 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -26.5,15.5
-      parent: 2
-    - type: ApcPowerReceiver
-      powerLoad: 0
-  - uid: 9056
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -21.5,6.5
       parent: 2
     - type: ApcPowerReceiver
       powerLoad: 0
@@ -61659,6 +62002,24 @@ entities:
       rot: 3.141592653589793 rad
       pos: 18.5,-28.5
       parent: 2
+  - uid: 12631
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -18.5,6.5
+      parent: 2
+  - uid: 12647
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -15.5,6.5
+      parent: 2
+  - uid: 12726
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,5.5
+      parent: 2
 - proto: PoweredlightLED
   entities:
   - uid: 10397
@@ -61904,12 +62265,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -19.5,-48.5
       parent: 2
-  - uid: 9204
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -23.5,6.5
-      parent: 2
   - uid: 9205
     components:
     - type: Transform
@@ -61986,11 +62341,6 @@ entities:
     components:
     - type: Transform
       pos: -26.5,24.5
-      parent: 2
-  - uid: 9220
-    components:
-    - type: Transform
-      pos: -25.5,24.5
       parent: 2
   - uid: 9221
     components:
@@ -62123,11 +62473,6 @@ entities:
       rot: 1.5707963267948966 rad
       pos: 36.5,26.5
       parent: 2
-  - uid: 9246
-    components:
-    - type: Transform
-      pos: -28.5,23.5
-      parent: 2
   - uid: 9247
     components:
     - type: Transform
@@ -62147,6 +62492,11 @@ entities:
     components:
     - type: Transform
       pos: -12.5,-11.5
+      parent: 2
+  - uid: 10711
+    components:
+    - type: Transform
+      pos: 37.5,10.5
       parent: 2
 - proto: RadioHandheld
   entities:
@@ -62492,6 +62842,12 @@ entities:
       parent: 2
 - proto: RandomPosterAny
   entities:
+  - uid: 9220
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -31.5,20.5
+      parent: 2
   - uid: 9307
     components:
     - type: Transform
@@ -62556,16 +62912,6 @@ entities:
     components:
     - type: Transform
       pos: 14.5,19.5
-      parent: 2
-  - uid: 9320
-    components:
-    - type: Transform
-      pos: -33.5,20.5
-      parent: 2
-  - uid: 9321
-    components:
-    - type: Transform
-      pos: -25.5,25.5
       parent: 2
   - uid: 9322
     components:
@@ -62755,6 +63101,16 @@ entities:
       parent: 2
 - proto: RandomSpawner
   entities:
+  - uid: 1903
+    components:
+    - type: Transform
+      pos: -25.5,6.5
+      parent: 2
+  - uid: 1904
+    components:
+    - type: Transform
+      pos: -12.5,8.5
+      parent: 2
   - uid: 4392
     components:
     - type: Transform
@@ -62771,6 +63127,16 @@ entities:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 42.5,-24.5
+      parent: 2
+  - uid: 8356
+    components:
+    - type: Transform
+      pos: -20.5,7.5
+      parent: 2
+  - uid: 8638
+    components:
+    - type: Transform
+      pos: -17.5,6.5
       parent: 2
   - uid: 9359
     components:
@@ -63093,11 +63459,6 @@ entities:
     - type: Transform
       pos: -29.5,22.5
       parent: 2
-  - uid: 9423
-    components:
-    - type: Transform
-      pos: -34.5,23.5
-      parent: 2
   - uid: 9424
     components:
     - type: Transform
@@ -63162,16 +63523,6 @@ entities:
     components:
     - type: Transform
       pos: -8.5,10.5
-      parent: 2
-  - uid: 9437
-    components:
-    - type: Transform
-      pos: -13.5,10.5
-      parent: 2
-  - uid: 9438
-    components:
-    - type: Transform
-      pos: -20.5,8.5
       parent: 2
   - uid: 9439
     components:
@@ -63802,11 +64153,11 @@ entities:
       linearDamping: 0
 - proto: Recycler
   entities:
-  - uid: 9563
+  - uid: 5078
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -33.5,24.5
+      pos: -34.5,23.5
       parent: 2
   - uid: 9925
     components:
@@ -63903,6 +64254,28 @@ entities:
       parent: 2
 - proto: ReinforcedWindow
   entities:
+  - uid: 621
+    components:
+    - type: Transform
+      pos: -10.5,8.5
+      parent: 2
+  - uid: 4277
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -22.5,8.5
+      parent: 2
+  - uid: 4480
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -22.5,4.5
+      parent: 2
+  - uid: 5172
+    components:
+    - type: Transform
+      pos: -18.5,7.5
+      parent: 2
   - uid: 7813
     components:
     - type: Transform
@@ -64047,12 +64420,6 @@ entities:
     - type: Transform
       pos: 1.5,18.5
       parent: 2
-  - uid: 9605
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -10.5,8.5
-      parent: 2
   - uid: 9606
     components:
     - type: Transform
@@ -64118,41 +64485,16 @@ entities:
       rot: 3.141592653589793 rad
       pos: -9.5,4.5
       parent: 2
-  - uid: 9618
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -11.5,4.5
-      parent: 2
-  - uid: 9619
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -12.5,4.5
-      parent: 2
   - uid: 9620
     components:
     - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -14.5,4.5
+      pos: -24.5,8.5
       parent: 2
   - uid: 9621
     components:
     - type: Transform
       rot: 3.141592653589793 rad
-      pos: -15.5,4.5
-      parent: 2
-  - uid: 9622
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -18.5,4.5
-      parent: 2
-  - uid: 9623
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -17.5,4.5
+      pos: -21.5,8.5
       parent: 2
   - uid: 9624
     components:
@@ -64170,16 +64512,6 @@ entities:
     components:
     - type: Transform
       pos: -26.5,8.5
-      parent: 2
-  - uid: 9627
-    components:
-    - type: Transform
-      pos: -25.5,8.5
-      parent: 2
-  - uid: 9628
-    components:
-    - type: Transform
-      pos: -23.5,8.5
       parent: 2
   - uid: 9629
     components:
@@ -65835,6 +66167,11 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 21.5,-29.5
       parent: 2
+  - uid: 10365
+    components:
+    - type: Transform
+      pos: -15.5,7.5
+      parent: 2
   - uid: 10398
     components:
     - type: Transform
@@ -65936,24 +66273,12 @@ entities:
     - type: Transform
       pos: 24.5,-26.5
       parent: 2
-- proto: Saw
-  entities:
-  - uid: 9941
-    components:
-    - type: Transform
-      pos: -25.476225,20.817598
-      parent: 2
 - proto: Scalpel
   entities:
   - uid: 9942
     components:
     - type: Transform
       pos: 15.411595,21.507236
-      parent: 2
-  - uid: 9943
-    components:
-    - type: Transform
-      pos: -25.484652,20.468168
       parent: 2
 - proto: ScienceComputerComms
   entities:
@@ -66073,12 +66398,6 @@ entities:
     - type: Transform
       pos: 18.442343,-6.3270855
       parent: 2
-  - uid: 9957
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -23.643227,6.536538
-      parent: 2
   - uid: 9958
     components:
     - type: Transform
@@ -66174,12 +66493,6 @@ entities:
       parent: 2
 - proto: SheetPlastic
   entities:
-  - uid: 9976
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -23.486977,6.645913
-      parent: 2
   - uid: 9977
     components:
     - type: Transform
@@ -66316,6 +66629,11 @@ entities:
       parent: 2
 - proto: ShuttersNormalOpen
   entities:
+  - uid: 5265
+    components:
+    - type: Transform
+      pos: -22.5,4.5
+      parent: 2
   - uid: 10003
     components:
     - type: Transform
@@ -66360,26 +66678,6 @@ entities:
     components:
     - type: Transform
       pos: -20.5,4.5
-      parent: 2
-  - uid: 10012
-    components:
-    - type: Transform
-      pos: -18.5,4.5
-      parent: 2
-  - uid: 10013
-    components:
-    - type: Transform
-      pos: -17.5,4.5
-      parent: 2
-  - uid: 10014
-    components:
-    - type: Transform
-      pos: -15.5,4.5
-      parent: 2
-  - uid: 10015
-    components:
-    - type: Transform
-      pos: -14.5,4.5
       parent: 2
   - uid: 10016
     components:
@@ -66460,16 +66758,6 @@ entities:
     components:
     - type: Transform
       pos: 21.5,-15.5
-      parent: 2
-  - uid: 10032
-    components:
-    - type: Transform
-      pos: -12.5,4.5
-      parent: 2
-  - uid: 10033
-    components:
-    - type: Transform
-      pos: -11.5,4.5
       parent: 2
   - uid: 10034
     components:
@@ -66647,6 +66935,43 @@ entities:
       parent: 2
 - proto: SignalButton
   entities:
+  - uid: 1885
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -19.5,5.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        10011:
+        - - Pressed
+          - Toggle
+        10010:
+        - - Pressed
+          - Toggle
+        5265:
+        - - Pressed
+          - Toggle
+  - uid: 1886
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -9.5,5.5
+      parent: 2
+    - type: DeviceLinkSource
+      linkedPorts:
+        10034:
+        - - Pressed
+          - Toggle
+        10035:
+        - - Pressed
+          - Toggle
+        10036:
+        - - Pressed
+          - Toggle
+        10039:
+        - - Pressed
+          - Toggle
   - uid: 7327
     components:
     - type: Transform
@@ -66855,50 +67180,6 @@ entities:
         - - Pressed
           - Toggle
         10030:
-        - - Pressed
-          - Toggle
-  - uid: 10077
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -14.5,8.5
-      parent: 2
-    - type: DeviceLinkSource
-      linkedPorts:
-        10010:
-        - - Pressed
-          - Toggle
-        10011:
-        - - Pressed
-          - Toggle
-        10012:
-        - - Pressed
-          - Toggle
-        10013:
-        - - Pressed
-          - Toggle
-        10014:
-        - - Pressed
-          - Toggle
-        10015:
-        - - Pressed
-          - Toggle
-        10032:
-        - - Pressed
-          - Toggle
-        10033:
-        - - Pressed
-          - Toggle
-        10034:
-        - - Pressed
-          - Toggle
-        10035:
-        - - Pressed
-          - Toggle
-        10039:
-        - - Pressed
-          - Toggle
-        10036:
         - - Pressed
           - Toggle
   - uid: 10078
@@ -67209,19 +67490,24 @@ entities:
     - type: Transform
       pos: -7.5,12.5
       parent: 2
-- proto: SignCloning
-  entities:
-  - uid: 10099
-    components:
-    - type: Transform
-      pos: -22.5,8.5
-      parent: 2
 - proto: SignConference
   entities:
   - uid: 10100
     components:
     - type: Transform
       pos: -6.5,30.5
+      parent: 2
+- proto: SignCryogenicsMed
+  entities:
+  - uid: 5023
+    components:
+    - type: Transform
+      pos: -19.5,8.5
+      parent: 2
+  - uid: 10032
+    components:
+    - type: Transform
+      pos: -23.5,8.5
       parent: 2
 - proto: SignDangerMed
   entities:
@@ -67762,10 +68048,10 @@ entities:
       parent: 2
 - proto: SignSurgery
   entities:
-  - uid: 10182
+  - uid: 9976
     components:
     - type: Transform
-      pos: -24.5,19.5
+      pos: -13.5,7.5
       parent: 2
 - proto: SignTelecomms
   entities:
@@ -67812,11 +68098,12 @@ entities:
     - type: Transform
       pos: -16.5,-24.5
       parent: 2
-  - uid: 10189
+- proto: SinkStemlessWater
+  entities:
+  - uid: 4243
     components:
     - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -13.5,14.5
+      pos: -9.5,14.5
       parent: 2
 - proto: SinkWide
   entities:
@@ -67842,6 +68129,13 @@ entities:
     components:
     - type: Transform
       pos: 18.5,-0.5
+      parent: 2
+- proto: SmartFridge
+  entities:
+  - uid: 10566
+    components:
+    - type: Transform
+      pos: -18.5,8.5
       parent: 2
 - proto: SMESBasic
   entities:
@@ -68682,6 +68976,13 @@ entities:
     - type: Transform
       pos: 1.5,15.5
       parent: 2
+- proto: SpawnPointParamedic
+  entities:
+  - uid: 4472
+    components:
+    - type: Transform
+      pos: -20.5,10.5
+      parent: 2
 - proto: SpawnPointPassenger
   entities:
   - uid: 10332
@@ -68900,10 +69201,10 @@ entities:
       parent: 2
 - proto: StasisBed
   entities:
-  - uid: 10365
+  - uid: 12602
     components:
     - type: Transform
-      pos: -12.5,5.5
+      pos: -21.5,9.5
       parent: 2
 - proto: StationAiUploadCircuitboard
   entities:
@@ -69875,14 +70176,6 @@ entities:
       parent: 2
     - type: SurveillanceCamera
       id: Virology
-  - uid: 10496
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -22.5,22.5
-      parent: 2
-    - type: SurveillanceCamera
-      id: Surgery Room
   - uid: 10497
     components:
     - type: Transform
@@ -70252,8 +70545,20 @@ entities:
     - type: Transform
       pos: -19.460943,-48.42677
       parent: 2
+- proto: Syringe
+  entities:
+  - uid: 12835
+    components:
+    - type: Transform
+      pos: -21.147396,5.581326
+      parent: 2
 - proto: Table
   entities:
+  - uid: 5174
+    components:
+    - type: Transform
+      pos: -22.5,24.5
+      parent: 2
   - uid: 8531
     components:
     - type: Transform
@@ -70269,6 +70574,17 @@ entities:
     - type: Transform
       pos: 16.5,-8.5
       parent: 2
+  - uid: 8767
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -21.5,5.5
+      parent: 2
+  - uid: 9619
+    components:
+    - type: Transform
+      pos: -22.5,23.5
+      parent: 2
   - uid: 9785
     components:
     - type: Transform
@@ -70283,7 +70599,7 @@ entities:
   - uid: 10539
     components:
     - type: Transform
-      pos: -14.5,5.5
+      pos: -26.5,9.5
       parent: 2
   - uid: 10540
     components:
@@ -70320,12 +70636,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -8.5,12.5
-      parent: 2
-  - uid: 10546
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 18.5,15.5
       parent: 2
   - uid: 10547
     components:
@@ -70431,11 +70741,6 @@ entities:
     - type: Transform
       pos: 4.5,-27.5
       parent: 2
-  - uid: 10566
-    components:
-    - type: Transform
-      pos: -18.5,5.5
-      parent: 2
   - uid: 10567
     components:
     - type: Transform
@@ -70447,23 +70752,6 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 24.5,27.5
-      parent: 2
-  - uid: 10569
-    components:
-    - type: Transform
-      pos: -19.5,5.5
-      parent: 2
-  - uid: 10570
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -21.5,11.5
-      parent: 2
-  - uid: 10571
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -22.5,11.5
       parent: 2
   - uid: 10572
     components:
@@ -70794,11 +71082,6 @@ entities:
     - type: Transform
       pos: -17.5,-4.5
       parent: 2
-  - uid: 10635
-    components:
-    - type: Transform
-      pos: -13.5,5.5
-      parent: 2
   - uid: 10636
     components:
     - type: Transform
@@ -71038,26 +71321,6 @@ entities:
     - type: Transform
       pos: 2.5,3.5
       parent: 2
-  - uid: 10685
-    components:
-    - type: Transform
-      pos: -26.5,21.5
-      parent: 2
-  - uid: 10686
-    components:
-    - type: Transform
-      pos: -26.5,20.5
-      parent: 2
-  - uid: 10687
-    components:
-    - type: Transform
-      pos: -25.5,20.5
-      parent: 2
-  - uid: 10688
-    components:
-    - type: Transform
-      pos: -24.5,20.5
-      parent: 2
   - uid: 10689
     components:
     - type: Transform
@@ -71182,11 +71445,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: 32.5,-4.5
       parent: 2
-  - uid: 10711
-    components:
-    - type: Transform
-      pos: 37.5,10.5
-      parent: 2
   - uid: 10712
     components:
     - type: Transform
@@ -71308,6 +71566,18 @@ entities:
     - type: Transform
       pos: 22.5,-27.5
       parent: 2
+  - uid: 10924
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -20.5,5.5
+      parent: 2
+  - uid: 12730
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -9.5,5.5
+      parent: 2
 - proto: TableCarpet
   entities:
   - uid: 10736
@@ -71370,6 +71640,29 @@ entities:
       parent: 2
 - proto: TableGlass
   entities:
+  - uid: 5014
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -18.5,5.5
+      parent: 2
+  - uid: 10496
+    components:
+    - type: Transform
+      pos: -12.5,5.5
+      parent: 2
+  - uid: 10569
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -15.5,6.5
+      parent: 2
+  - uid: 10570
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: -15.5,5.5
+      parent: 2
   - uid: 10746
     components:
     - type: Transform
@@ -71393,35 +71686,22 @@ entities:
       rot: 3.141592653589793 rad
       pos: -11.5,13.5
       parent: 2
-  - uid: 10750
-    components:
-    - type: Transform
-      pos: -18.5,8.5
-      parent: 2
   - uid: 10751
     components:
     - type: Transform
       pos: -13.5,16.5
       parent: 2
-  - uid: 10752
+  - uid: 11311
     components:
     - type: Transform
-      pos: -17.5,8.5
+      rot: -1.5707963267948966 rad
+      pos: -23.5,9.5
       parent: 2
-  - uid: 10753
+  - uid: 11312
     components:
     - type: Transform
-      pos: -16.5,8.5
-      parent: 2
-  - uid: 10754
-    components:
-    - type: Transform
-      pos: -15.5,8.5
-      parent: 2
-  - uid: 10755
-    components:
-    - type: Transform
-      pos: -14.5,8.5
+      rot: -1.5707963267948966 rad
+      pos: -22.5,9.5
       parent: 2
 - proto: TablePlasmaGlass
   entities:
@@ -72478,21 +72758,21 @@ entities:
       parent: 2
     - type: DeviceLinkSource
       linkedPorts:
-        4375:
+        9320:
+        - - Right
+          - Reverse
+        - - Left
+          - Forward
+        - - Middle
+          - Off
+        3869:
         - - Left
           - Forward
         - - Right
           - Reverse
         - - Middle
           - Off
-        4374:
-        - - Left
-          - Forward
-        - - Right
-          - Reverse
-        - - Middle
-          - Off
-        9563:
+        5078:
         - - Left
           - Forward
         - - Right
@@ -72500,13 +72780,6 @@ entities:
         - - Middle
           - Off
         4373:
-        - - Left
-          - Forward
-        - - Right
-          - Reverse
-        - - Middle
-          - Off
-        4372:
         - - Left
           - Forward
         - - Right
@@ -72772,11 +73045,6 @@ entities:
       parent: 2
 - proto: VendingMachineMedical
   entities:
-  - uid: 10925
-    components:
-    - type: Transform
-      pos: -20.5,11.5
-      parent: 2
   - uid: 10926
     components:
     - type: Transform
@@ -72784,10 +73052,10 @@ entities:
       parent: 2
 - proto: VendingMachineMediDrobe
   entities:
-  - uid: 10927
+  - uid: 10750
     components:
     - type: Transform
-      pos: -23.5,5.5
+      pos: -26.5,5.5
       parent: 2
 - proto: VendingMachineNutri
   entities:
@@ -73493,27 +73761,6 @@ entities:
     - type: Transform
       pos: -17.5,13.5
       parent: 2
-  - uid: 11036
-    components:
-    - type: Transform
-      pos: -22.5,5.5
-      parent: 2
-  - uid: 11037
-    components:
-    - type: Transform
-      pos: -22.5,7.5
-      parent: 2
-  - uid: 11038
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -22.5,4.5
-      parent: 2
-  - uid: 11039
-    components:
-    - type: Transform
-      pos: -22.5,6.5
-      parent: 2
   - uid: 11040
     components:
     - type: Transform
@@ -73533,11 +73780,6 @@ entities:
     components:
     - type: Transform
       pos: -27.5,6.5
-      parent: 2
-  - uid: 11044
-    components:
-    - type: Transform
-      pos: -22.5,8.5
       parent: 2
   - uid: 11045
     components:
@@ -78754,12 +78996,129 @@ entities:
       rot: 1.5707963267948966 rad
       pos: -15.5,27.5
       parent: 2
+  - uid: 12323
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -23.5,5.5
+      parent: 2
+  - uid: 12585
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -23.5,6.5
+      parent: 2
+  - uid: 12597
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -23.5,8.5
+      parent: 2
+  - uid: 12598
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -23.5,7.5
+      parent: 2
 - proto: WallSolid
   entities:
+  - uid: 488
+    components:
+    - type: Transform
+      pos: -13.5,6.5
+      parent: 2
+  - uid: 611
+    components:
+    - type: Transform
+      pos: -13.5,5.5
+      parent: 2
+  - uid: 5463
+    components:
+    - type: Transform
+      pos: -10.5,5.5
+      parent: 2
+  - uid: 5669
+    components:
+    - type: Transform
+      pos: -19.5,5.5
+      parent: 2
+  - uid: 7342
+    components:
+    - type: Transform
+      pos: -19.5,6.5
+      parent: 2
+  - uid: 7452
+    components:
+    - type: Transform
+      pos: -19.5,7.5
+      parent: 2
+  - uid: 7614
+    components:
+    - type: Transform
+      pos: -18.5,4.5
+      parent: 2
+  - uid: 7615
+    components:
+    - type: Transform
+      pos: -15.5,4.5
+      parent: 2
+  - uid: 7617
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -11.5,4.5
+      parent: 2
+  - uid: 7619
+    components:
+    - type: Transform
+      pos: -19.5,8.5
+      parent: 2
+  - uid: 8497
+    components:
+    - type: Transform
+      pos: -13.5,7.5
+      parent: 2
+  - uid: 8616
+    components:
+    - type: Transform
+      pos: -16.5,6.5
+      parent: 2
+  - uid: 8617
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -23.5,19.5
+      parent: 2
   - uid: 8772
     components:
     - type: Transform
       pos: 17.5,-25.5
+      parent: 2
+  - uid: 9204
+    components:
+    - type: Transform
+      pos: -14.5,4.5
+      parent: 2
+  - uid: 9628
+    components:
+    - type: Transform
+      pos: -17.5,4.5
+      parent: 2
+  - uid: 9943
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -12.5,4.5
+      parent: 2
+  - uid: 10013
+    components:
+    - type: Transform
+      pos: -16.5,5.5
+      parent: 2
+  - uid: 10014
+    components:
+    - type: Transform
+      pos: -16.5,7.5
       parent: 2
   - uid: 12000
     components:
@@ -80467,11 +80826,6 @@ entities:
     components:
     - type: Transform
       pos: -26.5,25.5
-      parent: 2
-  - uid: 12323
-    components:
-    - type: Transform
-      pos: -25.5,25.5
       parent: 2
   - uid: 12324
     components:
@@ -82208,6 +82562,23 @@ entities:
       parent: 2
 - proto: WindoorSecure
   entities:
+  - uid: 1883
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -34.5,21.5
+      parent: 2
+  - uid: 4375
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -33.5,24.5
+      parent: 2
+  - uid: 9618
+    components:
+    - type: Transform
+      pos: -23.5,23.5
+      parent: 2
   - uid: 12619
     components:
     - type: Transform
@@ -82218,28 +82589,6 @@ entities:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 12.5,-9.5
-      parent: 2
-  - uid: 12621
-    components:
-    - type: Transform
-      pos: -9.5,12.5
-      parent: 2
-  - uid: 12622
-    components:
-    - type: Transform
-      pos: -8.5,12.5
-      parent: 2
-  - uid: 12623
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -9.5,7.5
-      parent: 2
-  - uid: 12624
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -8.5,7.5
       parent: 2
   - uid: 12625
     components:
@@ -82373,11 +82722,6 @@ entities:
       parent: 2
 - proto: WindoorSecureMedicalLocked
   entities:
-  - uid: 12647
-    components:
-    - type: Transform
-      pos: -12.5,12.5
-      parent: 2
   - uid: 12648
     components:
     - type: Transform
@@ -82682,6 +83026,17 @@ entities:
       parent: 2
 - proto: WindowDirectional
   entities:
+  - uid: 4254
+    components:
+    - type: Transform
+      pos: -14.5,10.5
+      parent: 2
+  - uid: 9321
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -13.5,9.5
+      parent: 2
   - uid: 12702
     components:
     - type: Transform
@@ -82693,6 +83048,17 @@ entities:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -11.5,20.5
+      parent: 2
+  - uid: 12734
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: -14.5,9.5
+      parent: 2
+  - uid: 12832
+    components:
+    - type: Transform
+      pos: -13.5,10.5
       parent: 2
 - proto: WindowFrostedDirectional
   entities:
@@ -82726,6 +83092,44 @@ entities:
       parent: 2
 - proto: WindowReinforcedDirectional
   entities:
+  - uid: 3922
+    components:
+    - type: Transform
+      pos: -26.5,23.5
+      parent: 2
+  - uid: 4374
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -33.5,22.5
+      parent: 2
+  - uid: 4397
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -33.5,25.5
+      parent: 2
+  - uid: 7618
+    components:
+    - type: Transform
+      pos: -24.5,23.5
+      parent: 2
+  - uid: 9423
+    components:
+    - type: Transform
+      rot: -1.5707963267948966 rad
+      pos: -33.5,23.5
+      parent: 2
+  - uid: 10687
+    components:
+    - type: Transform
+      pos: -22.5,23.5
+      parent: 2
+  - uid: 10688
+    components:
+    - type: Transform
+      pos: -25.5,23.5
+      parent: 2
   - uid: 12709
     components:
     - type: Transform
@@ -82840,10 +83244,10 @@ entities:
       parent: 2
 - proto: Wrench
   entities:
-  - uid: 12730
+  - uid: 12600
     components:
     - type: Transform
-      pos: -23.533852,6.770913
+      pos: -20.471506,5.6210523
       parent: 2
   - uid: 12731
     components:

--- a/Resources/Prototypes/_Goobstation/Maps/cluster.yml
+++ b/Resources/Prototypes/_Goobstation/Maps/cluster.yml
@@ -39,6 +39,7 @@
             #medical
             ChiefMedicalOfficer: [ 1, 1 ]
             Chemist: [ 1, 1 ]
+            Paramedic: [ 1, 1 ]
             MedicalDoctor: [ 2, 2 ]
             MedicalIntern: [ 2, 2 ]
             #science


### PR DESCRIPTION
## About the PR
This PR changes the layout of Cluster's medbay, making it less open and more defined.  Two surgical wards have been added, alongside a few changes to the general setup of where everything is on the map.

## Why / Balance
I really like cluster's overall feel as a map, and so I wanted to improve its medbay to make it more usable.

## Media
![2025-5-22_20 22 53](https://github.com/user-attachments/assets/573f2d08-d3bb-4d10-aad8-da032db92e6f)
Shows everything
![2025-5-22_20 23 00](https://github.com/user-attachments/assets/c02f0f50-58cb-4da0-8276-7b7478c6a116)
Just fullbright
![2025-5-22_20 23 06](https://github.com/user-attachments/assets/d5d42257-a7fc-4d18-b2b7-b15ce0abd73c)
As the players would see it
![wouldyouliketoplayagame](https://github.com/user-attachments/assets/91b4d972-ce8c-41c2-8d4c-34ec35fd42bf)
Would you like to play a game? (what happened to the original maints surgery room)

**Changelog**
:cl:
- tweak: changed the design of the medbay to make it more usable
- tweak: changed one of the tables in the armory into a rack
- tweak: added an EOD suit locker to the sec locker room
- tweak: converted the maints surgery room into a potential saw trap room
- tweak: added a paramedic locker and opened the paramedic role on cluster
- tweak: removed waiting area
- tweak: closed off front desk better into its own room
