### PR TITLE
Fixes missing FTL entry for the Pumps & Valves section of the RPD

### DIFF
--- a/Resources/Locale/en-US/rcd/components/rcd-component.ftl
+++ b/Resources/Locale/en-US/rcd/components/rcd-component.ftl
@@ -40,7 +40,7 @@ rcd-component-electrical = Electrical
 rcd-component-lighting = Lighting
 rcd-component-piping = Piping
 rcd-component-atmosphericutility = Atmospheric Utility
-rcd-component-pumps = Pumps & Valves
+rcd-component-pumpsvalves = Pumps & Valves
 rcd-component-vents = Vents
 
 


### PR DESCRIPTION
## About the PR
The RPD uses the FTL entry of "pumpsvalves", which didn't exist in the RCD FTL. I renamed the existing "pumps" entry to "pumpsvalves" to fix this.

This did work, I just didn't bother taking a screenshot

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
