### PR TITLE
Organic shield fix

### DIFF
--- a/Content.Server/Destructible/Thresholds/Behaviors/RemoveOrganicShield.cs
+++ b/Content.Server/Destructible/Thresholds/Behaviors/RemoveOrganicShield.cs
@@ -1,0 +1,42 @@
+using Content.Shared.Changeling;
+using System.Linq;
+using Content.Server.Cargo.Components;
+using Content.Shared.Cargo;
+using Content.Shared.Cargo.BUI;
+using Content.Shared.Cargo.Components;
+using Content.Shared.Cargo.Events;
+using Content.Shared.Cargo.Prototypes;
+using JetBrains.Annotations;
+using Robust.Shared.Audio;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.Destructible.Thresholds.Behaviors
+{
+    [DataDefinition]
+    public sealed partial class RemoveOrganicShield : IThresholdBehavior
+    {
+        public void Execute(EntityUid owner, DestructibleSystem system, EntityUid? cause = null)
+        {
+            var entManager = IoCManager.Resolve<IEntityManager>();
+            //Logger.Debug($"[RemoveOrganicShield] Executing on entity {owner}");
+
+            // Climb the parent chain to find the root entity with the ChangelingComponent
+            var current = owner;
+            while (entManager.TryGetComponent(current, out TransformComponent? xform) && xform.ParentUid.IsValid())
+            {
+                current = xform.ParentUid;
+
+                if (entManager.HasComponent<ChangelingComponent>(current))
+                {
+                    if (entManager.TryGetComponent(current, out ChangelingComponent? changelingComponent))
+                    {
+                        // Logger.Debug($"[RemoveOrganicShield] Found ChangelingComponent on {current}, removing shield.");
+                        changelingComponent.Equipment.Remove(changelingComponent.ShieldPrototype);
+                        return;
+                    }
+                }
+            }
+            Logger.Warning($"[RemoveOrganicShield] Could not find owning entity with ChangelingComponent for {owner}");
+        }
+    }
+}

--- a/Content.Server/Destructible/Thresholds/Behaviors/RemoveOrganicShield.cs
+++ b/Content.Server/Destructible/Thresholds/Behaviors/RemoveOrganicShield.cs
@@ -1,14 +1,4 @@
 using Content.Shared.Changeling;
-using System.Linq;
-using Content.Server.Cargo.Components;
-using Content.Shared.Cargo;
-using Content.Shared.Cargo.BUI;
-using Content.Shared.Cargo.Components;
-using Content.Shared.Cargo.Events;
-using Content.Shared.Cargo.Prototypes;
-using JetBrains.Annotations;
-using Robust.Shared.Audio;
-using Robust.Shared.Prototypes;
 
 namespace Content.Server.Destructible.Thresholds.Behaviors
 {

--- a/Content.Server/_Goobstation/Changeling/ChangelingSystem.Abilities.cs
+++ b/Content.Server/_Goobstation/Changeling/ChangelingSystem.Abilities.cs
@@ -213,7 +213,7 @@ public sealed partial class ChangelingSystem : EntitySystem
             bonusChemicals += targetComp.MaxChemicals / 2;
             bonusEvolutionPoints += 10;
             comp.MaxBiomass += targetComp.MaxBiomass / 2;
-            
+
             isTargetChangeling = true;
         }
         else
@@ -239,12 +239,12 @@ public sealed partial class ChangelingSystem : EntitySystem
                 objective.Absorbed += 1;
 
         if (isTargetChangeling) return;
-        
+
         if (!TryComp<TargetingComponent>(target, out var targetingComponent))
             return; // funky station - if you get here somethings really wrong
-            
+
         var bodyPart = _bodySystem.GetRandomBodyPart(target, targetingComponent, _bodyPartBlacklist);
-        
+
         if (bodyPart != null)
         {
             if (_proto.TryIndex<DamageTypePrototype>("Blunt", out var bluntDamage))
@@ -255,7 +255,7 @@ public sealed partial class ChangelingSystem : EntitySystem
         var bodyOrgans = _bodySystem.GetBodyOrgans(target);
 
         var valueTuples = bodyOrgans.ToList();
-        
+
         foreach (var organ in valueTuples)
         {
             if (organs.Contains(organ.Component.SlotId))
@@ -271,11 +271,11 @@ public sealed partial class ChangelingSystem : EntitySystem
         var organWhitelist = new Dictionary<string, float>(_organWhitelist);
         List<string> organs = [];
         const int tries = 3;
-        
+
         for (var i = 0; i < tries; i++)
         {
             _rand.TryPickAndTake(organWhitelist, out var organ);
-            
+
             if (organ != null)
                 organs.Add(organ);
         }
@@ -424,7 +424,7 @@ public sealed partial class ChangelingSystem : EntitySystem
         if (!TryUseAbility(uid, comp, args))
             return;
 
-        if (!TryToggleItem(uid, ShieldPrototype, comp))
+        if (!TryToggleItem(uid, comp.ShieldPrototype, comp))
             return;
 
         PlayMeatySound(uid, comp);

--- a/Content.Server/_Goobstation/Changeling/ChangelingSystem.cs
+++ b/Content.Server/_Goobstation/Changeling/ChangelingSystem.cs
@@ -108,8 +108,7 @@ public sealed partial class ChangelingSystem : EntitySystem
 
     public EntProtoId ArmbladePrototype = "ArmBladeChangeling";
     public EntProtoId FakeArmbladePrototype = "FakeArmBladeChangeling";
-
-    //public EntProtoId ShieldPrototype = "ChangelingShield";
+    
     public EntProtoId BoneShardPrototype = "ThrowingStarChangeling";
 
     public EntProtoId ArmorPrototype = "ChangelingClothingOuterArmor";

--- a/Content.Server/_Goobstation/Changeling/ChangelingSystem.cs
+++ b/Content.Server/_Goobstation/Changeling/ChangelingSystem.cs
@@ -109,7 +109,7 @@ public sealed partial class ChangelingSystem : EntitySystem
     public EntProtoId ArmbladePrototype = "ArmBladeChangeling";
     public EntProtoId FakeArmbladePrototype = "FakeArmBladeChangeling";
 
-    public EntProtoId ShieldPrototype = "ChangelingShield";
+    //public EntProtoId ShieldPrototype = "ChangelingShield";
     public EntProtoId BoneShardPrototype = "ThrowingStarChangeling";
 
     public EntProtoId ArmorPrototype = "ChangelingClothingOuterArmor";
@@ -118,17 +118,17 @@ public sealed partial class ChangelingSystem : EntitySystem
     public EntProtoId SpacesuitPrototype = "ChangelingClothingOuterHardsuit";
     public EntProtoId SpacesuitHelmetPrototype = "ChangelingClothingHeadHelmetHardsuit";
 
-    private readonly List<TargetBodyPart> _bodyPartBlacklist = 
-    [ 
-        TargetBodyPart.Head, 
-        TargetBodyPart.Torso, 
+    private readonly List<TargetBodyPart> _bodyPartBlacklist =
+    [
+        TargetBodyPart.Head,
+        TargetBodyPart.Torso,
         TargetBodyPart.Groin,
         TargetBodyPart.LeftFoot,
         TargetBodyPart.RightFoot,
         TargetBodyPart.RightHand,
         TargetBodyPart.LeftHand
     ];
-    
+
     private readonly Dictionary<string, float> _organWhitelist = new()
     {
         { "stomach", 0.5f },
@@ -463,15 +463,15 @@ public sealed partial class ChangelingSystem : EntitySystem
         || !TryComp<DnaComponent>(target, out var dna)
         || !TryComp<FingerprintComponent>(target, out var fingerprint))
         return false;
-        
+
         if (_mobState.IsAlive(target) && comp.UsedDnaStingFirstTime)
         {
             _popup.PopupEntity(Loc.GetString("changeling-sting-extract-alive-fail"), uid, uid);
             return false;
         }
-        
+
         comp.UsedDnaStingFirstTime = true;
-        
+
         foreach (var storedDNA in comp.AbsorbedDNA)
         {
             if (storedDNA.DNA == dna.DNA)

--- a/Content.Shared/_Goobstation/Changeling/ChangelingComponent.cs
+++ b/Content.Shared/_Goobstation/Changeling/ChangelingComponent.cs
@@ -46,6 +46,8 @@ public sealed partial class ChangelingComponent : Component
 
     #endregion
 
+    public EntProtoId ShieldPrototype = "ChangelingShield";
+
     public bool IsInStasis = false;
 
     public bool StrainedMusclesActive = false;
@@ -133,7 +135,7 @@ public sealed partial class ChangelingComponent : Component
 
     [ViewVariables(VVAccess.ReadOnly)]
     public TransformData? SelectedForm;
-    
+
     /// <summary>
     /// If the changeling used their DNA sting for the first time. Only set when used first time.
     /// By default false.

--- a/Resources/Prototypes/_Goobstation/Changeling/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/Entities/Objects/Shields/shields.yml
@@ -16,14 +16,9 @@
       thresholds:
         - trigger:
             !type:DamageTrigger
-            damage: 60
-          behaviors:
-            - !type:DoActsBehavior
-              acts: [ "Destruction" ]
-        - trigger:
-            !type:DamageTrigger
             damage: 50
           behaviors:
+            - !type:RemoveOrganicShield # Remove the shield Uid in the equipment dictionary of the changeling component (avoid triggering this ability to "deactivate a shield that is destroyed")
             - !type:DoActsBehavior
               acts: [ "Destruction" ]
             - !type:PlaySoundBehavior


### PR DESCRIPTION
## About the PR
Delete organic shield Uid in changeling equipment dictionary if destroyed.

## Why / Balance
When your organic shield gets destroyed, if you recast the ability, it will not do anything, but still cost you chemicals.
You have to cast it a second time to have your shield back. This made the organic shield one of the least used ability, due to its high cost (having to trigger it twice once broken) and low return of investment (fleshmend was simply superior).
Now that this is fixed, organic shield should see the light more often now, and have a real benefit to the player.
If the shield isnt destroyed, the player will still have to retract it and pay the full ability price.

## Technical details
When the organic shield is destroyed, it was not removing itself from the equipment list in the changeling component. This issue was fixed by adding a new IThresholdBehavior to the shield yml that removes the EntityUid corresponding to the shield.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl:
- fix: Changeling organic shield no longer needs to be "retracted" when it is broken.
