### PR TITLE
Fix protectionTime from Jamgoggles

### DIFF
--- a/Resources/Prototypes/_Funkystation/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Clothing/Eyes/glasses.yml
@@ -101,7 +101,6 @@
     sprite: _Funkystation/Clothing/Eyes/Jamjars/jamgog.rsi
   - type: VisionCorrection
   - type: EyeProtection
-    protectionTime: 5
   - type: IdentityBlocker
     coverage: EYES
   - type: Construction


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Removed protectionTime from Jamgoggles so you don't take any damage from welding at all as opposed to taking a little every time. Oops!
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
They're engineering goggles, full protection is a requirement.
## Technical details
<!-- Summary of code changes for easier review. -->
Removed "protectionTime" line from Resources/Prototypes/_Funkystation/Entities/Clothing/Eyes/glasses.yml (line 104)

Bug reported at https://github.com/funky-station/funky-station/issues/900
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

