### PR TITLE
Makes reptiloids able to eat chili

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/soup.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/soup.yml
@@ -810,6 +810,7 @@
   - type: Tag
     tags:
     - ChiliBowl
+    - Meat
 
 
 - type: entity
@@ -838,6 +839,7 @@
   - type: Tag
     tags:
     - ChiliBowl
+    - Meat
 
 - type: entity
   name: chili con carnival
@@ -871,6 +873,7 @@
   - type: Tag
     tags:
     - ChiliBowl
+    - Meat
 
 - type: entity
   name: monkey's delight


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Made reptiloids (and anything that eats meat) able to eat chili

## Why / Balance
Chili has meat in it. Even the clown chili, chili con carnival, is a reference to the name chili con carne (which is just chili). It makes me sad when my lizard can't eat chili :(

## Technical details
Added the meat tag to all 3 chili dishes

## Media
https://github.com/user-attachments/assets/e57de345-716c-48b4-bbdd-3b0a0e16c80f


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Chili is now considered a meat dish.
