### PR TITLE
Change default Boxer jumpsuit to be the one with the top

### DIFF
--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1447,8 +1447,8 @@
   id: BoxerJumpsuit
   name: loadout-group-boxer-jumpsuit
   loadouts:
-  - BoxerShorts
   - BoxerShortsWithTop
+  - BoxerShorts
 
 - type: loadoutGroup
   id: BoxerGloves


### PR DESCRIPTION
## About the PR
Changes the default Boxer jumpsuit to the "boxing shorts with top" by setting it as the first thing in the loadout group. This apparently worked.

## Why / Balance
The shorts with the top option is probably better to have as the default because it works for all characters. It's unisex, where the one without the top would conditionally be frowned upon in polite society

I have to change this on my female characters so they aren't *just* wearing shorts if I ever misclick on Boxer or something

## Media
(brand new character)
![image](https://github.com/user-attachments/assets/e51ab9e1-a704-47f4-bd7b-9e8e73d16ad2)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->