### PR TITLE
Minor sec belt fixes

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -485,6 +485,8 @@
         - CombatKnife
         - Truncheon
         - BolaEnergy # Goobstation
+        - NonlethalGrenade
+        - Multiphase
       components:
         - Stunbaton
         - FlashOnTrigger

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -837,7 +837,7 @@
   name: X-01 Multiphase # Goobstation - Changed the capitalization because it was annoying me.
   parent: [BaseWeaponBatterySmall, BaseCommandContraband] # Frontier: added BaseC2ContrabandUnredeemable. Goobstation: removed BaseC2ContrabandUnredeemable, added BaseCommandContraband
   id: WeaponEnergyGunMultiphase
-  description: This is an expensive, modern recreation of the antique laser gun. This gun has several unique firemodes, but lacks the ability to recharge over time.
+  description: This is an expensive, modern recreation of the antique laser gun. This gun has several unique firemodes, including stun, kill and ion options.
   components:
   - type: Sprite
     sprite: _DV/Objects/Weapons/Guns/Battery/multiphase_energygun.rsi
@@ -896,6 +896,7 @@
   - type: Tag
     tags:
     - HighRiskItem
+    - Sidearm
   - type: BatterySelfRecharger
     autoRecharge: true
     autoRechargeRate: 40

--- a/Resources/Prototypes/Entities/Objects/Weapons/Throwable/projectile_grenades.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Throwable/projectile_grenades.yml
@@ -52,6 +52,9 @@
   - type: TimerTriggerVisuals
     primingSound:
       path: /Audio/Effects/countdown.ogg
+  - type: Tag
+    tags:
+    - NonlethalGrenade
 
 - type: entity
   parent: [ProjectileGrenadeBase, BaseSyndicateContraband]

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -922,6 +922,9 @@
   id: NoConsoleSound
 
 - type: Tag
+  id: NonlethalGrenade
+
+- type: Tag
   id: NoRecharge # Assmos - Crystallizer
 
 - type: Tag
@@ -1322,7 +1325,7 @@
 
 - type: Tag
   id: Torch
-  
+
 - type: Tag
   id: Tourniquet
 


### PR DESCRIPTION
## About the PR
Recently the stinger grenade and X-01 multiphase became unable to go into the sec belt. I've not found what did this but I have fixed so now they do again. Also changed description of X-01 which says it does not recharge, when it clearly does. 

## Why / Balance
Standard fixing of a bug

## Technical details
None needed, just yaml. Added a new tag 'NonlethalGrenade' which I may add to others for sensible codebase

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
<!--
:cl:
- fix: Fixed stinger grenade and x-01 multiphase not going in the sec belt (they now do) and also changed description for the pistol as it does recharge despite what it said
-->
