### PR TITLE
Changeling/Antag weight Update

### DIFF
--- a/Content.Server/_Goobstation/Changeling/ChangelingSystem.cs
+++ b/Content.Server/_Goobstation/Changeling/ChangelingSystem.cs
@@ -56,6 +56,9 @@ using Content.Server.Stunnable;
 using Content.Shared.Jittering;
 using Content.Server.Explosion.EntitySystems;
 using System.Linq;
+using Content.Server.EntityEffects.EffectConditions;
+using Content.Shared._Shitmed.Targeting;
+using Content.Shared.Body.Part;
 using Content.Shared.Forensics.Components;
 
 namespace Content.Server.Changeling;
@@ -114,6 +117,26 @@ public sealed partial class ChangelingSystem : EntitySystem
 
     public EntProtoId SpacesuitPrototype = "ChangelingClothingOuterHardsuit";
     public EntProtoId SpacesuitHelmetPrototype = "ChangelingClothingHeadHelmetHardsuit";
+
+    private readonly List<TargetBodyPart> _bodyPartBlacklist = 
+    [ 
+        TargetBodyPart.Head, 
+        TargetBodyPart.Torso, 
+        TargetBodyPart.Groin,
+        TargetBodyPart.LeftFoot,
+        TargetBodyPart.RightFoot,
+        TargetBodyPart.RightHand,
+        TargetBodyPart.LeftHand
+    ];
+    
+    private readonly Dictionary<string, float> _organWhitelist = new()
+    {
+        { "stomach", 0.5f },
+        { "eyes", 0.5f },
+        { "liver", 0.5f },
+        { "lungs", 0.5f },
+        //{ "kidneys", 0.5f }, kidneys are not fucking implemented. some bullshit
+    };
 
     public override void Initialize()
     {

--- a/Content.Server/_Goobstation/Changeling/ChangelingSystem.cs
+++ b/Content.Server/_Goobstation/Changeling/ChangelingSystem.cs
@@ -439,8 +439,16 @@ public sealed partial class ChangelingSystem : EntitySystem
         || !TryComp<MetaDataComponent>(target, out var metadata)
         || !TryComp<DnaComponent>(target, out var dna)
         || !TryComp<FingerprintComponent>(target, out var fingerprint))
+        return false;
+        
+        if (_mobState.IsAlive(target) && comp.UsedDnaStingFirstTime)
+        {
+            _popup.PopupEntity(Loc.GetString("changeling-sting-extract-alive-fail"), uid, uid);
             return false;
-
+        }
+        
+        comp.UsedDnaStingFirstTime = true;
+        
         foreach (var storedDNA in comp.AbsorbedDNA)
         {
             if (storedDNA.DNA == dna.DNA)

--- a/Content.Shared/_Goobstation/Changeling/AbsorbedSystem.cs
+++ b/Content.Shared/_Goobstation/Changeling/AbsorbedSystem.cs
@@ -8,8 +8,9 @@ public sealed partial class AbsorbedSystem : EntitySystem
     public override void Initialize()
     {
         base.Initialize();
-
-        SubscribeLocalEvent<AbsorbedComponent, ExaminedEvent>(OnExamine);
+        
+        // funky station: remove hollowing as is
+        //SubscribeLocalEvent<AbsorbedComponent, ExaminedEvent>(OnExamine); 
         SubscribeLocalEvent<AbsorbedComponent, MobStateChangedEvent>(OnMobStateChange);
     }
 

--- a/Content.Shared/_Goobstation/Changeling/ChangelingComponent.cs
+++ b/Content.Shared/_Goobstation/Changeling/ChangelingComponent.cs
@@ -133,6 +133,13 @@ public sealed partial class ChangelingComponent : Component
 
     [ViewVariables(VVAccess.ReadOnly)]
     public TransformData? SelectedForm;
+    
+    /// <summary>
+    /// If the changeling used their DNA sting for the first time. Only set when used first time.
+    /// By default false.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadOnly)]
+    public bool UsedDnaStingFirstTime = false;
 }
 
 [DataDefinition]

--- a/Content.Shared/_Shitmed/Body/Systems/SharedBodySystem.Targeting.cs
+++ b/Content.Shared/_Shitmed/Body/Systems/SharedBodySystem.Targeting.cs
@@ -280,6 +280,38 @@ public partial class SharedBodySystem
 
         return TargetBodyPart.Torso; // Default to torso if something goes wrong
     }
+    
+    /// <summary>
+    /// funky station: get a random body part with an optional blacklist!
+    /// useful for not wanting to get torso, or head.
+    /// </summary>
+    /// <param name="uid">body entuid</param>
+    /// <param name="target">attackers targeting component</param>
+    /// <param name="blacklist">blacklisted parts</param>
+    /// <returns>part or null</returns>
+    public TargetBodyPart? GetRandomBodyPart(EntityUid uid, TargetingComponent? target, List<TargetBodyPart>? blacklist)
+    {
+        if (!Resolve(uid, ref target))
+            return null;
+
+        var totalWeight = target.TargetOdds.Values.Sum();
+        var randomValue = _random.NextFloat() * totalWeight;
+
+        foreach (var (part, weight) in target.TargetOdds)
+        {
+            if (randomValue <= weight)
+            {
+                if (blacklist!.Contains(part))
+                    continue;
+                
+                return part;
+            }
+
+            randomValue -= weight;
+        }
+
+        return null; // returns null which signifies that this body is FUCKED up
+    }
 
     /// <summary>
     /// This should be called after body part damage was changed.

--- a/Resources/Locale/en-US/_Goobstation/changeling/abilities/changeling.ftl
+++ b/Resources/Locale/en-US/_Goobstation/changeling/abilities/changeling.ftl
@@ -56,6 +56,7 @@ changeling-sting-fail-simplemob = You can't sting a lesser creature!
 changeling-sting-extract-fail = Unable to extract DNA
 changeling-sting-fail = You cannot sting that!
 changeling-sting-extract-max = Need to get rid of the stored DNA beforehand
+changeling-sting-extract-alive-fail = You cannot extract DNA from someone alive
 
 changeling-stasis-enter = You enter regenerative stasis
 changeling-stasis-enter-fail = Can't enter stasis!

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -21,7 +21,7 @@
   - type: SubGamemodes
     rules:
     - id: Thief
-      prob: 0.5
+      prob: 0.65
     - id: Heretic
       prob: 0.3
 

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -24,8 +24,6 @@
       prob: 0.5
     - id: Heretic
       prob: 0.3
-    - id: Changeling 
-      prob: 0.3
 
 - type: entity
   parent: BaseGameRule

--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -21,9 +21,11 @@
   - type: SubGamemodes
     rules:
     - id: Thief
-      prob: 0.75
-    - id: Heretic # goob edit
-      prob: 0.2 # funkystation - 20% of rounds can have a heretic as a treat
+      prob: 0.5
+    - id: Heretic
+      prob: 0.3
+    - id: Changeling 
+      prob: 0.3
 
 - type: entity
   parent: BaseGameRule

--- a/Resources/Prototypes/Recipes/Lathes/rehydrateable.yml
+++ b/Resources/Prototypes/Recipes/Lathes/rehydrateable.yml
@@ -95,77 +95,77 @@
   result: BioSynthLungs
   completetime: 30
   materials:
-    Biomass: 10
+    Biomass: 4
 
 - type: latheRecipe
   id: SynthLiver
   result: BioSynthLiver
-  completetime: 30
+  completetime: 10
   materials:
-    Biomass: 10
+    Biomass: 4
 
 - type: latheRecipe
   id: SynthEyes
   result: BioSynthEyes
-  completetime: 30
+  completetime: 10
   materials:
-    Biomass: 10
+    Biomass: 4
 
 - type: latheRecipe
   id: SynthLeftArm
   result: BioSynthLeftArm
-  completetime: 30
+  completetime: 10
   materials:
-    Biomass: 10
+    Biomass: 6
 
 - type: latheRecipe
   id: SynthLeftHand
   result: BioSynthLeftHand
-  completetime: 30
+  completetime: 10
   materials:
-    Biomass: 10
+    Biomass: 3
 
 - type: latheRecipe
   id: SynthRightArm
   result: BioSynthRightArm
-  completetime: 30
+  completetime: 10
   materials:
-    Biomass: 10
+    Biomass: 6
 
 - type: latheRecipe
   id: SynthRightHand
   result: BioSynthRightHand
-  completetime: 30
+  completetime: 10
   materials:
-    Biomass: 10
+    Biomass: 3
 
 - type: latheRecipe
   id: SynthLeftLeg
   result: BioSynthLeftLeg
-  completetime: 30
+  completetime: 10
   materials:
-    Biomass: 10
+    Biomass: 6
 
 - type: latheRecipe
   id: SynthRightLeg
   result: BioSynthRightLeg
-  completetime: 30
+  completetime: 10
   materials:
-    Biomass: 10
+    Biomass: 6
 
 - type: latheRecipe
   id: SynthLeftFoot
   result: BioSynthLeftFoot
-  completetime: 30
+  completetime: 10
   materials:
-    Biomass: 10
+    Biomass: 3
 
 - type: latheRecipe
   id: SynthRightFoot
   result: BioSynthRightFoot
-  completetime: 30
+  completetime: 10
   materials:
-    Biomass: 10
+    Biomass: 3
 
 - type: latheRecipe
   id: PizzaLeftArm

--- a/Resources/Prototypes/Recipes/Lathes/rehydrateable.yml
+++ b/Resources/Prototypes/Recipes/Lathes/rehydrateable.yml
@@ -86,14 +86,14 @@
 - type: latheRecipe
   id: SynthHeart
   result: BioSynthHeart
-  completetime: 30
+  completetime: 10
   materials:
     Biomass: 10
 
 - type: latheRecipe
   id: SynthLungs
   result: BioSynthLungs
-  completetime: 30
+  completetime: 10
   materials:
     Biomass: 4
 

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -1,13 +1,13 @@
 - type: weightedRandom # All dual antag gamemodes are goobstation
   id: Secret
   weights:
-    Traitor: 0.35 # Goobstation
+    Traitor: 0.25 # Goobstation
     #Changeling: 0.06 # Goobstation unique antag
-    #Traitorling: 0.15 # 2 antags but less of each type applies for all hybrid modes, they all need 30 pop. Also makes lower pops roll more traitor games.
+    Traitorling: 0.15 # 2 antags but less of each type applies for all hybrid modes, they all need 30 pop. Also makes lower pops roll more traitor games.
     Nukeops: 0.15 # Funkystation
     #NukeTraitor: 0.01 #why the fuck does this exist
     #NukeLing: 0.01 #why the fuck does this exist
-    Revolutionary: 0.20 # Maybe 0.04 after wiz/cult? Goobstation
+    Revolutionary: 0.15 # Maybe 0.04 after wiz/cult? Goobstation
     #RevTraitor: 0.02 #why the fuck does this exist
     #RevLing: 0.03
     Zombie: 0.01 # Maybe 0.03 after wiz/cult? Goobstation

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -1,13 +1,13 @@
 - type: weightedRandom # All dual antag gamemodes are goobstation
   id: Secret
   weights:
-    Traitor: 0.25 # Goobstation
-    Changeling: 0.06 # Goobstation unique antag
-    Traitorling: 0.15 # 2 antags but less of each type applies for all hybrid modes, they all need 30 pop. Also makes lower pops roll more traitor games.
+    Traitor: 0.35 # Goobstation
+    #Changeling: 0.06 # Goobstation unique antag
+    #Traitorling: 0.15 # 2 antags but less of each type applies for all hybrid modes, they all need 30 pop. Also makes lower pops roll more traitor games.
     Nukeops: 0.15 # Funkystation
     #NukeTraitor: 0.01 #why the fuck does this exist
     #NukeLing: 0.01 #why the fuck does this exist
-    Revolutionary: 0.15 # Maybe 0.04 after wiz/cult? Goobstation
+    Revolutionary: 0.20 # Maybe 0.04 after wiz/cult? Goobstation
     #RevTraitor: 0.02 #why the fuck does this exist
     #RevLing: 0.03
     Zombie: 0.01 # Maybe 0.03 after wiz/cult? Goobstation
@@ -15,7 +15,7 @@
     Blob: 0.05 #funky Blobmode
     BlobTraitor: 0.1 #funky Blobmode
   #  Wizard: 0.05 # Why not, should probably be lower
-    CosmicCult: 0.05 # miish or someone else should actually enable this later
+    CosmicCult: 0.11 # miish or someone else should actually enable this later
   #  HereticTraitor: 0.15 # funkystation - balance antag weights and separate them - removing for side antag ver
   #  ChangelingHeretics: 0.10 # funkystation - balance antag weights and separate them - removing for side antag ver
   #  KesslerSyndrome: 0.01 # Goobstation - remove kessler

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -2,8 +2,8 @@
   id: Secret
   weights:
     Traitor: 0.25 # Goobstation
-    #Changeling: 0.06 # Goobstation unique antag
-    Traitorling: 0.15 # 2 antags but less of each type applies for all hybrid modes, they all need 30 pop. Also makes lower pops roll more traitor games.
+    Changeling: 0.05 # Goobstation unique antag
+    Traitorling: 0.10 # 2 antags but less of each type applies for all hybrid modes, they all need 30 pop. Also makes lower pops roll more traitor games.
     Nukeops: 0.15 # Funkystation
     #NukeTraitor: 0.01 #why the fuck does this exist
     #NukeLing: 0.01 #why the fuck does this exist

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -2,8 +2,8 @@
   id: Secret
   weights:
     Traitor: 0.25 # Goobstation
-    Changeling: 0.05 # Goobstation unique antag
-    Traitorling: 0.10 # 2 antags but less of each type applies for all hybrid modes, they all need 30 pop. Also makes lower pops roll more traitor games.
+    Changeling: 0.03 # Goobstation unique antag
+    Traitorling: 0.12 # 2 antags but less of each type applies for all hybrid modes, they all need 30 pop. Also makes lower pops roll more traitor games.
     Nukeops: 0.15 # Funkystation
     #NukeTraitor: 0.01 #why the fuck does this exist
     #NukeLing: 0.01 #why the fuck does this exist

--- a/Resources/ServerInfo/Guidebook/ServerRules/Metashield.xml
+++ b/Resources/ServerInfo/Guidebook/ServerRules/Metashield.xml
@@ -34,15 +34,15 @@
   ## Changelings
 
   In the eyes of the public, changelings are an exterminated predatory lifeform and their potential existence on the station is shielded.
-  This metashield prohibits players from crew bloodtesting until the metashield is revealed.
+  This metashield prohibits players from general crew bloodtesting until the metashield is revealed. Witnessing two of the same person in one location is grounds for a specific blood test on those two individuals, but not a revealing condition itself.
 
   Knowledge about the abilities of changelings is not shielded.
-
+    
   The revealing condition for this shield is any of the following:
-  - discovering a hollowed body
   - witnessing the use of changeling-only abilities
   - witnessing someone trying to absorb a body
-  - witnessing someone changing their appearance
+  - witnessing someone changing their appearance 
+  - witnessing a positive changeling blood test
 
   ## Implanted Implants
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR


## Why / Balance


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: taydeo, Rainbeon
- tweak: Changelings can now sting one alive person for DNA extraction, then other targets must be either crit or dead.
- add: Changelings now eat random non-vital organs and a limb when absorbing someone.
- remove: Removed hollowing text on absorbed bodies, and removed genetic damage dealt when absorbing.
- remove: Ferrochromic Acid no longer replaces someones blood when absorbed.
- tweak: The metashield for Changelings has been changed to account for hollowing changes, and now allows for bloodtests in very specific circumstances.
- tweak: The Medical Biofabricator is now significantly cheaper to operate, with prices being more than halved overall for all objects except the Heart.
- tweak: All organ and limb print times have been reduced to 10 seconds in the Medical Biofabricator.
- tweak: Heretics now have a slightly greater chance to spawn, and Thieves have a slightly lower chance to spawn.
- tweak: Cosmic Cult now has a greater chance of rolling, and Changeling a slightly lower chance of rolling.