### PR TITLE
Multiplies cold temperature damage by 5

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/animals.yml
@@ -2256,7 +2256,7 @@
     specificHeat: 46
     coldDamage:
       types:
-        Cold : 0.05 #per second, scales with temperature & other constants
+        Cold : 0.25 #per second, scales with temperature & other constants
     heatDamage:
       types:
         Heat : 0.2 #per second, scales with temperature & other constants

--- a/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/familiars.yml
@@ -215,7 +215,7 @@
     specificHeat: 42
     coldDamage:
       types:
-        Cold : 0.1 #per second, scales with temperature & other constants
+        Cold : 0.5 #per second, scales with temperature & other constants
     heatDamage:
       types:
         Heat : 1.5 #per second, scales with temperature & other constants

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -293,7 +293,7 @@
     specificHeat: 42
     coldDamage:
       types:
-        Cold: 0.1 #per second, scales with temperature & other constants
+        Cold: 0.5 #per second, scales with temperature & other constants
     heatDamage:
       types:
         Heat: 1.5 #per second, scales with temperature & other constants

--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -60,7 +60,7 @@
     specificHeat: 46
     coldDamage:
       types:
-        Cold : 0.05 #per second, scales with temperature & other constants
+        Cold : 0.25 #per second, scales with temperature & other constants
     heatDamage:
       types:
         Heat : 3 #per second, scales with temperature & other constants

--- a/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
@@ -58,7 +58,7 @@
     specificHeat: 42
     coldDamage:
       types:
-        Cold : 0.1 #per second, scales with temperature & other constants
+        Cold : 0.5 #per second, scales with temperature & other constants
     heatDamage:
       types:
         Heat : 1.5 #per second, scales with temperature & other constants

--- a/Resources/Prototypes/Entities/Mobs/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/base.yml
@@ -148,7 +148,7 @@
     currentTemperature: 310.15
     coldDamage: #per second, scales with temperature & other constants
       types:
-        Cold : 0.1
+        Cold : 0.5
     specificHeat: 42
     heatDamage: #per second, scales with temperature & other constants
       types:

--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/felinid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/felinid.yml
@@ -33,7 +33,7 @@
     specificHeat: 46
     coldDamage:
       types:
-        Cold: 0.1 #per second, scales with temperature & other constants
+        Cold: 0.5 #per second, scales with temperature & other constants
   # Funkystation - same as lizard for now, could probably work on a rebalance
   - type: TemperatureSpeed
     thresholds:

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
@@ -69,7 +69,7 @@
       specificHeat: 42
       coldDamage:
         types:
-          Cold: 0.1 #per second, scales with temperature & other constants
+          Cold: 0.5 #per second, scales with temperature & other constants
       heatDamage:
         types:
           Heat: 2 # DeltaV - was 3


### PR DESCRIPTION
## About the PR
I've increased the cold damage from temperature loss across the board by about 5x

## Why / Balance
While spacing is a real threat currently, cold damage is pathetic outside of the actual slowdown it gives you, especially when compared to fire damage. This is the beginning part to a Void heretic buff I will be making a PR for after, however this PR doesn't actually affect void because Void sucks ass.

Ultimately, this PR makes the Emergency EVA less useful in a full spacing, as it protects from the pressure still, but doesn't protect from the cold of space as well as a proper hardsuit or EVA suit, as it should be. Previously, you could wear an Emergency EVA and never really notice any ill effects when in space, or a completely spaced area.

## Technical details
I edited the coldDamage value under Temperature wherever I could find it.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl: amethystowo
- tweak: Cold damage is now increased by about 5x. Make sure to bundle up!
