### PR TITLE
Properly update UI ammo counter when ammo is directly inserted into an in-hand weapon (primarily shotguns)

### DIFF
--- a/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
+++ b/Content.Shared/Weapons/Ranged/Systems/SharedGunSystem.Ballistic.cs
@@ -120,6 +120,7 @@ public abstract partial class SharedGunSystem
         {
             // We call SharedInteractionSystem to raise contact events. Checks are already done by this point.
             _interaction.InteractUsing(args.User, ammo, ammoProvider, coordinates, checkCanInteract: false, checkCanUse: false);
+            UpdateAmmoCount(ammoProvider);
         }
 
         List<(EntityUid? Entity, IShootable Shootable)> ammo = new();


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This change will properly update the ammo indication UI when reloading an in-hand weapon, such as an Enforcer, Kammerer, etc. 


## Why / Balance
Now players can have an accurate view of how many rounds are in a weapon. Previously, the ammo indicator UI would only update when the weapon was fired, or if the weapon was dropped and reequipped. 

## Technical details
The change is very simple, UpdateAmmoCount is now invoked within the SimulateInsertAmmo function. This will cause the ammo count to be updated when ammo is inserted from an AmmoProvider on an in-hand weapon.

## Media

https://github.com/user-attachments/assets/cf6f5ebd-15a7-4b47-8b52-d9d18b6a47f9

The ammo indicator UI at the bottom of the screen is now updated upon insertion of ammo directly into the weapon.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
No known issues.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: nullrout3
- fix: Ammo indicator UI is now properly updated when inserting ammo into an in-hand weapon. (Enforcer, Kammerer, etc.)
