### PR TITLE
Reduce the selling price of firelock electronics

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/Electronics/firelock.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/Electronics/firelock.yml
@@ -13,4 +13,4 @@
       tags:
       - FirelockElectronics
     - type: StaticPrice
-      price: 61
+      price: 19


### PR DESCRIPTION
prevents ATS factories at their core

## About the PR
self-explanatory

## Why / Balance
this is currently the single item that sells for much more than the base materials cost; most items result in a loss, a handful is perfectly balanced at 0 loss or gain, but firelocks sell for 4x the cost of making them (`19.(4)` per piece).

## Technical details
adjusts the static price of `FirelockElectronics` to 19

## Media
n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Fixed the economy once and for all by nerfing firelock electronics selling price.
