### PR TITLE
Fix incredibly important typo in the species guidebook page

### DIFF
--- a/Resources/ServerInfo/Guidebook/Mobs/Species.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Species.xml
@@ -19,7 +19,7 @@
   <GuideEntityEmbed Entity="MobVox" Caption="Vox"/>
   </Box>
   <Box>
-  <GuideEntityEmbed Entity="MobVulpkanin" Caption="Vuplkanin"/>
+  <GuideEntityEmbed Entity="MobVulpkanin" Caption="Vulpkanin"/>
   <GuideEntityEmbed Entity="MobRodentia" Caption="Rodentia"/>
   <GuideEntityEmbed Entity="MobIPCDummy" Caption="I.P.C."/>
   <GuideEntityEmbed Entity="MobThaven" Caption="Thaven"/>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
moved two letters around

## Why / Balance
because otherwise it's incorrect

## Technical details
:)

## Media
![image](https://github.com/user-attachments/assets/fd0a1962-4717-492a-97ae-15db6c61f38f)


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
it breaks my mind that this typo exists

**Changelog**
nah
