### PR TITLE
Adds "HOS" To "Sheriff" Word Replacements For the Cowboy Accent

### DIFF
--- a/Resources/Locale/en-US/accent/cowboy.ftl
+++ b/Resources/Locale/en-US/accent/cowboy.ftl
@@ -228,6 +228,9 @@ accent-cowboy-replacement-101 = sheriff
 accent-cowboy-words-102 = head of law
 accent-cowboy-replacement-102 = sheriff
 
+accent-cowboy-words-103 = head of sec
+accent-cowboy-replacement-103 = sheriff
+
 <#-- end funky  -->
 
 accent-cowboy-words-74 = sec

--- a/Resources/Locale/en-US/accent/cowboy.ftl
+++ b/Resources/Locale/en-US/accent/cowboy.ftl
@@ -300,5 +300,5 @@ accent-cowboy-replacement-99 = hollering
 accent-cowboy-words-100 = hos
 accent-cowboy-replacement-100 = sheriff
 
-accent-cowboy-words-101 = head of security
+accent-cowboy-words-101 = head of law
 accent-cowboy-replacement-101 = sheriff

--- a/Resources/Locale/en-US/accent/cowboy.ftl
+++ b/Resources/Locale/en-US/accent/cowboy.ftl
@@ -217,6 +217,19 @@ accent-cowboy-replacement-72 = hollered
 accent-cowboy-words-73 = screaming
 accent-cowboy-replacement-73 = hollering
 
+<#-- funky -->
+
+accent-cowboy-words-100 = hos
+accent-cowboy-replacement-100 = sheriff
+
+accent-cowboy-words-101 = head of security
+accent-cowboy-replacement-101 = sheriff
+
+accent-cowboy-words-102 = head of law
+accent-cowboy-replacement-102 = sheriff
+
+<#-- end funky  -->
+
 accent-cowboy-words-74 = sec
 accent-cowboy-replacement-74 = law
 
@@ -294,14 +307,3 @@ accent-cowboy-replacement-98 = hollered
 
 accent-cowboy-words-99 = yelling
 accent-cowboy-replacement-99 = hollering
-
-<#-- funky -->
-
-accent-cowboy-words-100 = hos
-accent-cowboy-replacement-100 = sheriff
-
-accent-cowboy-words-101 = head of security
-accent-cowboy-replacement-101 = sheriff
-
-accent-cowboy-words-102 = head of law
-accent-cowboy-replacement-102 = sheriff

--- a/Resources/Locale/en-US/accent/cowboy.ftl
+++ b/Resources/Locale/en-US/accent/cowboy.ftl
@@ -224,7 +224,7 @@ accent-cowboy-words-75 = secoff
 accent-cowboy-replacement-75 = deputy
 
 accent-cowboy-words-76 = security
-accent-cowboy-replacement-76 = law 
+accent-cowboy-replacement-76 = law
 
 accent-cowboy-words-77 = shitsec
 accent-cowboy-replacement-77 = crooked law
@@ -294,3 +294,11 @@ accent-cowboy-replacement-98 = hollered
 
 accent-cowboy-words-99 = yelling
 accent-cowboy-replacement-99 = hollering
+
+<#-- funky -->
+
+accent-cowboy-words-100 = hos
+accent-cowboy-replacement-100 = sheriff
+
+accent-cowboy-words-101 = head of security
+accent-cowboy-replacement-101 = sheriff

--- a/Resources/Locale/en-US/accent/cowboy.ftl
+++ b/Resources/Locale/en-US/accent/cowboy.ftl
@@ -303,5 +303,5 @@ accent-cowboy-replacement-100 = sheriff
 accent-cowboy-words-101 = head of security
 accent-cowboy-replacement-101 = sheriff
 
-accent-cowboy-words-101 = head of law
+accent-cowboy-words-102 = head of law
 accent-cowboy-replacement-102 = sheriff

--- a/Resources/Locale/en-US/accent/cowboy.ftl
+++ b/Resources/Locale/en-US/accent/cowboy.ftl
@@ -62,7 +62,6 @@ accent-cowboy-words-21 = crazy
 accent-cowboy-replacement-21 = cracked
 
 accent-cowboy-words-22 = cyborg
-accent-cowboy-words-22-2 = borg
 accent-cowboy-replacement-22 = tin man
 
 accent-cowboy-words-23 = dad

--- a/Resources/Locale/en-US/accent/cowboy.ftl
+++ b/Resources/Locale/en-US/accent/cowboy.ftl
@@ -62,6 +62,7 @@ accent-cowboy-words-21 = crazy
 accent-cowboy-replacement-21 = cracked
 
 accent-cowboy-words-22 = cyborg
+accent-cowboy-words-22-2 = borg
 accent-cowboy-replacement-22 = tin man
 
 accent-cowboy-words-23 = dad
@@ -88,225 +89,203 @@ accent-cowboy-replacement-29 = partner
 accent-cowboy-words-30 = goodbye
 accent-cowboy-replacement-30 = so long
 
-accent-cowboy-words-31 = greytide
-accent-cowboy-replacement-31 = varmints
+accent-cowboy-words-31 = greytider
+accent-cowboy-replacement-31 = varmint
 
-accent-cowboy-words-32 = greytider
-accent-cowboy-replacement-32 = varmint
+accent-cowboy-words-32 = greytide
+accent-cowboy-words-32-2 = greytiders
+accent-cowboy-replacement-32 = varmints
 
-accent-cowboy-words-33 = greytiders
-accent-cowboy-replacement-33 = varmints
+accent-cowboy-words-33 = group
+accent-cowboy-replacement-33 = possee
 
-accent-cowboy-words-34 = group
-accent-cowboy-replacement-34 = possee
+accent-cowboy-words-34 = guess
+accent-cowboy-replacement-34 = reckon
 
-accent-cowboy-words-35 = guess
-accent-cowboy-replacement-35 = reckon
+accent-cowboy-words-35 = gun
+accent-cowboy-replacement-35 = big iron
 
-accent-cowboy-words-36 = gun
-accent-cowboy-replacement-36 = big iron
+accent-cowboy-words-36 = handcuff
+accent-cowboy-replacement-36 = hog tie
 
-accent-cowboy-words-37 = handcuff
-accent-cowboy-replacement-37 = hog tie
+accent-cowboy-words-37 = handcuffed
+accent-cowboy-replacement-37 = hog tied
 
-accent-cowboy-words-38 = handcuffed
-accent-cowboy-replacement-38 = hog tied
+accent-cowboy-words-38 = hell
+accent-cowboy-replacement-38 = tarnation
 
-accent-cowboy-words-39 = hell
-accent-cowboy-replacement-39 = tarnation
+accent-cowboy-words-39 = hello
+accent-cowboy-words-39-2 = hey
+accent-cowboy-words-39-3 = hi
+accent-cowboy-replacement-39 = howdy
 
-accent-cowboy-words-40 = hello
-accent-cowboy-replacement-40 = howdy
+accent-cowboy-words-40 = hungry
+accent-cowboy-replacement-40 = peckish
 
-accent-cowboy-words-41 = hey
-accent-cowboy-replacement-41 = howdy
+accent-cowboy-words-41 = idiot
+accent-cowboy-replacement-41 = dunderhead
 
-accent-cowboy-words-42 = hi
-accent-cowboy-replacement-42 = howdy
+accent-cowboy-words-42 = intending
+accent-cowboy-replacement-42 = fixing
 
-accent-cowboy-words-43 = hungry
-accent-cowboy-replacement-43 = peckish
+accent-cowboy-words-43 = jail
+accent-cowboy-replacement-43 = pokey
 
-accent-cowboy-words-44 = idiot
-accent-cowboy-replacement-44 = dunderhead
+accent-cowboy-words-44 = liqour
+accent-cowboy-replacement-44 = firewater
 
-accent-cowboy-words-45 = intending
-accent-cowboy-replacement-45 = fixing
+accent-cowboy-words-45 = lot
+accent-cowboy-replacement-45 = heap
 
-accent-cowboy-words-46 = jail
-accent-cowboy-replacement-46 = pokey
+accent-cowboy-words-46 = lots
+accent-cowboy-replacement-46 = heaps
 
-accent-cowboy-words-47 = liqour
-accent-cowboy-replacement-47 = firewater
+accent-cowboy-words-47 = mouth
+accent-cowboy-replacement-47 = bazoo
 
-accent-cowboy-words-48 = lot
-accent-cowboy-replacement-48 = heap
+accent-cowboy-words-48 = nervous
+accent-cowboy-replacement-48 = rattled
 
-accent-cowboy-words-49 = lots
-accent-cowboy-replacement-49 = heaps
+accent-cowboy-words-49 = ninja
+accent-cowboy-replacement-49 = bushwhacker
 
-accent-cowboy-words-50 = mouth
-accent-cowboy-replacement-50 = bazoo
+accent-cowboy-words-50 = ninjas
+accent-cowboy-replacement-50 = bushwhackers
 
-accent-cowboy-words-51 = nervous
-accent-cowboy-replacement-51 = rattled
+accent-cowboy-words-51 = noise
+accent-cowboy-replacement-51 = ruckus
 
-accent-cowboy-words-52 = ninja
-accent-cowboy-replacement-52 = bushwhacker
+accent-cowboy-words-52 = operator
+accent-cowboy-words-52-2 = nukie
+accent-cowboy-replacement-52 = outlaw
 
-accent-cowboy-words-53 = ninjas
-accent-cowboy-replacement-53 = bushwhackers
+accent-cowboy-words-53 = nukies
+accent-cowboy-words-53-2 = operators
+accent-cowboy-words-53-3 = ops
+accent-cowboy-replacement-53 = outlaws
 
-accent-cowboy-words-54 = noise
-accent-cowboy-replacement-54 = ruckus
+accent-cowboy-words-54 = pal
+accent-cowboy-replacement-54 = partner
 
-accent-cowboy-words-55 = nukies
-accent-cowboy-replacement-55 = outlaws
+accent-cowboy-words-55 = party
+accent-cowboy-replacement-55 = shindig
 
-accent-cowboy-words-56 = operator
-accent-cowboy-replacement-56 = outlaw
+accent-cowboy-words-56 = passenger
+accent-cowboy-replacement-56 = greenhorn
 
-accent-cowboy-words-57 = operators
-accent-cowboy-replacement-57 = outlaws
+accent-cowboy-words-57 = passengers
+accent-cowboy-replacement-57 = greenhorns
 
-accent-cowboy-words-58 = ops
-accent-cowboy-replacement-58 = outlaws
+accent-cowboy-words-58 = planning
+accent-cowboy-replacement-58 = fixing
 
-accent-cowboy-words-59 = pal
-accent-cowboy-replacement-59 = partner
+accent-cowboy-words-59 = please
+accent-cowboy-replacement-59 = pray
 
-accent-cowboy-words-60 = party
-accent-cowboy-replacement-60 = shindig
+accent-cowboy-words-60 = punch
+accent-cowboy-replacement-60 = lick
 
-accent-cowboy-words-61 = passenger
-accent-cowboy-replacement-61 = greenhorn
+accent-cowboy-words-61 = punched
+accent-cowboy-replacement-61 = slogged
 
-accent-cowboy-words-62 = passengers
-accent-cowboy-replacement-62 = greenhorns
+accent-cowboy-words-62 = ran
+accent-cowboy-replacement-62 = skedaddled
 
-accent-cowboy-words-63 = planning
-accent-cowboy-replacement-63 = fixing
+accent-cowboy-words-63 = robbery
+accent-cowboy-replacement-63 = stick up
 
-accent-cowboy-words-64 = please
-accent-cowboy-replacement-64 = pray
+accent-cowboy-words-64 = run
+accent-cowboy-replacement-64 = skedaddle
 
-accent-cowboy-words-65 = punch
-accent-cowboy-replacement-65 = lick
+accent-cowboy-words-65 = running
+accent-cowboy-replacement-65 = skedaddling
 
-accent-cowboy-words-66 = punched
-accent-cowboy-replacement-66 = slogged
+accent-cowboy-words-66 = scream
+accent-cowboy-replacement-66 = holler
 
-accent-cowboy-words-67 = ran
-accent-cowboy-replacement-67 = skedaddled
+accent-cowboy-words-67 = screamed
+accent-cowboy-replacement-67 = hollered
 
-accent-cowboy-words-68 = robbery
-accent-cowboy-replacement-68 = stick up
+accent-cowboy-words-68 = screaming
+accent-cowboy-replacement-68 = hollering
 
-accent-cowboy-words-69 = run
-accent-cowboy-replacement-69 = skedaddle
+accent-cowboy-words-69 = hos
+accent-cowboy-words-69-2 = head of security
+accent-cowboy-words-69-3 = head of law
+accent-cowboy-words-69-4 = head of sec
+accent-cowboy-replacement-69 = sheriff
 
-accent-cowboy-words-70 = running
-accent-cowboy-replacement-70 = skedaddling
+accent-cowboy-words-70 = secoff
+accent-cowboy-words-70-2 = security officer
+accent-cowboy-words-70-3 = sec officer
+accent-cowboy-words-70-4 = law officer
+accent-cowboy-replacement-70 = deputy
 
-accent-cowboy-words-71 = scream
-accent-cowboy-replacement-71 = holler
+accent-cowboy-words-71 = sec
+accent-cowboy-words-71-2 = security
+accent-cowboy-replacement-71 = law
 
-accent-cowboy-words-72 = screamed
-accent-cowboy-replacement-72 = hollered
+accent-cowboy-words-72 = shitsec
+accent-cowboy-replacement-72 = crooked law
 
-accent-cowboy-words-73 = screaming
-accent-cowboy-replacement-73 = hollering
+accent-cowboy-words-73 = shoe
+accent-cowboy-replacement-73 = boot
 
-<#-- funky -->
+accent-cowboy-words-74 = shoes
+accent-cowboy-replacement-74 = boots
 
-accent-cowboy-words-100 = hos
-accent-cowboy-replacement-100 = sheriff
+accent-cowboy-words-75 = steal
+accent-cowboy-replacement-75 = rustle
 
-accent-cowboy-words-101 = head of security
-accent-cowboy-replacement-101 = sheriff
+accent-cowboy-words-76 = stole
+accent-cowboy-words-76-2 = stolen
+accent-cowboy-replacement-76 = rustled
 
-accent-cowboy-words-102 = head of law
-accent-cowboy-replacement-102 = sheriff
+accent-cowboy-words-77 = story
+accent-cowboy-replacement-77 = yarn
 
-accent-cowboy-words-103 = head of sec
-accent-cowboy-replacement-103 = sheriff
+accent-cowboy-words-78 = thank you
+accent-cowboy-words-78-2 = thanks
+accent-cowboy-replacement-78 = much obliged
 
-<#-- end funky  -->
+accent-cowboy-words-79 = thief
+accent-cowboy-replacement-79 = rustler
 
-accent-cowboy-words-74 = sec
-accent-cowboy-replacement-74 = law
+accent-cowboy-words-80 = thieves
+accent-cowboy-replacement-80 = rustlers
 
-accent-cowboy-words-75 = secoff
-accent-cowboy-replacement-75 = deputy
+accent-cowboy-words-81 = think
+accent-cowboy-replacement-81 = reckon
 
-accent-cowboy-words-76 = security
-accent-cowboy-replacement-76 = law
+accent-cowboy-words-82 = tired
+accent-cowboy-replacement-82 = dragged out
 
-accent-cowboy-words-77 = shitsec
-accent-cowboy-replacement-77 = crooked law
+accent-cowboy-words-83 = toilet
+accent-cowboy-replacement-83 = outhouse
 
-accent-cowboy-words-78 = shoe
-accent-cowboy-replacement-78 = boot
+accent-cowboy-words-84 = totally
+accent-cowboy-replacement-84 = plumb
 
-accent-cowboy-words-79 = shoes
-accent-cowboy-replacement-79 = boots
+accent-cowboy-words-85 = traitor
+accent-cowboy-replacement-85 = outlaw
 
-accent-cowboy-words-80 = steal
-accent-cowboy-replacement-80 = rustle
+accent-cowboy-words-86 = traitors
+accent-cowboy-replacement-86 = outlaws
 
-accent-cowboy-words-81 = stole
-accent-cowboy-replacement-81 = rustled
+accent-cowboy-words-87 = very
+accent-cowboy-replacement-87 = mighty
 
-accent-cowboy-words-82 = stolen
-accent-cowboy-replacement-82 = rustled
+accent-cowboy-words-88 = worried
+accent-cowboy-replacement-89 = rattled
 
-accent-cowboy-words-83 = story
-accent-cowboy-replacement-83 = yarn
+accent-cowboy-words-90 = wow
+accent-cowboy-replacement-90 = by gum
 
-accent-cowboy-words-84 = thank you
-accent-cowboy-replacement-84 = much obliged
+accent-cowboy-words-91 = yell
+accent-cowboy-replacement-91 = holler
 
-accent-cowboy-words-85 = thanks
-accent-cowboy-replacement-85 = much obliged
+accent-cowboy-words-92 = yelled
+accent-cowboy-replacement-92 = hollered
 
-accent-cowboy-words-86 = thief
-accent-cowboy-replacement-86 = rustler
-
-accent-cowboy-words-87 = thieves
-accent-cowboy-replacement-87 = rustlers
-
-accent-cowboy-words-88 = think
-accent-cowboy-replacement-88 = reckon
-
-accent-cowboy-words-89 = tired
-accent-cowboy-replacement-89 = dragged out
-
-accent-cowboy-words-90 = toilet
-accent-cowboy-replacement-90 = outhouse
-
-accent-cowboy-words-91 = totally
-accent-cowboy-replacement-91 = plumb
-
-accent-cowboy-words-92 = traitor
-accent-cowboy-replacement-92 = outlaw
-
-accent-cowboy-words-93 = traitors
-accent-cowboy-replacement-93 = outlaws
-
-accent-cowboy-words-94 = very
-accent-cowboy-replacement-94 = mighty
-
-accent-cowboy-words-95 = worried
-accent-cowboy-replacement-95 = rattled
-
-accent-cowboy-words-96 = wow
-accent-cowboy-replacement-96 = by gum
-
-accent-cowboy-words-97 = yell
-accent-cowboy-replacement-97 = holler
-
-accent-cowboy-words-98 = yelled
-accent-cowboy-replacement-98 = hollered
-
-accent-cowboy-words-99 = yelling
-accent-cowboy-replacement-99 = hollering
+accent-cowboy-words-93 = yelling
+accent-cowboy-replacement-93 = hollering

--- a/Resources/Locale/en-US/accent/cowboy.ftl
+++ b/Resources/Locale/en-US/accent/cowboy.ftl
@@ -300,5 +300,8 @@ accent-cowboy-replacement-99 = hollering
 accent-cowboy-words-100 = hos
 accent-cowboy-replacement-100 = sheriff
 
-accent-cowboy-words-101 = head of law
+accent-cowboy-words-101 = head of security
 accent-cowboy-replacement-101 = sheriff
+
+accent-cowboy-words-101 = head of law
+accent-cowboy-replacement-102 = sheriff

--- a/Resources/Prototypes/Accents/word_replacements.yml
+++ b/Resources/Prototypes/Accents/word_replacements.yml
@@ -366,6 +366,9 @@
     accent-cowboy-words-97: accent-cowboy-replacement-97
     accent-cowboy-words-98: accent-cowboy-replacement-98
     accent-cowboy-words-99: accent-cowboy-replacement-99
+    # funkystation
+    accent-cowboy-words-100: accent-cowboy-replacement-100
+    accent-cowboy-words-101: accent-cowboy-replacement-101
 
 - type: accent
   id: southern

--- a/Resources/Prototypes/Accents/word_replacements.yml
+++ b/Resources/Prototypes/Accents/word_replacements.yml
@@ -369,6 +369,7 @@
     # funkystation
     accent-cowboy-words-100: accent-cowboy-replacement-100
     accent-cowboy-words-101: accent-cowboy-replacement-101
+    accent-cowboy-words-102: accent-cowboy-replacement-102
 
 - type: accent
   id: southern

--- a/Resources/Prototypes/Accents/word_replacements.yml
+++ b/Resources/Prototypes/Accents/word_replacements.yml
@@ -289,6 +289,7 @@
     accent-cowboy-words-20: accent-cowboy-replacement-20
     accent-cowboy-words-21: accent-cowboy-replacement-21
     accent-cowboy-words-22: accent-cowboy-replacement-22
+    accent-cowboy-words-22-2: accent-cowboy-replacement-22
     accent-cowboy-words-23: accent-cowboy-replacement-23
     accent-cowboy-words-24: accent-cowboy-replacement-24
     accent-cowboy-words-25: accent-cowboy-replacement-25
@@ -299,6 +300,7 @@
     accent-cowboy-words-30: accent-cowboy-replacement-30
     accent-cowboy-words-31: accent-cowboy-replacement-31
     accent-cowboy-words-32: accent-cowboy-replacement-32
+    accent-cowboy-words-32-2: accent-cowboy-replacement-32
     accent-cowboy-words-33: accent-cowboy-replacement-33
     accent-cowboy-words-34: accent-cowboy-replacement-34
     accent-cowboy-words-35: accent-cowboy-replacement-35
@@ -306,6 +308,8 @@
     accent-cowboy-words-37: accent-cowboy-replacement-37
     accent-cowboy-words-38: accent-cowboy-replacement-38
     accent-cowboy-words-39: accent-cowboy-replacement-39
+    accent-cowboy-words-39-2: accent-cowboy-replacement-39
+    accent-cowboy-words-39-3: accent-cowboy-replacement-39
     accent-cowboy-words-40: accent-cowboy-replacement-40
     accent-cowboy-words-41: accent-cowboy-replacement-41
     accent-cowboy-words-42: accent-cowboy-replacement-42
@@ -319,7 +323,10 @@
     accent-cowboy-words-50: accent-cowboy-replacement-50
     accent-cowboy-words-51: accent-cowboy-replacement-51
     accent-cowboy-words-52: accent-cowboy-replacement-52
+    accent-cowboy-words-52-2: accent-cowboy-replacement-52
     accent-cowboy-words-53: accent-cowboy-replacement-53
+    accent-cowboy-words-53-2: accent-cowboy-replacement-53
+    accent-cowboy-words-53-3: accent-cowboy-replacement-53
     accent-cowboy-words-54: accent-cowboy-replacement-54
     accent-cowboy-words-55: accent-cowboy-replacement-55
     accent-cowboy-words-56: accent-cowboy-replacement-56
@@ -336,21 +343,24 @@
     accent-cowboy-words-67: accent-cowboy-replacement-67
     accent-cowboy-words-68: accent-cowboy-replacement-68
     accent-cowboy-words-69: accent-cowboy-replacement-69
+    accent-cowboy-words-69-2: accent-cowboy-replacement-69
+    accent-cowboy-words-69-3: accent-cowboy-replacement-69
+    accent-cowboy-words-69-4: accent-cowboy-replacement-69
     accent-cowboy-words-70: accent-cowboy-replacement-70
+    accent-cowboy-words-70-2: accent-cowboy-replacement-70
+    accent-cowboy-words-70-3: accent-cowboy-replacement-70
+    accent-cowboy-words-70-4: accent-cowboy-replacement-70
     accent-cowboy-words-71: accent-cowboy-replacement-71
+    accent-cowboy-words-71-2: accent-cowboy-replacement-71
     accent-cowboy-words-72: accent-cowboy-replacement-72
     accent-cowboy-words-73: accent-cowboy-replacement-73
-    # funkystation
-    accent-cowboy-words-100: accent-cowboy-replacement-100
-    accent-cowboy-words-101: accent-cowboy-replacement-101
-    accent-cowboy-words-102: accent-cowboy-replacement-102
-    accent-cowboy-words-103: accent-cowboy-replacement-103
-    # end funkystation
     accent-cowboy-words-74: accent-cowboy-replacement-74
     accent-cowboy-words-75: accent-cowboy-replacement-75
     accent-cowboy-words-76: accent-cowboy-replacement-76
+    accent-cowboy-words-76-2: accent-cowboy-replacement-76
     accent-cowboy-words-77: accent-cowboy-replacement-77
     accent-cowboy-words-78: accent-cowboy-replacement-78
+    accent-cowboy-words-78-2: accent-cowboy-replacement-78
     accent-cowboy-words-79: accent-cowboy-replacement-79
     accent-cowboy-words-80: accent-cowboy-replacement-80
     accent-cowboy-words-81: accent-cowboy-replacement-81
@@ -366,12 +376,6 @@
     accent-cowboy-words-91: accent-cowboy-replacement-91
     accent-cowboy-words-92: accent-cowboy-replacement-92
     accent-cowboy-words-93: accent-cowboy-replacement-93
-    accent-cowboy-words-94: accent-cowboy-replacement-94
-    accent-cowboy-words-95: accent-cowboy-replacement-95
-    accent-cowboy-words-96: accent-cowboy-replacement-96
-    accent-cowboy-words-97: accent-cowboy-replacement-97
-    accent-cowboy-words-98: accent-cowboy-replacement-98
-    accent-cowboy-words-99: accent-cowboy-replacement-99
 
 - type: accent
   id: southern

--- a/Resources/Prototypes/Accents/word_replacements.yml
+++ b/Resources/Prototypes/Accents/word_replacements.yml
@@ -344,6 +344,7 @@
     accent-cowboy-words-100: accent-cowboy-replacement-100
     accent-cowboy-words-101: accent-cowboy-replacement-101
     accent-cowboy-words-102: accent-cowboy-replacement-102
+    accent-cowboy-words-103: accent-cowboy-replacement-103
     # end funkystation
     accent-cowboy-words-74: accent-cowboy-replacement-74
     accent-cowboy-words-75: accent-cowboy-replacement-75

--- a/Resources/Prototypes/Accents/word_replacements.yml
+++ b/Resources/Prototypes/Accents/word_replacements.yml
@@ -340,6 +340,11 @@
     accent-cowboy-words-71: accent-cowboy-replacement-71
     accent-cowboy-words-72: accent-cowboy-replacement-72
     accent-cowboy-words-73: accent-cowboy-replacement-73
+    # funkystation
+    accent-cowboy-words-100: accent-cowboy-replacement-100
+    accent-cowboy-words-101: accent-cowboy-replacement-101
+    accent-cowboy-words-102: accent-cowboy-replacement-102
+    # end funkystation
     accent-cowboy-words-74: accent-cowboy-replacement-74
     accent-cowboy-words-75: accent-cowboy-replacement-75
     accent-cowboy-words-76: accent-cowboy-replacement-76
@@ -366,10 +371,6 @@
     accent-cowboy-words-97: accent-cowboy-replacement-97
     accent-cowboy-words-98: accent-cowboy-replacement-98
     accent-cowboy-words-99: accent-cowboy-replacement-99
-    # funkystation
-    accent-cowboy-words-100: accent-cowboy-replacement-100
-    accent-cowboy-words-101: accent-cowboy-replacement-101
-    accent-cowboy-words-102: accent-cowboy-replacement-102
 
 - type: accent
   id: southern

--- a/Resources/Prototypes/Accents/word_replacements.yml
+++ b/Resources/Prototypes/Accents/word_replacements.yml
@@ -289,7 +289,6 @@
     accent-cowboy-words-20: accent-cowboy-replacement-20
     accent-cowboy-words-21: accent-cowboy-replacement-21
     accent-cowboy-words-22: accent-cowboy-replacement-22
-    accent-cowboy-words-22-2: accent-cowboy-replacement-22
     accent-cowboy-words-23: accent-cowboy-replacement-23
     accent-cowboy-words-24: accent-cowboy-replacement-24
     accent-cowboy-words-25: accent-cowboy-replacement-25


### PR DESCRIPTION
## About the PR
Title.

Also, I renumbered the cowboy accent's back-end files to (mostly) fit with the German accent's back-end files, preferring the usage of sub-numbering systems for multiple words with a singular, shared replacement.

E.g.,
```
(cowboy.ftl)
accent-cowboy-words-69 = hos
accent-cowboy-words-69-2 = head of security
accent-cowboy-words-69-3 = head of law
accent-cowboy-words-69-4 = head of sec
accent-cowboy-replacement-69 = sheriff
```
```
(word_replacements.yml)
accent-cowboy-words-69: accent-cowboy-replacement-69
accent-cowboy-words-69-2: accent-cowboy-replacement-69
accent-cowboy-words-69-3: accent-cowboy-replacement-69
accent-cowboy-words-69-4: accent-cowboy-replacement-69
```

Also, a few extra replacements were added to existing words. For example, cowboy-accented individuals now refer to secoffs as "deputy" when calling them "secoff", "security officer", and "law officer" instead of just "secoff".

Of note is that no replacements were removed, only added or otherwise reorganized for the purposes of clarity.

## Why / Balance
I think "Sheriff" is a pretty thematic choice for talking about the HOS.

As for the organizational changes, the cowboy accent page was a mess, and I felt like fixing it.

## Technical details
basic yml changes, with the german.ftl page used as reference.

## Media
N/A

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A

**Changelog**
:cl:
- add: Characters with cowboy accents now refer to the Head of Security as "Sheriff".
