### PR TITLE
Shuttleloop hotfix

### DIFF
--- a/Content.Server/_Goobstation/GameTicking/Rules/BlobRuleSystem.cs
+++ b/Content.Server/_Goobstation/GameTicking/Rules/BlobRuleSystem.cs
@@ -113,18 +113,6 @@ public sealed class BlobRuleSystem : GameRuleSystem<BlobRuleComponent>
 
         var stationName = Name(stationUid);
 
-        if (blobTilesCount >= (stationUid.Comp?.StageBegin ?? StationBlobConfigComponent.DefaultStageBegin)
-            && _roundEndSystem.ExpectedCountdownEnd != null)
-        {
-            _roundEndSystem.CancelRoundEndCountdown(checkCooldown: false);
-            _chatSystem.DispatchStationAnnouncement(stationUid,
-                Loc.GetString("blob-alert-recall-shuttle"),
-                Loc.GetString("Station"),
-                false,
-                null,
-                Color.Red);
-        }
-
         switch (blobRuleComp.Stage)
         {
             case BlobStage.Default when blobTilesCount >= (stationUid.Comp?.StageBegin ?? StationBlobConfigComponent.DefaultStageBegin):

--- a/Resources/Locale/en-US/_Goobstation/blob/blob.ftl
+++ b/Resources/Locale/en-US/_Goobstation/blob/blob.ftl
@@ -14,7 +14,7 @@ ent-CoreBlobTile = Blob Core
 ent-FactoryBlobTile = Blob Factory
     .desc = A disgusting looking blob structure that creates blob drops over time, and creates powerful blobbernauts when fed resources.
 ent-ResourceBlobTile = Resource Blob
-    .desc = A hill-shaped blob structure that constantly produces a yellow viscous fluid. The fluid seems to seep into the surrounding infestation, helping it to spread and grow... 
+    .desc = A hill-shaped blob structure that constantly produces a yellow viscous fluid. The fluid seems to seep into the surrounding infestation, helping it to spread and grow...
 ent-NodeBlobTile = Blob Node
     .desc = A mini version of the core that allows special blob structures to be constructed around itself.
 ent-StrongBlobTile = thick blob infestation
@@ -89,7 +89,7 @@ blob-alert-out-off-station = The blob was removed because it was found outside t
 
 # Announcment
 blob-alert-recall-shuttle = The emergency shuttle can not be sent while there is a level 5 biohazard present on the station.
-blob-alert-detect = Confirmed outbreak of level 5 biohazard aboard the station. All personnel must contain the outbreak. The emergency shuttle can not be sent due to contamination risks.
+blob-alert-detect = Confirmed outbreak of level 5 biohazard aboard the station. All personnel must contain the outbreak.
 blob-alert-critical = Biohazard level critical, nuclear authentication codes have been sent to the station. Central Command orders any remaining personnel to activate the self-destruction mechanism.
 blob-alert-critical-NoNukeCode = Biohazard level critical. Central Command orders any remaining personnel to seek shelter, and await rescue.
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Just Blob blocking shuttle recall

## Why / Balance
When there are zombies and a blob on the station simultaneously, the zombie event continually tries calling the evac shuttle, while the blob continually recalls it, leading to annoying announcement spam. This situation is particularly common on Survival.

## Technical details
Just deleted the code for recalling the shuttle from blob, and removed reference to shuttle being unable to be called

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
:cl:
- remove: Removed blob blocking shuttle recall
