### PR TITLE
Added stun resistances to hardsuits and select armor.

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -123,6 +123,8 @@
       shader: unshaded
   - type: Clothing
     sprite: Clothing/OuterClothing/Armor/syndie-raid.rsi
+  - type: StaminaResistance
+    damageCoefficient: 0.8
   - type: Armor
     modifiers:
       coefficients:
@@ -315,6 +317,8 @@
     sprite: Clothing/OuterClothing/Armor/lingarmor.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Armor/lingarmor.rsi
+  - type: StaminaResistance
+    damageCoefficient: 0.4
   - type: Armor
     modifiers:
       coefficients:
@@ -427,6 +431,8 @@
     coolingCoefficient: 0.001
   - type: FireProtection
     reduction: 0.8
+  - type: StaminaResistance
+    damageCoefficient: 0.75
   - type: Armor
     modifiers:
       coefficients:

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -177,6 +177,8 @@
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
     damageCoefficient: 0.3
+  - type: StaminaResistance
+    damageCoefficient: 0.75 
   - type: Armor
     modifiers:
       coefficients:
@@ -213,6 +215,8 @@
   - type: ClothingSpeedModifier
     walkModifier: 1.0
     sprintModifier: 1.0
+  - type: StaminaResistance
+    damageCoefficient: 0.6
   - type: Armor
     modifiers:
       coefficients:
@@ -245,6 +249,8 @@
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
     damageCoefficient: 0.4
+  - type: StaminaResistance
+    damageCoefficient: 0.8 
   - type: Armor
     modifiers:
       coefficients:
@@ -274,6 +280,8 @@
   - type: PressureProtection
     highPressureMultiplier: 0.3
     lowPressureMultiplier: 1000
+  - type: StaminaResistance
+    damageCoefficient: 0.8 
   - type: Armor
     modifiers:
       coefficients:
@@ -304,6 +312,8 @@
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
     damageCoefficient: 0.4
+  - type: StaminaResistance
+    damageCoefficient: 0.7 
   - type: Armor
     modifiers:
       coefficients:
@@ -335,6 +345,8 @@
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
     damageCoefficient: 0.5
+  - type: StaminaResistance
+    damageCoefficient: 0.7
   - type: Armor
     modifiers:
       coefficients:
@@ -476,6 +488,8 @@
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
     damageCoefficient: 0.6
+  - type: StaminaResistance
+    damageCoefficient: 0.6
   - type: Armor
     modifiers:
       coefficients:
@@ -543,8 +557,8 @@
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
     damageCoefficient: 0.5
-  #- type: StaminaResistance
-  #  damageCoefficient: 0.75
+  - type: StaminaResistance
+    damageCoefficient: 0.75
   - type: Armor
     modifiers:
       coefficients:
@@ -605,8 +619,8 @@
     damageCoefficient: 0.2
   - type: FireProtection
     reduction: 0.8
-  #- type: StaminaResistance
-  #  damageCoefficient: 0.6
+  - type: StaminaResistance
+    damageCoefficient: 0.6
   - type: Armor
     modifiers:
       coefficients:
@@ -641,8 +655,8 @@
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
     damageCoefficient: 0.5
-  #- type: StaminaResistance
-  #  damageCoefficient: 0.6
+  - type: StaminaResistance
+    damageCoefficient: 0.5
   - type: Armor
     modifiers:
       coefficients:
@@ -709,6 +723,8 @@
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
     damageCoefficient: 0.5
+  - type: StaminaResistance
+    damageCoefficient: 0.8 
   - type: Armor
     modifiers:
       coefficients:
@@ -770,6 +786,8 @@
     sprite: Clothing/OuterClothing/Hardsuits/pirateeva.rsi
   - type: ExplosionResistance
     damageCoefficient: 0.7
+  - type: StaminaResistance
+    damageCoefficient: 0.8
   - type: Armor
     modifiers:
       coefficients:
@@ -803,6 +821,8 @@
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
     damageCoefficient: 0.6
+  - type: StaminaResistance
+    damageCoefficient: 0.70 
   - type: Armor
     modifiers:
       coefficients:
@@ -967,6 +987,8 @@
     coolingCoefficient: 0.001
   - type: ExplosionResistance
     damageCoefficient: 0.7
+  - type: StaminaResistance
+    damageCoefficient: 0.75 
   - type: Armor
     modifiers:
       coefficients:

--- a/Resources/Prototypes/_DV/CosmicCult/Clothing/cosmiccult_armor.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Clothing/cosmiccult_armor.yml
@@ -20,6 +20,8 @@
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
     damageCoefficient: 0.4
+  - type: StaminaResistance
+    damageCoefficient: 0.75
   - type: Armor
     modifiers:
       coefficients:

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -61,6 +61,8 @@
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
     damageCoefficient: 0.4
+  - type: StaminaResistance
+    damageCoefficient: 0.70
   - type: Armor
     modifiers:
       coefficients:
@@ -99,6 +101,8 @@
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
     damageCoefficient: 0.65
+  - type: StaminaResistance
+    damageCoefficient: 0.8
   - type: Armor
     modifiers:
       coefficients:

--- a/Resources/Prototypes/_Goobstation/Heretic/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Entities/Clothing/OuterClothing/armor.yml
@@ -9,6 +9,8 @@
     state: icon
   - type: Clothing
     sprite: _Goobstation/Heretic/eldritch_armor.rsi
+  - type: StaminaResistance
+    damageCoefficient: 0.6 
   - type: Armor
     modifiers:
       coefficients:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
So, the stun systems are a long debated and sensitive matter, and I get why. Stunning is a pretty core and critical aspect to how security functions in general. That said, I do think there are some issues with the system as it stands, and have thought through some changes that I think could help this.

In a broad scope overview, I added stun resistances to all hardsuits and a few select armors. The magnitudes of these resistances vary in strength, and they aren't all on antag accessible items.


## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

**Why Introduce Stun Resistance?**

Often times I think discusses on stun resistances focus in on topics of nukies. Nukies often wear hardsuits, they often are shot with large amounts of things, and they often exemplify "big combat encounter" in most people's minds. Naturally a lot of talk about combat metas tends to center there, but I think that's kind of a mistake. 

I think the current stun system very much hurts solo antags in a big way. The classic counter to stuns being unbalanced, in regards to nukies, is to not split up, to have others cover you while you are down etc. That's true, but that's also completely irrelevant for solo antags. They get stunned and lose, immediately. There are some ways around that of course, but stuns are very painful to deal with as solo traitors/lone ops/changelings/heretics. They get access to fun armors, but often times they are completely irrelevant, as the optimal solution becomes hitting them with a baton until they fall over. 

I know it's not desired for security to simply gun down any threat they see, but at the moment I think the balance has swung too far in the other direction. Stuns are one of the best ways to deal with threats, even in situations where lethals are authorized, _and_ they incredibly prolific on the station at all alert levels. In my opinion, when hardsuits and guns are getting taken deployed on the enemy's side, or you're fighting a solo super monster, stuns should be less good, less optimal.

**Stun Resistance Effects**

Before looking at adding numbers, the effects of stun resistance as a stat need to be examined. By default, a disabler takes 4 hits to stun a target, and a stun baton 3 hits. Stun resistance modifies these values, increasing the total amount needed. Here are several common and key breakpoints used. Stun resistance is multiplicative on the value of stun damage, so a higher fraction is less resistance.

| Stun Resistance  | Baton | Disabler | Misc
| ------------- | ------------- |------------- | ------------- |
| 1.00  | 3  | 4  | Disabler Slows at 2 hits |
| .80  |  4  | 4  | -  |
| .75  |  4  | 5  | Disabler Slows at 3 hits  |
| .70  |  4  | 5  | No Change  |
| .60  |  5  | 6  | Baton Slows at 3 hits  |
| .40  |  7  | 8  | Baton Slows at 4 hits  |

**Changed Items**

| Stun Resist | Item
| ------------- | ------------- |
| .80  |  Cybersun Stealth Hardsuit, Security Hardsuit, Brigmedic, Wizard Hardsuit, Syndicate Raid Suit, Deep Space EVA Suit  |  
| .75  |  Atmosian Armor, CBURN Exosuit, Goliath Hardsuit, Blood-Red Hardsuit, Entropic Armor |
| .70  |  Warden's Hardsuit, Blueshield Hardsuit, Captain's Armored Spacesuit, Pirate Captain's Hardsuit | 
| .60  |  Ominous Armor, Head of Security's Hardsuit, Syndicate Elite Hardsuit, Salvager Maxim Hardsuit | 
|.50| Syndicate Commander Hardsuit|
| .40  |  Chitinous Armor | 

**Commentary on Changes**

All combat tied hardsuits are given stun resist, even if only minor, for thematic and mechanical consistency that "Hardsuit = Stun's Less Good" in player's minds. This ties into SOP and how enemy hardsuits authorize lethal weapons.

**.8:** Very minor value, and thus used for hardsuits that aren't defensively special in anyway. The Raid Suit isn't a hardsuit, and I eventually settled on putting this small amount in, but it's the change I'm most worried about in total. The Raid Suit is already very good, and this might not be good.

**.75:** Where the stun resistance starts to become notable. Disablers not slowing on 2 hits makes stunning less consistent in high combat situations. Atmosian Armor is not a hardsuit, but stun resistance was added a fun little reward for doing all the work of making metal hydrogen armor, which is rather iffy currently. Salvagers can build into this level of stun resistance with work.

**.7:** functionally equivalent to .75 in most respects. It exists to make the relevant people feel special about their unique armor, even it's not any better really.

**.6:** Advanced stun resistance, for special armors. There heretic armor is pushed above most others, as they are a very loud solo antag, and are heavily punished by stuns. This will allow their armor to actually matter now, as people will need to shoot them. With their mobility, they will be hard to stun.

**.5:** Irrelevant for almost all games. Mainly implemented for code completeness amongst various ERT armors.

**.4:** This is unique to changeling armor, and very strong, but I feel still a good change to make. Changelings are in a rough state, and currently their "go loud" playstyle is almost non-existent. A big reason for that is that stuns are incredibly good against them. Tied to melee as they are, they are very easy to stun. Going loud also removes their social chameleon aspect, which is the main strength of them. I don't think I've ever actually seen this armor used before in a real game. It doesn't protect them in ways they need, and it requires multiple successful kills. Adding a strong stun resistance lets changelings actually fight in close quarters successfully, and give them the chance to be the threat the SOP response implies they are.

**Misc Comments:** 

A notable absence from this list is the Jugg Suit. This is intentional. The Jugg suit is incredibly good at dealing with lethal damage, and I think having stun as a counterplay mechanism is a good thing. If this change goes through, the meta will of course develop over time. It may need to be tweaked in some way at some point, but I think not having stun resist is a good niche weakness for it.

This will make things such as Revs and Cults a bit bloodier, though I don't think that's necessarily a bad thing. The crew accessible stun resist will apply to all kinds of inter-crew struggles, not just Sec stunning criminals. 

I do think these changes will make nukies stronger, though I don't think to an undue degree. It would just lead to a shift in approach, rather than an unbeatable edge, in my opinion. Things can and of course be shifted over time if there is an enduring balance issue. 

## Technical details
<!-- Summary of code changes for easier review. -->

Technical changes are very simple. Just adding
```
- type: StaminaResistance
    damageCoefficient: X
```
to .yaml prototypes, where X is the stun damage fraction.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

![image](https://github.com/user-attachments/assets/66d309cc-5eae-4e9e-8538-7862aa1fab10)

The resistance type exists and works.

# Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Stun resistances are added to all combat hardsuits, as well as a small number of non-hardsuits.
