### PR TITLE
Fix IPC infinite bloodloss loop

### DIFF
--- a/Resources/Prototypes/_DV/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_DV/Damage/modifier_sets.yml
@@ -22,7 +22,7 @@
 - type: damageModifierSet
   id: BloodlossIPC
   coefficients:
-    Blunt: 0.08
+    Blunt: 0.00 # damagetype for bloodloss, dealing this will cause a loop
     Slash: 0.25
     Piercing: 0.2
     Shock: 0.0


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
For IPCs:
Blunt damage dealt bleed stacks
Blood/oil loss caused blunt damage
This created an infinite loop of repairing/bleeding

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The IPC buffs (fixes) will continue until morale improves

## Technical details
<!-- Summary of code changes for easier review. -->
Line
-->
