### PR TITLE
Fix rodentia screams

### DIFF
--- a/Resources/Prototypes/_DV/Voice/speech_emote_sounds.yml
+++ b/Resources/Prototypes/_DV/Voice/speech_emote_sounds.yml
@@ -263,7 +263,7 @@
     variation: 0.125
   sounds:
     Scream:
-      path: /Audio/Animals/mouse_squeak.ogg
+      collection: MaleScreams
     Laugh:
       collection: MaleLaugh
     Sneeze:
@@ -297,7 +297,7 @@
     variation: 0.125
   sounds:
     Scream:
-      path: /Audio/Animals/mouse_squeak.ogg
+      collection: FemaleScreams
     Laugh:
       collection: FemaleLaugh
     Sneeze:


### PR DESCRIPTION
## About the PR
This PR allows rodentia to scream properly.

## Why / Balance
Currently, speaking, screaming and squeaking uses the same sound for rodents. Which makes no point in squeaking/screaming, since the sounds are identical. Rodents' sounds are identical to human ones except for screaming, we also removed their smaller size and ability to crawl under tables which doesn't make them small n' squeaky anymore.  This PR makes screaming sound like actual screaming, and keeps squeaking so you can squeak. 

## Media
https://github.com/user-attachments/assets/b3a51c8f-6cb1-48dd-b423-8d5a29a2619b



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ x ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ x ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**

:cl:
- tweak: Rodents can now squeak AND scream with appropriate sounds.
