### PR TITLE
Buff throwing away items + slimes become ThrowInsertContainer because funny

### DIFF
--- a/Content.Server/Containers/ThrowInsertContainerComponent.cs
+++ b/Content.Server/Containers/ThrowInsertContainerComponent.cs
@@ -16,7 +16,7 @@ public sealed partial class ThrowInsertContainerComponent : Component
     /// Throw chance of hitting into the container
     /// </summary>
     [DataField]
-    public float Probability = 0.75f;
+    public float Probability = 0.5f; // funkystation: 0.75f;
 
     /// <summary>
     /// Sound played when an object is throw into the container.

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -25,6 +25,12 @@
     containers:
       storagebase: !type:Container
         ents: []
+  # Funkystation - body catches items thrown in
+  - type: ThrowInsertContainer
+    probability: 0.3
+    containerId: storagebase
+    insertSound:
+      path: /Audio/Voice/Slime/slime_squish.ogg
   - type: UserInterface
     interfaces:
       enum.VoiceMaskUIKey.Key:

--- a/Resources/Prototypes/Entities/Mobs/Species/slime.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/slime.yml
@@ -30,7 +30,7 @@
     probability: 0.3
     containerId: storagebase
     insertSound:
-      path: /Audio/Voice/Slime/slime_squish.ogg
+      path: /Audio/Voice/Slime/slime_squish_1.ogg
   - type: UserInterface
     interfaces:
       enum.VoiceMaskUIKey.Key:


### PR DESCRIPTION
## About the PR
This buffs the effective rate at which trash lands in the trash bin if you throw an item at it. Players are rewarded for an "accurate" throw that would have "landed" in the vicinity of the trash can with an extra roll to get in.

Comes with free goofy crap because having something thrown at you as a slimeperson only to have it embed in your own personal storage is funny.

## Why / Balance
Original hit rate for disposal units was 25% due to some backward code. This was frustrating. MALD PR DETECTED

Also, funny.

## Technical details
A "good throw" gets defined as a throw which would "land" within 0.2 seconds of colliding with the trash can. If it's a "good throw", the probability to hit is rolled _twice_ and passes if either roll succeeds.

## Media
![image](https://github.com/user-attachments/assets/c314cb28-2fa9-4a5e-9e07-a09df585a98d)
![2025-06-29_19-40-26](https://github.com/user-attachments/assets/99dbd808-8299-4db6-a5e8-743ea177bbf2)


## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Disposal units now more receptive of thrown items. Aim well for a 75% chance to land your throw!
- add: Throwing an item at a slimeperson now has a low chance of adding it to their body storage.