### PR TITLE
Syndicate Elite Hardsuit Brute Rebalance

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -610,9 +610,9 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.6
-        Slash: 0.6
-        Piercing: 0.6
+        Blunt: 0.5
+        Slash: 0.5
+        Piercing: 0.45
         Heat: 0.2
         Radiation: 0.01
         Caustic: 0.5


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

I changed the brute damage resistances of the Syndicate Elite Hardsuit. It now has the same slash and blunt resist as the Blood-Red, and 5 percent more pierce than the blood red

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Well, the Elite Hardsuit is just worse than the Blood-Red right now, unless you're planning on facing/using flamethrowers. Which kind of surprised me, as I hadn't noticed it until now. If this is intentional feel free to ignore 
this PR, but I'm assuming it is an oversight.

In game currently, the elite suit has 40 percent brute resist across the board, while the blood-red has 50 percent. In exchange the elite suit gets more fireproofing and rad resistance, but this seems like a very strange tradeoff for an "elite" suit that costs 25 more TC. I feel like most people just assume that it has more resists with reading or something, as it seems very not worth it in most cases compared to the blood red.

So, now I changed the brute resists to 50/50/55 for Blunt/Slash/Pierce respectively. About the same as the blood-red, with marginal increases in shooting resist to make it feel more elite.

## Technical details
<!-- Summary of code changes for easier review. -->

Number tweak in .yaml prototype

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Current Elite Suit:
![image](https://github.com/user-attachments/assets/5dde68ee-9853-4553-b637-916aee1532f2)

Blood Red:
![bloodRed](https://github.com/user-attachments/assets/2f882035-d38c-41da-b35d-d1f98ad3365b)

New Elite Suit:
![eliteChanged](https://github.com/user-attachments/assets/755e2bd9-09b9-4168-97cd-ef804c218014)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Increased brute resist values of syndicate elite hardsuit to be better than the blood-red


