### PR TITLE
Crystallizer Rebalance

### DIFF
--- a/Resources/Prototypes/_Funkystation/Atmospherics/crystallizer.yml
+++ b/Resources/Prototypes/_Funkystation/Atmospherics/crystallizer.yml
@@ -196,7 +196,7 @@
   minimumRequirements:
   - 0     # oxygen
   - 0     # nitrogen
-  - 1500  # carbon dioxide
+  - 15000  # carbon dioxide
   - 0     # plasma
   - 0     # tritium
   - 0     # vapor


### PR DESCRIPTION
Increases the amount of CO2 needed to create a diamond in the crystallizer by 10 times. This should stop this from being abused as an exceptionally easy way to make huge amounts of funds for the station. Suggested by @Terkala

## About the PR
CO2 required from 1500 -> 15000

## Why / Balance
Currently it is far too easy to make an insane amount of cash quickly due to the sell price of diamonds and how quickly they can be made.

## Technical details
N/A (one value)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A

**Changelog**
<!--
:cl:
- tweak: Increases the amount of CO2 needed to create a diamond in the crystallizer by 10 times.
-->
