### PR TITLE
Herostar898 medbot fix

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -334,7 +334,7 @@
         reagent: Tricordrazine
         quantity: 30
         minDamage: 0
-        maxDamage: 50
+        maxDamage: 40
       Critical:
         reagent: Inaprovaline
         quantity: 15


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Medbot code. Made the max for trico treatment 

## Why / Balance
Trico doesn't work past 40.

## Technical details
I changed a 5 to a 4.



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Nothing, this shouldn't be that big a deal

**Changelog**
-Changed; Medbots now only administer tricordizone when you are at 40 damage or below.