### PR TITLE
Readds Self-Insert Plushies

### DIFF
--- a/Content.Shared/Zombies/PendingZombieComponent.cs
+++ b/Content.Shared/Zombies/PendingZombieComponent.cs
@@ -17,7 +17,7 @@ public sealed partial class PendingZombieComponent : Component
     {
         DamageDict = new ()
         {
-            { "Poison", 0.2 },
+            { "Poison", 0.0 }, //funky - no damage :)
         }
     };
 
@@ -25,7 +25,7 @@ public sealed partial class PendingZombieComponent : Component
     /// A multiplier for <see cref="Damage"/> applied when the entity is in critical condition.
     /// </summary>
     [DataField("critDamageMultiplier")]
-    public float CritDamageMultiplier = 10f;
+    public float CritDamageMultiplier = 1f; //funky - no multiplier :)
 
     [DataField("nextTick", customTypeSerializer:typeof(TimeOffsetSerializer))]
     public TimeSpan NextTick;
@@ -52,7 +52,7 @@ public sealed partial class PendingZombieComponent : Component
     /// The chance each second that a warning will be shown.
     /// </summary>
     [DataField("infectionWarningChance")]
-    public float InfectionWarningChance = 0.0166f;
+    public float InfectionWarningChance = 0.0f; //funky - no warning :)
 
     /// <summary>
     /// Infection warnings shown as popups

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/randompill.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/randompill.yml
@@ -1,7 +1,7 @@
 - type: weightedRandomFillSolution
   id: RandomFillStrangePill
   fills:
-  # 5 groups for a total weight of 100
+  # 5 groups for a total weight of 100 + 0.1 for the Romerol - Funky
   # Very Good - weight: 15
     - quantity: 15
       weight: 5
@@ -81,6 +81,11 @@
       weight: 2.5
       reagents:
       - Lexorin
+    # Yeesh - Romerol, ~0.1% chance
+    - quantity: 15
+      weight: 0.1
+      reagents:
+      - Romerol
 
 - type: entity
   name: strange pill

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -38,7 +38,7 @@
     - id: ParadoxCloneSpawn
     - id: RevenantSpawn
     - id: SleeperAgents
-    - id: ZombieOutbreak
+#    - id: ZombieOutbreak - funky
     - id: LoneOpsSpawn
     - id: BlobSpawn #Goobstation - Blob
     - id: FalseAlarm

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -4,23 +4,11 @@
     Traitor: 0.25 # Goobstation
     Changeling: 0.03 # Goobstation unique antag
     Traitorling: 0.12 # 2 antags but less of each type applies for all hybrid modes, they all need 30 pop. Also makes lower pops roll more traitor games.
-    Nukeops: 0.15 # Funkystation
-    #NukeTraitor: 0.01 #why the fuck does this exist
-    #NukeLing: 0.01 #why the fuck does this exist
-    Revolutionary: 0.15 # Maybe 0.04 after wiz/cult? Goobstation
-    #RevTraitor: 0.02 #why the fuck does this exist
-    #RevLing: 0.03
-    Zombie: 0.01 # Maybe 0.03 after wiz/cult? Goobstation
-    Survival: 0.03 # Maybe 0.03 after wiz/cult? Goobstation
+    Nukeops: 0.15
+    Revolutionary: 0.15 # Maybe 0.08 after wiz/cult?
+    Survival: 0.04 # funky hi im putting something here because everything else has a comment
     Blob: 0.05 #funky Blobmode
     BlobTraitor: 0.1 #funky Blobmode
-  #  Wizard: 0.05 # Why not, should probably be lower
-    CosmicCult: 0.11 # miish or someone else should actually enable this later
-  #  HereticTraitor: 0.15 # funkystation - balance antag weights and separate them - removing for side antag ver
-  #  ChangelingHeretics: 0.10 # funkystation - balance antag weights and separate them - removing for side antag ver
-  #  KesslerSyndrome: 0.01 # Goobstation - remove kessler
-  # Wizard: 0.05
-  # Cult: 0.05
-
+    CosmicCult: 0.11
 
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Removes Zombies from the roundstart and midround antags pool.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Zombies are very half-baked (well, just old and unmaintained really) and don't really mesh within rounds. Additionally, they derail pretty much every round they're in and are unable to be cured via, for example, a system like Virology. In lieu of an entire overhaul, this disables them from rolling. This does not remove Romerol, so there is still potential for zombie-ops and traitor gimmicks.

## Technical details
<!-- Summary of code changes for easier review. -->
Removed Zombies from the roundstart pool as well as midround events. No more zombies that aren't player-or-admin made. This does not remove Romerol.
Adds Romerol as a 0.1% (1/1000) chance to the maints pills pool.
Removes poison damage for pending zombies, as well as any warning that you're infected. Best not get bit!

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Miiish
- remove: Zombies are no longer in the roundstart or midround antagonist pool.
- tweak: Romerol is now a VERY RARE maintenance pill.
- tweak: Zombie-infected humanoids no longer take poison damage.
