### PR TITLE
Cryoxadone Works on Dead

### DIFF
--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -176,6 +176,7 @@
   physicalDesc: reagent-physical-desc-fizzy
   flavor: medicine
   color: "#0091ff"
+  worksOnTheDead: true
   plantMetabolism:
   - !type:PlantAdjustToxins
     amount: -5


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Cryoxadone now works on dead people

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Now it's useful as a revival chemical, because it's normally not used in favor of chems that are just better in every way.
Set em up in cryo and forget about em for 10 minutes or so until that 5000 burn damage turns into 1000

## Technical details
<!-- Summary of code changes for easier review. -->
Yamlmaxxing, one line added

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Miiish
- tweak: Cryoxadone now works on dead people