### PR TITLE
Adds Velociraptor Cube to emagged biocube fabricators

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -860,6 +860,7 @@
     - AbominationCube
     - SpaceCarpCube
     - SpaceTickCube
+    - VelociraptorCube
 
 - type: entity
   id: SecurityTechFab

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -860,7 +860,7 @@
     - AbominationCube
     - SpaceCarpCube
     - SpaceTickCube
-    - VelociraptorCube
+    - VelociraptorCube #funky
 
 - type: entity
   id: SecurityTechFab

--- a/Resources/Prototypes/_Funkystation/Recipes/Lathes/rehydrateable.yml
+++ b/Resources/Prototypes/_Funkystation/Recipes/Lathes/rehydrateable.yml
@@ -1,0 +1,7 @@
+- type: latheRecipe
+  parent: BaseCubeRecipe
+  id: VelociraptorCube
+  result: VelociraptorCube
+  materials:
+    Biomass: 20
+    Plasma: 1000 #these things are strong


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
Velociraptor Cubes are now available in emagged biocube fabricators. They cost 10 sheets of plasma (5x that of abomination cubes) and 20 units of biomass.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The Dino Wars must continue.

They are still very expensive unless Botany gets a large supply of plasma, and only spawn velociraptors rather than the assorted dinocube box zookeepers and scientists can buy.

:cl: Miiish
- add: Added velociraptor cubes to emagged biocube fabricators
