### PR TITLE
Make space carps' livers clear out radiation from the body

### DIFF
--- a/Content.Server/_Funkystation/Medical/ConstantHealing/ConstantHealingComponent.cs
+++ b/Content.Server/_Funkystation/Medical/ConstantHealing/ConstantHealingComponent.cs
@@ -1,0 +1,24 @@
+using Content.Shared.EntityEffects;
+using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom;
+
+[RegisterComponent]
+public sealed partial class ConstantHealingComponent : Component
+{
+    /// <summary>
+    /// Effects to apply every cycle.
+    /// </summary>
+    [DataField("effects", required: true)]
+    public List<EntityEffect> Effects = default!;
+    /// <summary>
+    ///     The next time that reagents will be metabolized.
+    /// </summary>
+    [DataField(customTypeSerializer: typeof(TimeOffsetSerializer))]
+    public TimeSpan NextUpdate;
+
+    /// <summary>
+    ///     How often to metabolize reagents.
+    /// </summary>
+    /// <returns></returns>
+    [DataField]
+    public TimeSpan UpdateInterval = TimeSpan.FromSeconds(1);
+}

--- a/Content.Server/_Funkystation/Medical/ConstantHealing/ConstantHealingSystem.cs
+++ b/Content.Server/_Funkystation/Medical/ConstantHealing/ConstantHealingSystem.cs
@@ -1,0 +1,74 @@
+using Content.Shared.Administration.Logs;
+using Content.Shared.Body.Organ;
+using Content.Shared.Database;
+using Content.Shared.EntityEffects;
+
+using Robust.Shared.Random;
+using Robust.Shared.Timing;
+
+namespace Content.Server.Body.Systems
+{
+    public sealed class ConstantHealingSystem : EntitySystem
+    {
+        [Dependency] private readonly IGameTiming _gameTiming = default!;
+        [Dependency] private readonly IRobustRandom _random = default!;
+        [Dependency] private readonly ISharedAdminLogManager _adminLogger = default!;
+        private EntityQuery<OrganComponent> _organQuery;
+
+        public override void Initialize()
+        {
+            base.Initialize();
+
+            _organQuery = GetEntityQuery<OrganComponent>();
+        }
+
+        private void OnMapInit(Entity<ConstantHealingComponent> ent, ref MapInitEvent args)
+        {
+            ent.Comp.NextUpdate = _gameTiming.CurTime + ent.Comp.UpdateInterval;
+        }
+
+        private void OnUnpaused(Entity<ConstantHealingComponent> ent, ref EntityUnpausedEvent args)
+        {
+            ent.Comp.NextUpdate += args.PausedTime;
+        }
+        public override void Update(float frameTime)
+        {
+            base.Update(frameTime);
+
+            var query = EntityQueryEnumerator<ConstantHealingComponent>();
+
+            while (query.MoveNext(out var uid, out var comp))
+            {
+                if (_gameTiming.CurTime < comp.NextUpdate)
+                    continue;
+                comp.NextUpdate += comp.UpdateInterval;
+
+                Entity<ConstantHealingComponent, OrganComponent?> ent = (uid, comp);
+                _organQuery.Resolve(ent, ref ent.Comp2, logMissing: false);
+
+                if (ent.Comp2?.Body is EntityUid body) {
+                    var args = new EntityEffectBaseArgs(body, EntityManager);
+                    foreach (var effect in comp.Effects)
+                    {
+                        if (!effect.ShouldApply(args, _random))
+                            continue;
+
+                        if (effect.ShouldLog)
+                        {
+                            _adminLogger.Add(
+                                LogType.ReagentEffect,
+                                effect.LogImpact,
+                                $"Constant healing effect {effect.GetType().Name:effect}"
+                                + $" of organ {ent.Comp2.SlotId:organ}"
+                                + $" applied on entity {body:entity}"
+                                + $" at {Transform(body).Coordinates:coordinates}"
+                            );
+                        }
+
+                        effect.Effect(args);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Resources/Prototypes/_Shitmed/Body/Organs/Animal/space.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Organs/Animal/space.yml
@@ -21,6 +21,18 @@
     - type: PressureImmunity
 
 - type: entity
+  parent: OrganAnimalLiver
+  id: OrganSpaceAnimalLiver
+  name: space animal liver
+  components:
+  - type: ConstantHealing
+    effects:
+    - !type:HealthChange
+      damage:
+        types:
+          Radiation: -0.1
+
+- type: entity
   parent: OrganAnimalHeart
   id: OrganGoliathHeart
   name: goliath heart

--- a/Resources/Prototypes/_Shitmed/Body/Prototypes/Animal/carp.yml
+++ b/Resources/Prototypes/_Shitmed/Body/Prototypes/Animal/carp.yml
@@ -10,7 +10,7 @@
       organs:
         lungs: OrganSpaceAnimalLungs # Immunity to airloss
         stomach: OrganAnimalStomach
-        liver: OrganAnimalLiver
+        liver: OrganSpaceAnimalLiver
         heart: OrganSpaceAnimalHeart # Immunity to cold
         kidneys: OrganAnimalKidneys
     tail:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
the space animal liver now removes 0.1 rads per second from the body

## Why / Balance
funy

it might be unbalanced actually

## Technical details
added a `ConstantHealing` component / system that applies an effect every once in a while ( by default 1 second ), as well as a space animal liver, which contains that component

## Media

https://github.com/user-attachments/assets/be0df97d-3867-4948-aeac-548b16600c63

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Added space animal liver which can slowly filter out radiation from the body
