### PR TITLE
Medibot trico now only injects at the proper damage threshold

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -334,7 +334,7 @@
         reagent: Tricordrazine
         quantity: 30
         minDamage: 0
-        maxDamage: 50
+        maxDamage: 40
       Critical:
         reagent: Inaprovaline
         quantity: 15


### PR DESCRIPTION
## About the PR
Medibots now only inject trico when the target as at most 40 damage (from 50)

## Why / Balance
Medibots incorrectly tried to inject targets with trico when they had at most **50** damage while trico only works at **40** damage.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
- fix: Medibots now only inject trico at the correct damage threshold.
