### PR TITLE
Add eyes tag to animal eyes

### DIFF
--- a/Resources/Prototypes/_Shitmed/Body/Organs/Animal/animal.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Organs/Animal/animal.yml
@@ -64,3 +64,6 @@
     shape:
     - 0,0,1,0
     heldPrefix: eyeballs
+  - type: Tag # This allows heretic rituals to work with animals eyes
+    tags:
+    - Eyes


### PR DESCRIPTION
## About the PR
Add the eyes tag to the animal eyes, so that it can be used in heretic rituals.

## Why / Balance
This allow the heretic to use animal eyes when eyes are required for rituals

## Technical details
Add the eyes tag to the animal eyes

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- add: Animal eyes can be used in heretic rituals (animal eyes now have the eyes tag assigned to it)
