### PR TITLE
Thavens are fixed now, everyone clap

### DIFF
--- a/Resources/Prototypes/_Impstation/Entities/Mobs/Species/thaven.yml
+++ b/Resources/Prototypes/_Impstation/Entities/Mobs/Species/thaven.yml
@@ -67,8 +67,8 @@
     proto: thaven # DeltaV unique typing indicator
   - type: Vocal
     sounds:
-      Male: UnisexThaven
-      Female: UnisexThaven
+      Male: MaleThaven
+      Female: FemaleThaven
       Unsexed: UnisexThaven
   - type: Speech
     speechSounds: Alto


### PR DESCRIPTION
## About the PR
I changed two words in the code to fix an oversight. Thavens now actually have separate screams for each gender

## Why / Balance
It was really annoying that female thavens would use the male scream.

## Technical details
I changed two words across two lines in Resources/Prototypes/_Impstation/Entities/Mobs/Species/thaven.yml

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl: amethystowo
- fix: Thavens no longer all have unisex screams, and now have separate screams for each gender.
