### PR TITLE
Digital Audio Workstation Boards Bugfix

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Circuitboards/Machine/production.yml
@@ -829,6 +829,9 @@
           amount: 1
           defaultPrototype: SaxophoneInstrument
           examineName: construction-insert-info-examine-name-instrument-woodwind
+  - type: Tag
+    tags:
+    - DawInstrumentMachineCircuitboard  # Funky Station -- required for the musician hardsuit to be craftable
 
 - type: entity
   id: PortableGeneratorPacmanMachineCircuitboard


### PR DESCRIPTION
## About the PR
Fixes the bug related to the digital audio workstation board that made the musician hardsuit impossible to craft.
Resolves issue #805.

## Technical details
Re-added the tag component to the digital audio workstation board entity. 

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Fixed the bug that prevented musician hardsuits from being crafted.
