### PR TITLE
List of salvage related tweaks (hopyfully no longer violently evil)

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_cargo.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_cargo.yml
@@ -8,12 +8,4 @@
   category: cargoproduct-category-name-cargo
   group: market
 
-- type: cargoProduct
-  id: CargoLuxuryHardsuit
-  icon:
-    sprite: Clothing/Head/Hardsuits/luxury.rsi
-    state: icon
-  product: CrateCargoLuxuryHardsuit
-  cost: 15000
-  category: cargoproduct-category-name-cargo
-  group: market
+

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -3,7 +3,14 @@
   table: !type:AllSelector
     children:
     - id: BoxEncryptionKeyCargo
+    - id: OxygenTankFilled
+    - id: NitrogenTankFilled
+    - id: ClothingShoesBootsMag
+    - id: ClothingMaskGasExplorer
     - id: BoxFolderQmClipboard
+    - id: ClothingBeltUtilityFilled
+    - id: WeaponGrapplingGun
+    - id: WeaponProtoKineticAccelerator 
     - id: CargoBountyComputerCircuitboard
     - id: CargoRequestComputerCircuitboard
     - id: CargoSaleComputerCircuitboard

--- a/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
+++ b/Resources/Prototypes/Entities/Clothing/Masks/masks.yml
@@ -54,7 +54,7 @@
   parent: [ClothingMaskGas, BaseSyndicateContraband]
   id: ClothingMaskGasSyndicate
   name: syndicate gas mask
-  description: A close-fitting tactical mask that can be connected to an air supply.
+  description: A close-fitting tactical gas mask with built in welding goggles and face shield.
   components:
   - type: Sprite
     sprite: Clothing/Mask/gassyndicate.rsi
@@ -119,9 +119,9 @@
   - type: IngestionBlocker
 
 - type: entity
-  parent: [ClothingMaskGas, BaseCargoContraband]
+  parent: [ClothingMaskGas, BaseSecurityCargoContraband]
   id: ClothingMaskGasExplorer
-  name: explorer gas mask
+  name: armoured gas mask
   description: A military-grade gas mask that can be connected to an air supply.
   components:
   - type: Sprite
@@ -720,7 +720,7 @@
   parent: ClothingMaskGas
   id: ClothingMaskWeldingGas
   name: welding gas mask
-  description: A gas mask with built in welding goggles and face shield. Looks like a skull, clearly designed by a nerd.
+  description: A gas mask with built in welding goggles. Looks like a skull, clearly designed by a nerd.
   components:
   - type: Sprite
     sprite: Clothing/Mask/welding-gas.rsi

--- a/Resources/Prototypes/Entities/Clothing/Neck/misc.yml
+++ b/Resources/Prototypes/Entities/Clothing/Neck/misc.yml
@@ -47,7 +47,7 @@
   parent: ClothingNeckBase
   id: ClothingNeckBling
   name: bling
-  description: Damn, it feels good to be a gangster.
+  description: It would make you feel like a gangster, if it was not made out of cheap plastic. # Only worth 10 spesos kekw
   components:
   - type: Sprite
     sprite: Clothing/Neck/Misc/bling.rsi
@@ -55,6 +55,9 @@
     sprite: Clothing/Neck/Misc/bling.rsi
   - type: Item
     sprite: Clothing/Neck/Misc/bling.rsi
+  - type: PhysicalComposition
+    materialComposition:
+      Plastic: 200
 
 - type: entity
   parent: ClothingNeckBase

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -196,7 +196,7 @@
     graph: HardsuitGoliath
     node: hardsuitGoliath
 
-#Maxim Hardsuit
+#Maxim Hardsuit [TODO  Make this bastard somehow obtainable in a way thats not going to break game balance] 
 - type: entity
   parent: [ClothingOuterHardsuitBase, BaseCargoContraband]
   id: ClothingOuterHardsuitMaxim
@@ -210,11 +210,9 @@
   - type: PressureProtection
     highPressureMultiplier: 0.02
     lowPressureMultiplier: 1000
-  - type: ClothingSpeedModifier
+  - type: ClothingSpeedModifier # This right here is why the Maxim is terrifying
     walkModifier: 1.0
     sprintModifier: 1.0
-  - type: StaminaResistance
-    damageCoefficient: 0.6
   - type: Armor
     modifiers:
       coefficients:
@@ -223,6 +221,7 @@
         Piercing: 0.5
         Heat: 0.3
         Radiation: 0.1
+        Caustic: 0.6
   - type: ExplosionResistance
     damageCoefficient: 0.2
   - type: TemperatureProtection
@@ -247,8 +246,6 @@
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
     damageCoefficient: 0.4
-  - type: StaminaResistance
-    damageCoefficient: 0.8 
   - type: Armor
     modifiers:
       coefficients:
@@ -278,8 +275,6 @@
   - type: PressureProtection
     highPressureMultiplier: 0.3
     lowPressureMultiplier: 1000
-  - type: StaminaResistance
-    damageCoefficient: 0.8 
   - type: Armor
     modifiers:
       coefficients:
@@ -310,8 +305,6 @@
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
     damageCoefficient: 0.4
-  - type: StaminaResistance
-    damageCoefficient: 0.7 
   - type: Armor
     modifiers:
       coefficients:
@@ -343,8 +336,6 @@
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
     damageCoefficient: 0.5
-  - type: StaminaResistance
-    damageCoefficient: 0.7
   - type: Armor
     modifiers:
       coefficients:
@@ -466,7 +457,7 @@
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitRd
   - type: StaticPrice
-    price: 750
+    price: 7500
   - type: StealTarget
     stealGroup: ClothingOuterHardsuitRd
 
@@ -486,8 +477,6 @@
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
     damageCoefficient: 0.6
-  - type: StaminaResistance
-    damageCoefficient: 0.6
   - type: Armor
     modifiers:
       coefficients:
@@ -504,13 +493,12 @@
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSecurityRed
 
-#Luxury Mining Hardsuit
+#Quartermasters Mining Hardsuit (aka the Luxury mining hardsuit)
 - type: entity
-  parent: ClothingOuterHardsuitBase
-  id: ClothingOuterHardsuitLuxury #DO NOT MAP - https://github.com/space-wizards/space-station-14/pull/19738#issuecomment-1703486738
-  name: luxury mining hardsuit
-  description: A refurbished mining hardsuit, fashioned after the Quartermaster's colors. Graphene lining provides less protection, but is much easier to move.
-  categories: [ DoNotMap ]
+  parent: [ClothingOuterHardsuitBase, BaseCommandContraband]
+  id: ClothingOuterHardsuitLuxury 
+  name: quartermasters mining hardsuit
+  description: A custom ordered mining hardsuit, fashioned after the Quartermaster's colors. Just as protective as a regular mining hardsuit, but is much easier to move in.
   components:
   - type: Sprite
     sprite: Clothing/OuterClothing/Hardsuits/luxury.rsi
@@ -520,21 +508,31 @@
     highPressureMultiplier: 0.5
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
-    damageCoefficient: 0.5
-  - type: Armor
+    damageCoefficient: 0.3
+  - type: Armor # Wizden design can go to hell, this suit should not be a dirrect downgrage compared to the actual salvage suits
     modifiers:
       coefficients:
-        Blunt: 0.9
-        Slash: 0.9
-        Piercing: 0.8
-        Radiation: 0.5
-        Caustic: 0.8
+        Blunt: 0.7
+        Slash: 0.7
+        Piercing: 0.5
+        Radiation: 0.3
+        Caustic: 0.7
   - type: ClothingSpeedModifier
     walkModifier: 0.85
-    sprintModifier: 0.9
+    sprintModifier: 0.85
+  - type: Item
+    size: Huge
+    shape:
+    - 0,0,4,4 #5X5, can fit in a duffel bag but nothing smaller, this has been added incase this suit gets made into a steal objective
+  - type: Tag
+    tags:
+    - WhitelistChameleon
+    - HighRiskItem
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitLuxury
+  - type: StaticPrice
+    price: 15000 # a small callback to when you could buy this suit 
 
 #ANTAG HARDSUITS
 #Blood-red Hardsuit
@@ -555,8 +553,8 @@
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
     damageCoefficient: 0.5
-  - type: StaminaResistance
-    damageCoefficient: 0.75
+  #- type: StaminaResistance
+  #  damageCoefficient: 0.75
   - type: Armor
     modifiers:
       coefficients:
@@ -617,8 +615,8 @@
     damageCoefficient: 0.2
   - type: FireProtection
     reduction: 0.8
-  - type: StaminaResistance
-    damageCoefficient: 0.6
+  #- type: StaminaResistance
+  #  damageCoefficient: 0.6
   - type: Armor
     modifiers:
       coefficients:
@@ -653,8 +651,8 @@
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
     damageCoefficient: 0.5
-  - type: StaminaResistance
-    damageCoefficient: 0.5
+  #- type: StaminaResistance
+  #  damageCoefficient: 0.6
   - type: Armor
     modifiers:
       coefficients:
@@ -721,8 +719,6 @@
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
     damageCoefficient: 0.5
-  - type: StaminaResistance
-    damageCoefficient: 0.8 
   - type: Armor
     modifiers:
       coefficients:
@@ -784,8 +780,6 @@
     sprite: Clothing/OuterClothing/Hardsuits/pirateeva.rsi
   - type: ExplosionResistance
     damageCoefficient: 0.7
-  - type: StaminaResistance
-    damageCoefficient: 0.8
   - type: Armor
     modifiers:
       coefficients:
@@ -819,8 +813,6 @@
     lowPressureMultiplier: 1000
   - type: ExplosionResistance
     damageCoefficient: 0.6
-  - type: StaminaResistance
-    damageCoefficient: 0.70 
   - type: Armor
     modifiers:
       coefficients:
@@ -985,8 +977,6 @@
     coolingCoefficient: 0.001
   - type: ExplosionResistance
     damageCoefficient: 0.7
-  - type: StaminaResistance
-    damageCoefficient: 0.75 
   - type: Armor
     modifiers:
       coefficients:

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/tables_loot.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/tables_loot.yml
@@ -1,5 +1,4 @@
 # Scrap: Worthless items that can be recycled into materials
-
 - type: entityTable
   id: SalvageScrapLowValue
   table: !type:GroupSelector
@@ -35,7 +34,6 @@
       weight: 0.5
       amount: !type:RangeNumberSelector
         range: 1, 3
-
 - type: entityTable
   id: SalvageScrapHighValue
   table: !type:GroupSelector
@@ -59,8 +57,12 @@
       weight: 0.2
     - id: ArtifactFragment1
       weight: 0.05
+      weight: 0.20
+      amount: !type:RangeNumberSelector
+        range: 1, 10
     - id: SheetPlasteel10
       weight: 0.05
+      weight: 0.10
 
 - type: entityTable
   id: SalvageScrapLarge
@@ -77,17 +79,14 @@
       weight: 0.5
     - id: ScrapMopBucket
       weight: 0.5
-
 # Treasure: High-value scatterables that don't do a ton.
-
 - type: entityTable
   id: SalvageTreasureCommon
   table: !type:GroupSelector
     children:
     - id: SheetPlasma1
       amount: !type:RangeNumberSelector
-        range: 3, 5
-    - id: ResearchDisk
+        range: 5, 20
     - id: DrinkGoldenCup
     - id: TreasureSampleTube
     - !type:NestedSelector
@@ -96,23 +95,21 @@
         range: 1, 2
     - !type:NestedSelector
       tableId: RandomInstrumentTable
-
 - type: entityTable
   id: SalvageTreasureUncommon
   table: !type:GroupSelector
     children:
     - id: IngotSilver1
       amount: !type:RangeNumberSelector
-        range: 1, 5
+        range: 5, 10
     - id: IngotGold1
       amount: !type:RangeNumberSelector
-        range: 3, 5
+        range: 5, 10
     - id: TreasureDatadiskEncrypted
     - !type:GroupSelector
       children:
       - id: TreasureCDDrive
       - id: TreasureHardDiskDrive
-      - id: TreasureFlopDiskDrive
     - !type:NestedSelector
       tableId: TreasureCoinPile
       rolls: !type:RangeNumberSelector
@@ -121,15 +118,13 @@
     - id: WristwatchGold
     - !type:NestedSelector
       tableId: RingTableCommon
-
 - type: entityTable
   id: SalvageTreasureRare
   table: !type:GroupSelector
     children:
     - id: MaterialDiamond1
     - id: TreasureCPUSupercharged
-    - id: TechnologyDiskRare
-      weight: 0.5
+    - id: CrateCargoGambling
     - id: ResearchDisk10000
       weight: 0.5
     - id: ArabianLamp
@@ -154,7 +149,6 @@
           weight: 1
     - !type:NestedSelector
       tableId: RingTableRare
-
 - type: entityTable
   id: SalvageTreasureLegendary
   table: !type:GroupSelector
@@ -162,7 +156,7 @@
     - id: ClothingMaskGoldenCursed
     - id: ClothingHeadHatFancyCrown
     - id: GoldenBikeHorn
-    - id: ClothingHeadHatCatEars
+    - id: CrateCargoGambling
     - id: TreasureCoinDiamond
       amount: !type:RangeNumberSelector
         range: 2, 5
@@ -170,14 +164,36 @@
       tableId: RingTableRare
       rolls: !type:RangeNumberSelector
         range: 2, 3
-
 # Equipment: Tools and things used by salvagers. Quote unquote "Gamer Loot"
 
 - type: entityTable
-  id: SalvageEquipmentCommon
+  id: SalvageEquipmentCommon # Mostly misc items,tools and clothing 
   table: !type:GroupSelector
     children:
     - id: Flare
+    - id: ClothingHeadHatBeretMerc
+    - id: ClothingHeadBandMerc
+    - id: ClothingMaskBandMerc
+    - id: ClothingUniformJumpsuitMercenary
+    - id: ClothingHandsGlovesMercFingerless
+    - id: ClothingHeadHatUshanka 
+    - id: ClothingBackpackMerc
+      weight: 0.1
+    - id: ClothingBackpackSatchelLeather
+      weight: 0.1
+    - id: ClothingUniformJumpsuitPirate
+    - id: ClothingShoesBootsLaceup
+    - id: ClothingHeadBandBlack
+    - id: ClothingHeadHatPirate
+    - id: ClothingNeckCloakPirateCap
+      weight: 0.1
+    - id: PirateHandyFlag # Me Pirate! 
+      weight: 0.1
+    - id: RadioHandheld
+    - id: DrinkVodkaBottleFull
+    - id: BoxMRE
+    - id: CigPackBlack
+    - id: ClothingBeltUtility
     - id: Crowbar
     - id: Pickaxe
     - id: ClothingMaskGas
@@ -188,77 +204,132 @@
       - id: Wrench
       - id: Welder
         weight: 0.5
+      - id: WelderIndustrial
+        weight: 0.25
     - id: Shovel
     - id: FlashlightLantern
     - id: FireExtinguisher
     - id: SurvivalKnife
 
 - type: entityTable
-  id: SalvageEquipmentUncommon
+  id: SalvageEquipmentUncommon # Mostly just random but rarely seen melee weapons 
   table: !type:GroupSelector
     children:
     - id: OreBag
     - id: HandheldGPSBasic
+    - id: HandHeldMassScanner
+      weight: 0.25
     - id: PowerCellHighPrinted
-    - id: RadioHandheld
-    - id: ClothingBeltUtility
+    - id: Machete
+    - id: KukriKnife
+    - id: Cutlass
+    - id: Sledgehammer
+    - id: FireAxe
+      weight: 0.5
+    - id: Chainsaw
+      weight: 0.25
+    - id: Katana
     - id: WeaponProtoKineticAccelerator
       weight: 0.5
-    - id: OxygenTankFilled
     - id: WelderIndustrial
     - id: WeaponGrapplingGun
     - !type:GroupSelector
       children:
       - id: ClothingHeadHatWelding
       - id: ClothingHeadHatWeldingMaskFlame
+      - id: ClothingOuterHardsuitPirateEVA
         weight: 0.25
       - id: ClothingHeadHatWeldingMaskFlameBlue
         weight: 0.25
       - id: ClothingHeadHatWeldingMaskPainted
+      - id: ClothingOuterHardsuitPirateCap
         weight: 0.1
-
 - type: entityTable
-  id: SalvageEquipmentRare
+  id: SalvageEquipmentRare 
   table: !type:GroupSelector
     children:
     - id: BlueprintDoubleEmergencyTank
-    - id: FultonBeacon
+    - id: SeismicCharge
     - id: Fulton
       amount: !type:RangeNumberSelector
         range: 1, 3
     - id: HandHeldMassScanner
-    - id: WeaponCrusherDagger
     - id: MiningDrill
     - id: ClothingEyesGlassesMeson
     - id: ClothingBeltSalvageWebbing
+    - id: Machete
+      weight: 0.5
+    - id: KukriKnife
+      weight: 0.5
+    - id: Cutlass
+      weight: 0.5
+    - id: Sledgehammer
+      weight: 0.5
+    - id: Katana
+      weight: 0.25
     - id: SeismicCharge
     - id: MineralScanner
       weight: 0.5
-    - id: WeaponCrusher
-      weight: 0.5
-    - !type:GroupSelector
+    - !type:GroupSelector # The iconic arms of salvagers
       children:
-      - id: JetpackBlue
-      - id: JetpackBlack
+       - id: WeaponCrusherDagger  
+       - id: WeaponCrusher
+         weight: 0.5
+       - id: WeaponCrusherGlaive
+         weight: 0.5
+    - !type:GroupSelector # Jetpacks and Airtanks 
+      children:
+      - id: JetpackBlueFilled
+      - id: JetpackBlackFilled # This is technically sindie contra, but its not any diffrent from a regular jetpack
+        weight: 0.25
+      - id: DoubleEmergencyNitrogenTankFilled
+        weight: 0.5
+      - id: DoubleEmergencyOxygenTankFilled
 
 - type: entityTable
   id: SalvageEquipmentLegendary
-  table: !type:GroupSelector
+  table: !type:GroupSelector 
     children:
     - id: AdvancedMineralScanner
-    - id: BlueprintFulton
-    - id: BlueprintSeismicCharge
-    - id: WeaponCrusherGlaive
+    - id: CratePermaEscapeEVA
+    - id: CratePermaEscapeGun
+    - id: CratePermaEscapeGiftsFromSyndicate
+      weight: 0.45
+    - id: CratePermaEscapeMerc
+    - id: CratePermaEscapeComs
+    - id: CratePermaEscapeMats
+    - id: CratePermaEscapeLights
+    - id: CratePermaEscapeDigging
+    - id: CrateFoodPizzaLarge
+    - id: ClothingBackpackSatchelSmugglerUnanchored
+    - id: SyndicateBusinessCard
+      weight: 0.05
+    - id: ClothingEyesGlassesMercenary
+      weight: 0.05
+    - id: ClothingMaskGasMerc
+      weight: 0.15
+    - id: ClothingHeadHelmetMerc
+      weight: 0.25
+    - id: ClothingOuterVestWebMerc
+      weight: 0.15
+    - id: ClothingHandsMercGlovesCombat
+      weight: 0.05
+    - id: ClothingBeltMercWebbing
+      weight: 0.25
+    - id: ClothingShoesBootsMerc
+      weight: 0.15
+    - id: ToolDebug # Spanish Army Knife, not actualy sure why this is considered a debug tool, its cool
+      weight: 0.01
     - !type:GroupSelector
       children:
       - id: ClothingOuterHardsuitSalvage
       - id: ClothingOuterHardsuitMaxim # funkystation
         weight: 0.05
-    - id: OmnizineChemistryBottle
     - !type:GroupSelector
       children:
-      - id: JetpackBlueFilled
-      - id: JetpackBlackFilled
+      - id: PowerCellAntiqueProto
+        weight: 0.25
+      - id: PowerCellHyper
 
 - type: entityTable
   id: RandomGeneratorTable

--- a/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cups.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Drinks/drinks_cups.yml
@@ -52,7 +52,11 @@
   - type: Sprite
     sprite: Objects/Consumable/Drinks/golden_cup.rsi
   - type: StaticPrice
-    price: 125
+    price: 400 # This is mostly just a salvage find 
+  - type: PhysicalComposition  
+    materialComposition:
+      Gold: 125
+      Silver: 125
 
 - type: entity
   parent: DrinkBaseCup

--- a/Resources/Prototypes/Entities/Objects/Devices/wristwatch.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/wristwatch.yml
@@ -38,6 +38,9 @@
       behaviors:
       - !type:DoActsBehavior
         acts: [ "Breakage" ]
+  - type: PhysicalComposition
+    materialComposition:
+      Plastic: 100    
 
 - type: entity
   id: WristwatchGold
@@ -57,3 +60,6 @@
     sprite: Objects/Devices/goldwatch.rsi
   - type: StaticPrice
     price: 500 #if you ever increase the price of kidneys, increase this too.
+  - type: PhysicalComposition
+    materialComposition:
+      Gold: 250

--- a/Resources/Prototypes/Entities/Objects/Misc/treasure.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/treasure.yml
@@ -17,7 +17,7 @@
     castShadows: false
     color: "#0000ff"
   - type: StaticPrice
-    price: 500
+    price: 1000
 
 - type: entity
   parent: BaseItem
@@ -39,13 +39,13 @@
         harddisk_mini: ""
         harddisk_micro: ""
   - type: StaticPrice
-    price: 275
+    price: 525
 
 - type: entity
   parent: BaseItem
   id: TreasureFlopDiskDrive
   name: floppy disk drive
-  description: A drive for reading off info off of floppy disks. Shame that the only things stored on them nowadays are nuclear bomb operations.
+  description: A drive for reading off info off of floppy disks. Shame that the only things stored on them nowadays are nuclear bomb operations,curiously enough these are never in short demand.
   components:
   - type: Sprite
     sprite: Objects/Misc/module.rsi
@@ -54,13 +54,13 @@
   - type: Item
     storedRotation: -90
   - type: StaticPrice
-    price: 350
+    price: 700
 
 - type: entity
   parent: BaseItem
   id: TreasureCDDrive
   name: CD drive
-  description: A piece of tech for reading data off of CDs. Nowadays that's not the most useful thing, unless you plan on flying somewhere.
+  description: A piece of tech for reading data off of CDs. Nowadays that's not the most useful thing, but collectors pay a pretty penny for useless things.
   components:
   - type: Sprite
     sprite: Objects/Misc/module.rsi
@@ -69,13 +69,13 @@
   - type: Item
     storedRotation: -90
   - type: StaticPrice
-    price: 300
+    price: 600
 
 - type: entity
   parent: BaseItem
   id: TreasureCPUSupercharged
   name: supercharged CPU
-  description: Some kind of super alien space tech. Shame all the computers already come with CPUs nowadays.
+  description: Some kind of super alien space device. Tech like this makes for good scrap and fetches a decent price on the market.
   components:
   - type: Sprite
     sprite: Objects/Misc/module.rsi
@@ -85,17 +85,17 @@
     size: Tiny
   - type: PhysicalComposition
     materialComposition: # big mats if you don't sell it
-      Steel: 500
-      Glass: 1000
-      Silver: 300
+      Plasma: 1500
+      Gold: 500
+      Silver: 1000
   - type: StaticPrice
-    price: 750
+    price: 2500
 
 - type: entity
   parent: BaseItem
   id: TreasureSampleTube
   name: sample tube
-  description: A glass tube with some sort of goop in it. Looks prone to breaking.
+  description: A glass tube with some sort of sample in it. People are interested in buying these for whatever reason.
   components:
   - type: Sprite
     sprite: Objects/Misc/sample_tubes.rsi
@@ -112,7 +112,7 @@
         synchronizer: ""
         stabilizer: ""
   - type: StaticPrice
-    price: 120
+    price: 275
 
 - type: entityTable
   id: TreasureCoinPile
@@ -148,7 +148,7 @@
   parent: BaseItem
   id: TreasureCoinIron
   name: coin
-  description: A flat bit of metal. If it was still in circulation, inflation would've made it worthless. Since it isn't, it's worth enough to keep in a book.
+  description: A flat bit of metal. If it was still in circulation, inflation would've made it worthless. Since it isn't, it at least can make for some good scrap. # Good for recycling but also decent sell value
   components:
   - type: Sprite
     sprite: Objects/Misc/coins.rsi
@@ -157,9 +157,9 @@
     size: Tiny
   - type: PhysicalComposition
     materialComposition:
-      Steel: 300
+      Steel: 400
   - type: StaticPrice
-    price: 75
+    price: 125
 
 - type: entity
   parent: TreasureCoinIron
@@ -169,10 +169,9 @@
     state: coin_silver
   - type: PhysicalComposition
     materialComposition:
-      Steel: 100 # coins are fake on the inside
-      Silver: 200
+      Silver: 400
   - type: StaticPrice
-    price: 135
+    price: 200
 
 - type: entity
   parent: TreasureCoinIron
@@ -182,10 +181,9 @@
     state: coin_gold
   - type: PhysicalComposition
     materialComposition:
-      Steel: 100
-      Gold: 200
+      Gold: 400
   - type: StaticPrice
-    price: 175
+    price: 250
 
 - type: entity
   parent: TreasureCoinIron
@@ -195,10 +193,10 @@
     state: coin_adamantine
   - type: PhysicalComposition
     materialComposition:
-      Steel: 400
-      Diamond: 5
+      Silver: 450
+      Diamond: 10
   - type: StaticPrice
-    price: 250
+    price: 500
 
 - type: entity
   parent: TreasureCoinIron
@@ -208,8 +206,8 @@
     state: coin_diamond
   - type: PhysicalComposition
     materialComposition:
-      Steel: 300
-      Diamond: 15
+      Steel: 380
+      Diamond: 20
   - type: StaticPrice
-    price: 500
+    price: 1000
 


### PR DESCRIPTION
## About the PR
Made several changes to the loot tables related to salvage finds

Equipment table changes:
- Common loot table now mostly contains mercenary or pirate themed clothing items
- Uncommon table mostly unchanged with it having some tools 
- Rare table now contains a few random melee weapons, filled double emergency air tanks and jetpacks and the crushers
- Legendary table has some mercenary armors, perma escape crates (semi placehorder for the time being but they fit) alongside adding Hyper and Antique power cells to this pool. 

Tresure table changes:
- Many items have been given improved descriptions to better indicate if its meant for selling and/or scraping
- Buffed the sell value and/or scrap return value for many within the tresure table (entirely seperate from the scrap table items)
- Added Gamba crates to the tresure pool so salvs can get killed in new and funnier ways (hopefully, otherwise just adds a bit of spice to what they can find on occasion)

Misc changes:
- Rename the Explores Gas Mask into the Armored Gas Mask and reclasify it as Cargo and Security Contraband 
- Rebalance/buff of the Luxury mining suit to make it into a proper command member suit for the QM, reclasify it as Command Contraband, remove the ability to purchace the suit 
- Aditional items given to the QMs roundstart locker, adding air tanks for the hardsuit (because it lacked those for some reason) and a very basic set of salvage related eqipment such as: A filled toolbelt, Magboots, Armoured Gas Mask, PKA, Grapling hook,
intended to be mainly used by the QM in the event the salvages are dead/missing in space and require a rescue

## Why / Balance
As they currently are, the list of equipment that salvages can find contains items that are almost entirely useless for them
Examples being:

Fulton blueprints within the legendary table when those are buildable roundstart on funky at a lathe 
Engineering goggles within the rare table when thats a roundstart salvage item
Jetpacks with a filled tank on the legendary table, while a jetpack with a empty tank is part of the rare table
Crush Axes and Glaives being on diffrent rarity tables despite being identical in stats

Just to name a few examples 

while i dont consider the loot tables to be "fixed" strictly speaking, they will at least include fewer items that salvagers will never have a reason to care about, while in the mean time i will begin working on a more substantial change on how salvages go about looting and supplying the station 
and the changes to item names and  descriptions are intended as a QOL and help never salvages better know what items are intended to be used for 


And as for the quarermaster equipment changes
as of right now the luxury mining suit is considered a joke due to just how bad it is copared to actaul salvage suits, and its not even classified as a command item despite effectively being the QMs signiture hardsuit 
while also removing the ability to purchase it so its something that stays unique for just the QM like other head suits 

the addition of basic salvage eqipment is intended to make QMs life a bit easier in the not-uncommon event salvagers need a resque as the QM is effectively the only person on station who could assit them, giving them some basic tools to do so seems resonable while some others are nice to have in general day-to-day work

## Technical details
These are all just simple .yml changes

## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl: ThatOneMoon
- add: Changes to the salvage loot table to add new intresting things for them to potentialy find, such as pirate and mercenary related equipment
- tweak: The QMs luxury hardsuit has been relabalnced to now be properly clasified as a command item,
has been buffed to share the same defense values as a regular mining hardsuit but with a smaller move speed penalty, 
and is no longer able to be purchased.
- tweak: The QMs Roundstart locker now includes a very basic set of salvage eqipment.
- tweak: The Descriptions of many salvage related items have been improved to better indicate its purpose. 
- tweak: The recycler and/or sell values of salvage tresure related items have been buffed 
