### PR TITLE
Add godo and gocrazy plushies to the toys spawner pool

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/toy.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/toy.yml
@@ -35,6 +35,8 @@
         - PlushieDiona
         - PlushieArachind
         - PlushieCirno
+        - PlushieGodo
+        - PlushieGocrazy
       chance: 0.5
       offset: 0.2
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Fixed godo and gocrazy plushies not being spawned.

## Why / Balance
Because I forgot to do it when I added them into the game.

## Technical details
Added two entries to /Resources/Prototypes/Entities/Markers/Spawners/toy.yml

## Media
None

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ x ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ x ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Added Godo and Gocrazy plushies to the toys spawner pool