### PR TITLE
Fix/tweak item toggling for slime people and in pockets

### DIFF
--- a/Content.Shared/Item/SharedItemSystem.cs
+++ b/Content.Shared/Item/SharedItemSystem.cs
@@ -2,6 +2,7 @@ using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Interaction;
 using Content.Shared.Verbs;
 using Content.Shared.Examine;
+using Content.Shared.Inventory;
 using Content.Shared.Item.ItemToggle.Components;
 using Content.Shared.Storage;
 using Content.Shared.Storage.EntitySystems;
@@ -17,6 +18,7 @@ public abstract class SharedItemSystem : EntitySystem
 {
     [Dependency] private readonly SharedTransformSystem _transform = default!; // Goobstation
     [Dependency] private readonly SharedStorageSystem _storage = default!; // Goobstation
+    [Dependency] private readonly InventorySystem _inventory = default!;
     [Dependency] private readonly IPrototypeManager _prototype = default!;
     [Dependency] private   readonly SharedHandsSystem _handsSystem = default!;
     [Dependency] protected readonly SharedContainerSystem Container = default!;
@@ -249,12 +251,36 @@ public abstract class SharedItemSystem : EntitySystem
         }
 
         if (Container.TryGetContainingContainer((uid, null, null), out var container) &&
-            !_handsSystem.IsHolding(container.Owner, uid)) &&
-            TryComp(container.Owner,
-                out StorageComponent? storage)) // Goobstation - reinsert item in storage because size changed
+            !_handsSystem.IsHolding(container.Owner, uid))
         {
-            _transform.AttachToGridOrMap(uid);
-            _storage.Insert(container.Owner, uid, out _, null, storage, false);
+            // Check if the item is in a pocket.
+            var wasInPocket = false;
+            if (_inventory.TryGetContainerSlotEnumerator(container.Owner, out var enumerator, SlotFlags.POCKET))
+            {
+                while (enumerator.NextItem(out var slotItem, out var slot))
+                {
+                    if (slotItem == uid)
+                    {
+                        // We found it in a pocket.
+                        wasInPocket = true;
+
+                        if (!_inventory.CanEquip(container.Owner, uid, slot.Name, out var _, slot))
+                        {
+                            // It no longer fits, so try to hand it to whoever toggled it.
+                            _transform.AttachToGridOrMap(uid);
+                            _handsSystem.PickupOrDrop(args.User, uid, animate: true);
+                        }
+                        break;
+                    }
+                }
+            }
+
+            if (!wasInPocket && TryComp(container.Owner,
+                out StorageComponent? storage)) // Goobstation - reinsert item in storage because size changed
+            {
+                _transform.AttachToGridOrMap(uid);
+                _storage.Insert(container.Owner, uid, out _, null, storage, false);
+            }
         }
 
         Dirty(uid, item);

--- a/Content.Shared/Item/SharedItemSystem.cs
+++ b/Content.Shared/Item/SharedItemSystem.cs
@@ -249,6 +249,7 @@ public abstract class SharedItemSystem : EntitySystem
         }
 
         if (Container.TryGetContainingContainer((uid, null, null), out var container) &&
+            !_handsSystem.IsHolding(container.Owner, uid)) &&
             TryComp(container.Owner,
                 out StorageComponent? storage)) // Goobstation - reinsert item in storage because size changed
         {

--- a/Content.Shared/Item/SharedItemSystem.cs
+++ b/Content.Shared/Item/SharedItemSystem.cs
@@ -251,9 +251,9 @@ public abstract class SharedItemSystem : EntitySystem
         }
 
         if (Container.TryGetContainingContainer((uid, null, null), out var container) &&
-            !_handsSystem.IsHolding(container.Owner, uid))
+            !_handsSystem.IsHolding(container.Owner, uid)) // Funkystation - Don't move items in hands.
         {
-            // Check if the item is in a pocket.
+            // Funkystation - Check if the item is in a pocket.
             var wasInPocket = false;
             if (_inventory.TryGetContainerSlotEnumerator(container.Owner, out var enumerator, SlotFlags.POCKET))
             {
@@ -261,12 +261,12 @@ public abstract class SharedItemSystem : EntitySystem
                 {
                     if (slotItem == uid)
                     {
-                        // We found it in a pocket.
+                        // Funkystation - We found it in a pocket.
                         wasInPocket = true;
 
                         if (!_inventory.CanEquip(container.Owner, uid, slot.Name, out var _, slot))
                         {
-                            // It no longer fits, so try to hand it to whoever toggled it.
+                            // Funkystation - It no longer fits, so try to hand it to whoever toggled it.
                             _transform.AttachToGridOrMap(uid);
                             _handsSystem.PickupOrDrop(args.User, uid, animate: true);
                         }
@@ -281,7 +281,7 @@ public abstract class SharedItemSystem : EntitySystem
                 _transform.AttachToGridOrMap(uid);
                 if (!_storage.Insert(container.Owner, uid, out _, null, storage, false))
                 {
-                    // It didn't fit, so try to hand it to whoever toggled it.
+                    // Funkystation - It didn't fit, so try to hand it to whoever toggled it.
                     _handsSystem.PickupOrDrop(args.User, uid, animate: false);
                 }
             }

--- a/Content.Shared/Item/SharedItemSystem.cs
+++ b/Content.Shared/Item/SharedItemSystem.cs
@@ -279,7 +279,11 @@ public abstract class SharedItemSystem : EntitySystem
                 out StorageComponent? storage)) // Goobstation - reinsert item in storage because size changed
             {
                 _transform.AttachToGridOrMap(uid);
-                _storage.Insert(container.Owner, uid, out _, null, storage, false);
+                if (!_storage.Insert(container.Owner, uid, out _, null, storage, false))
+                {
+                    // It didn't fit, so try to hand it to whoever toggled it.
+                    _handsSystem.PickupOrDrop(args.User, uid, animate: false);
+                }
             }
         }
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This PR fixes several closely related issues regarding toggling items such as welding tools and lighters.

I apologize if it's not the neatest code. I haven't worked with C♯ much.

Since the code causing the issues was taken from Goob Station, I used Goob Station's current code as a reference, while hoping to avoid issues that version has as well: https://github.com/Goob-Station/Goob-Station/blob/de273de2ec63be4890b2a096cb344a580f1a75b5/Content.Shared/Item/SharedItemSystem.cs#L363-L388

## Why / Balance
Currently, toggling items has several unusual corner cases, due to the insertion behavior added in e5f8fdfb193c87260181ef2e8ec6b4d1df124be9, taken from Goob Station, namely these lines: https://github.com/funky-station/funky-station/blob/e5f8fdfb193c87260181ef2e8ec6b4d1df124be9/Content.Shared/Item/SharedItemSystem.cs#L251-L257

This leads to several inconsistent or inconvenient behaviors:

- A slime person toggling an item in their hand or pockets will have the item either inserted into their internal inventory, or dropped on the ground if it does not fit, due to slime people having a `StorageComponent`, as reported in the following issues/PRs:
  - #612
  - Goob-Station/Goob-Station#2455

- A non-slime person character toggling an item such as a welding tool in their pocket will be able to carry, for example, a lit welding tool in their pocket, despite it no longer fitting.

- If an item is toggled in an inventory where it no longer fits, such as a welding tool in a duffel bag, it will be dropped on the ground.

This PR changes the behavior to the following:

- If someone is holding the toggled item, it is kept where it is.
- If it's in a pocket and it fits, it's kept where it is.
- If it's in a pocket and no longer fits, it's either put in the toggler's hands, or dropped if that's not possible.
- If it's not in a pocket, and is in something with a storage, it's reinserted as before, or failing that, is put in the toggler's hands, or dropped if that's not possible.

Hopefully, this leads to more intuitive behavior.
  
## Technical details
The following test cases were used:

- A slime person toggling a flippo lighter or welding tool in their hands will have the item remain there when turned on or off.
- A slime person toggling a flippo lighter in their pocket will keep the lighter in their pocket.
- A slime person toggling a welding tool in their pocket on will have the welding tool placed in their hand, or on the ground if their hands are full.
- A slime person toggling a lighter in their internal inventory will have the lighter stay in their internal inventory if possible, otherwise put in their hands.
- A human character will keep a flippo lighter and welding tool in their hands when toggled.
- A human lighter will keep a flippo lighter in their pocket when toggled, but a lit welding tool will be moved to their hands.
- A welding tool toggled by a human player in a backpack will stay inside it if it fits, otherwise be placed in one of their hands, or dropped.
- An engineering cyborg will properly keep their industrial welding tool in its slot if toggled. 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
None.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Slime people no longer have items such as lighters inserted into their internal inventories or dropped when toggled.
- fix: Toggling items such as welding tools in pockets, if it no longer fits, will now either hand you the item, or drop it.
- tweak: Toggled items which no longer fit in their former storage container will be put in your hand if possible, rather than just dropped.