### PR TITLE
Thaven blood doesn't affect Thaven

### DIFF
--- a/Resources/Prototypes/_Impstation/Reagents/Consumable/Drink/drinks.yml
+++ b/Resources/Prototypes/_Impstation/Reagents/Consumable/Drink/drinks.yml
@@ -25,6 +25,10 @@
       - !type:SatiateThirst
         factor: 2
       - !type:GenericStatusEffect
+        conditions:
+        - !type:OrganType
+           type: Thaven
+           shouldHave: false
         key: SeeingRainbows
         component: SeeingRainbows
         type: Add

--- a/Resources/Prototypes/_Impstation/Reagents/biological.yml
+++ b/Resources/Prototypes/_Impstation/Reagents/biological.yml
@@ -50,6 +50,10 @@
     Narcotic:
       effects:
       - !type:GenericStatusEffect
+        conditions:
+        - !type:OrganType
+           type: Thaven
+           shouldHave: false
         key: SeeingRainbows
         component: SeeingRainbows
         type: Add


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
I disallowed Thaven Blood and Fever Dream from affecting Thaven with hallucinations. 

## Why / Balance
The blood is in them all the time. There's no reason it should affect them. Currently, can take blood out currently with a syringe, inject it back in, and get high. Fever Dream is a drink derived from Thaven blood, and also likely shouldn't affect them.

No balance changes.

## Technical details
Added a conditional to the narcotic effect for both yml entries. I followed the code format of their carpotoxin immunity.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: Thaven are immune to the drug effects of Shimmering Blood and Fever Dream.


