### PR TITLE
Changes the white shoes of the Atmospheric Technician, Reporter, and Zookeeper

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/atmosdrobe.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/atmosdrobe.yml
@@ -7,7 +7,7 @@
     ClothingUniformJumpsuitAtmos: 3
     ClothingUniformJumpskirtAtmos: 3
     ClothingUniformJumpsuitAtmosCasual: 3
-    ClothingShoesColorWhite: 3
+    ClothingShoesBootsWork: 3
     ClothingHeadsetEngineering: 2
     ClothingHeadHelmetFire: 2
     ClothingOuterSuitFire: 2

--- a/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
@@ -27,6 +27,7 @@
     id: AtmosPDA
     belt: ClothingBeltUtilityEngineering
     ears: ClothingHeadsetEngineering
+    shoes: ClothingShoesBootsWork
   #storage:
     #back:
     #- Stuff

--- a/Resources/Prototypes/Roles/Jobs/Wildcards/reporter.yml
+++ b/Resources/Prototypes/Roles/Jobs/Wildcards/reporter.yml
@@ -13,9 +13,9 @@
 - type: startingGear
   id: ReporterGear
   equipment:
-    shoes: ClothingShoesColorWhite
     id: ReporterPDA
     ears: ClothingHeadsetService
+    shoes: ClothingShoesColorBlack
     belt: NewsDigiBoard
   storage: # DeltaV: Give reporters tape recording equipment
     back:

--- a/Resources/Prototypes/Roles/Jobs/Wildcards/zookeeper.yml
+++ b/Resources/Prototypes/Roles/Jobs/Wildcards/zookeeper.yml
@@ -19,7 +19,7 @@
   equipment:
     jumpsuit: ClothingUniformJumpsuitSafari
     head: ClothingHeadSafari
-    shoes: ClothingShoesColorWhite
+    shoes: ClothingShoesBootsWork
     id: ZookeeperPDA
     ears: ClothingHeadsetService
   #storage:


### PR DESCRIPTION
## About the PR
Changes the white shoes of the Atmospheric Technician, Reporter, and Zookeeper

## Why / Balance
The white shoes are horrifically ugly for anything but the Medical department and even then it's pushing it. They're horrible as placeholders too, and I'd genuinely rather just see the black shoes.

Using workboots for the Zookeeper is a bit questionable, but I choose that as the lesser of many evils and it's not contraband so whatever

(here's how the zookeeper would look with black shoes. still not perfect)
![image](https://github.com/user-attachments/assets/70a7d36a-5284-40b8-acd4-2cba55950133)

## Media
![image](https://github.com/user-attachments/assets/4f5969d0-be97-4dff-8e09-0572787590eb)
![image](https://github.com/user-attachments/assets/0beb5fa4-0e8d-4473-9106-ece6287707a8)
![image](https://github.com/user-attachments/assets/721367cf-8490-43e5-99ad-c4a1d2a9d7a8)

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: Minerva
- tweak: Atmos Technician, Reporter, and Zookeeper no longer start with white shoes. The AtmosDrobe has been changed accordingly. Look for a ClothesMate if you liked them.
