### PR TITLE
Home-Run Bat Nerf

### DIFF
--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Melee/home_run_bat.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Melee/home_run_bat.yml
@@ -10,21 +10,25 @@
   - type: MeleeWeapon
     damage:
       types:
-        Blunt: 25 # Get to WHACKIN!
-        Structural: 30
+        Blunt: 22 # Get to WHACKIN!  Funky change - 25 > 20, since this inherits from a baseball bat it gains 5 more damage while wielded,
+                  # meaning that it actually does 30 blunt. Plus collision damage, it could kill unarmoured in 3 hits. It's now 25 for real
+        Structural: 30 # Funky - it also gains 10 more structural, but that hasn't proved to be an issue yet so it's unchanged.
     soundHit:
       collection: ExplosionSmall
+    attackRate: 0.40 # Funky change - Swing speed reduced significantly to prevent stunlocking with the knockdown
   - type: MeleeRequiresWield # You can't hit a home run with one hand, jimbo.
   - type: MeleeThrowOnHit
     stunTime: .1 # I get knocked DOWN
-    speed: 30
+    speed: 20 # Funky change - 30 -> 20 since 30 is incredibly fast, fast enough to frequently clip people through walls
     distance: 50
   - type: Item
     size: Large
   - type: Tool
     speedModifier: 0.5 # it's very heavy, it rolls slower than a wooden bat
   - type: UseDelay
-    delay: 2
+    delay: 2 # Funky - In theory, since the bat requires wielding this should stop you from swinging the bat until the wield delay is over...
+             # ...however that's not the case. You aren't able to knock people back during the delay but you're still able to swing for full damage instantly.
+             # This is an issue with use delay and is out of scope for me to fix here but should be kept in mind.
   - type: PhysicalComposition
     materialComposition:
       Steel: 350 # it's not made of wood

--- a/Resources/Prototypes/_DV/Entities/Objects/Weapons/Melee/home_run_bat.yml
+++ b/Resources/Prototypes/_DV/Entities/Objects/Weapons/Melee/home_run_bat.yml
@@ -10,8 +10,8 @@
   - type: MeleeWeapon
     damage:
       types:
-        Blunt: 22 # Get to WHACKIN!  Funky change - 25 > 20, since this inherits from a baseball bat it gains 5 more damage while wielded,
-                  # meaning that it actually does 30 blunt. Plus collision damage, it could kill unarmoured in 3 hits. It's now 25 for real
+        Blunt: 22 # Get to WHACKIN!  Funky change - 25 > 22, since this inherits from a baseball bat it gains 5 more damage while wielded,
+                  # meaning that it actually does 30 blunt. Plus collision damage, it could kill unarmoured in 3 hits. It's now 27 blunt.
         Structural: 30 # Funky - it also gains 10 more structural, but that hasn't proved to be an issue yet so it's unchanged.
     soundHit:
       collection: ExplosionSmall


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
_I promise this isn't a mald pr I am making this as someone who has USED this a few times_

- Decreased the blunt damage of the bat from 30 to 27, so it shouldn't kill unarmoured targets in 3 swings
- Massively nerfed the swing speed to 0.40 to prevent knockdown stunlocking
- Decreased the entity launching speed from 30 to 20
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Full swing speed on the bat allows for effortless knockdown stunlocking, sometimes even on multiple people at once. Getting hit should only trip you for 0.1 second while you're launched (as the stuntime on hit is 0.1) but because getting back up now has a do-after, it's closer to 1.5 seconds on the floor...which was long enough to stunlock someone as long as there's a wall to hit them into, since the weapon had base swing speed and getting hit while knocked down resets the get back up timer. 

Reducing the swing speed means your target has just enough time to get up and attempt to run. You will most likely be able to line up another hit, but the delay is enough for your target to perhaps escape the corner and force you to reposition. Keep in mind this still knocks items out of your target's hands.

The small damage tweak was made because I believe the damage was intended to be 25 instead of 30, but they forgot that inheriting from the baseball bat would mean inheriting the 5 extra blunt damage while wielded. Stacked with even more blunt damage from colliding with a wall, this thing killed and gibbed incredibly quickly. The swing speed reduction obviously does a lot of the heavy lifting in reducing the time-to-kill, but if anything it might still be overtuned, so I've made this damage reduction to make sure it isn't killing unarmoured targets in 3 hits.

Speed reduction was done because I've seen this thing clip people both into and through walls, and 30 speed was incredibly fast. Hopefully this is more reasonable.

## Technical details
<!-- Summary of code changes for easier review. -->
Yaml changes. MeleeWeapon component now has an attackRate added.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Demonstration of the bat's swing speed post-nerf. Keep in mind this poor urist obviously isn't trying to run away...

https://github.com/user-attachments/assets/0a8b337a-60af-4414-81d2-9342ee4139cc



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Reduced the home-run bat's swing speed, launch speed and slightly reduced it's damage
