### PR TITLE
bugfix, stun resist on ling armor

### DIFF
--- a/Resources/Prototypes/_Goobstation/Changeling/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/Entities/Clothing/OuterClothing/armor.yml
@@ -9,6 +9,8 @@
     sprite: _Goobstation/Changeling/ling_armor.rsi
   - type: Clothing
     sprite: _Goobstation/Changeling/ling_armor.rsi
+  - type: StaminaResistance
+    damageCoefficient: 0.40
   - type: Armor
     modifiers:
       coefficients:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

Added missing stamina resistance to chitinous armor 

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Bugfix, missing value

## Technical details
<!-- Summary of code changes for easier review. -->

Added missing stun resistance to changeling armor. Bugfix.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

n/a

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Added missing changeling armor stun resist.
