### PR TITLE
Update silicon.yml

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -334,7 +334,7 @@
         reagent: Tricordrazine
         quantity: 30
         minDamage: 0
-        maxDamage: 50
+        maxDamage: 40
       Critical:
         reagent: Inaprovaline
         quantity: 15


### PR DESCRIPTION
Changed the 50 for tricordizone treatment to 40, as per natalie's request.

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
I changed the Tricordizone treatment max on medbots from 50 to 40.

## Why / Balance
Trico doesn't heal past 40, and it was directly requested.
## Technical details
I changed a single god damn number.



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
I don't think there are any

**Changelog**
Medbots now limit tricordizone treatments to up to 40 damage.
