### PR TITLE
Ports Playtime Reminders from Wizard's Den

### DIFF
--- a/Content.Client/Entry/EntryPoint.cs
+++ b/Content.Client/Entry/EntryPoint.cs
@@ -14,6 +14,7 @@ using Content.Client.Lobby;
 using Content.Client.MainMenu;
 using Content.Client.Parallax.Managers;
 using Content.Client.Players.PlayTimeTracking;
+using Content.Client.Playtime;
 using Content.Client.Radiation.Overlays;
 using Content.Client.Replay;
 using Content.Client.Screenshot;
@@ -72,6 +73,8 @@ namespace Content.Client.Entry
         [Dependency] private readonly ILogManager _logManager = default!;
         [Dependency] private readonly DebugMonitorManager _debugMonitorManager = default!;
         [Dependency] private readonly TitleWindowManager _titleWindowManager = default!;
+        [Dependency] private readonly IEntitySystemManager _entitySystemManager = default!;
+        [Dependency] private readonly ClientsidePlaytimeTrackingManager _clientsidePlaytimeManager = default!;
 
         public override void Init()
         {
@@ -134,6 +137,7 @@ namespace Content.Client.Entry
             _extendedDisconnectInformation.Initialize();
             _jobRequirements.Initialize();
             _playbackMan.Initialize();
+            _clientsidePlaytimeManager.Initialize();
 
             //AUTOSCALING default Setup!
             _configManager.SetCVar("interface.resolutionAutoScaleUpperCutoffX", 1080);

--- a/Content.Client/IoC/ClientContentIoC.cs
+++ b/Content.Client/IoC/ClientContentIoC.cs
@@ -12,6 +12,7 @@ using Content.Client.Launcher;
 using Content.Client.Mapping;
 using Content.Client.Parallax.Managers;
 using Content.Client.Players.PlayTimeTracking;
+using Content.Client.Playtime;
 using Content.Client.Replay;
 using Content.Client.Screenshot;
 using Content.Client.Stylesheets;
@@ -59,6 +60,7 @@ namespace Content.Client.IoC
             collection.Register<PlayerRateLimitManager>();
             collection.Register<SharedPlayerRateLimitManager, PlayerRateLimitManager>();
             collection.Register<TitleWindowManager>();
+            collection.Register<ClientsidePlaytimeTrackingManager>();
         }
     }
 }

--- a/Content.Client/Lobby/LobbyState.cs
+++ b/Content.Client/Lobby/LobbyState.cs
@@ -4,6 +4,7 @@ using Content.Client.LateJoin;
 using Content.Client.Lobby.UI;
 using Content.Client.Message;
 using Content.Client.ReadyManifest;
+using Content.Client.Playtime;
 using Content.Client.UserInterface.Systems.Chat;
 using Content.Client.Voting;
 using Content.Shared.CCVar;
@@ -27,6 +28,7 @@ namespace Content.Client.Lobby
         [Dependency] private readonly IUserInterfaceManager _userInterfaceManager = default!;
         [Dependency] private readonly IGameTiming _gameTiming = default!;
         [Dependency] private readonly IVoteManager _voteManager = default!;
+        [Dependency] private readonly ClientsidePlaytimeTrackingManager _playtimeTracking = default!;
 
         private ClientGameTicker _gameTicker = default!;
         private ContentAudioSystem _contentAudioSystem = default!;
@@ -195,7 +197,9 @@ namespace Content.Client.Lobby
             else
             {
                 Lobby!.StartTime.Text = string.Empty;
-                Lobby!.ReadyButton.Text = Loc.GetString(Lobby!.ReadyButton.Pressed ? "lobby-state-player-status-ready": "lobby-state-player-status-not-ready");
+                Lobby!.ReadyButton.Text = Loc.GetString(Lobby!.ReadyButton.Pressed
+                    ? "lobby-state-player-status-ready"
+                    : "lobby-state-player-status-not-ready");
                 Lobby!.ReadyButton.ToggleMode = true;
                 Lobby!.ReadyButton.Disabled = false;
                 Lobby!.ReadyButton.Pressed = _gameTicker.AreWeReady;
@@ -207,6 +211,26 @@ namespace Content.Client.Lobby
             {
                 Lobby!.ServerInfo.SetInfoBlob(_gameTicker.ServerInfoBlob);
             }
+
+            var minutesToday = _playtimeTracking.PlaytimeMinutesToday;
+            if (minutesToday > 0)
+            {
+                Lobby!.PlaytimeComment.Visible = true;
+
+                var hoursToday = Math.Round(minutesToday / 60f, 1);
+
+                var chosenString = minutesToday switch
+                {
+                    < 180 => "lobby-state-playtime-comment-normal",
+                    < 360 => "lobby-state-playtime-comment-concerning",
+                    < 720 => "lobby-state-playtime-comment-grasstouchless",
+                    _ => "lobby-state-playtime-comment-selfdestructive"
+                };
+
+                Lobby.PlaytimeComment.SetMarkup(Loc.GetString(chosenString, ("hours", hoursToday)));
+            }
+            else
+                Lobby!.PlaytimeComment.Visible = false;
         }
 
         private void UpdateLobbySoundtrackInfo(LobbySoundtrackChangedEvent ev)

--- a/Content.Client/Lobby/UI/LobbyGui.xaml
+++ b/Content.Client/Lobby/UI/LobbyGui.xaml
@@ -44,6 +44,7 @@
                                                 StyleClasses="ButtonBig" MinWidth="137" />
                                     </BoxContainer>
                                 </controls:StripeBack>
+                                <RichTextLabel Name="PlaytimeComment" Visible="False" Access="Public" HorizontalAlignment="Center" />
                             </BoxContainer>
                         </PanelContainer>
                         <!-- Voting Popups -->

--- a/Content.Client/Playtime/ClientsidePlaytimeTrackingManager.cs
+++ b/Content.Client/Playtime/ClientsidePlaytimeTrackingManager.cs
@@ -1,0 +1,108 @@
+using Content.Shared.CCVar;
+using Robust.Client.Player;
+using Robust.Shared.Network;
+using Robust.Shared.Configuration;
+using Robust.Shared.Timing;
+
+namespace Content.Client.Playtime;
+
+/// <summary>
+///     Keeps track of how long the player has played today.
+/// </summary>
+/// <remarks>
+/// <para>
+///     Playtime is treated as any time in which the player is attached to an entity.
+///     This notably excludes scenarios like the lobby.
+/// </para>
+/// </remarks>
+public sealed class ClientsidePlaytimeTrackingManager
+{
+    [Dependency] private readonly IClientNetManager _clientNetManager = default!;
+    [Dependency] private readonly IConfigurationManager _configurationManager = default!;
+    [Dependency] private readonly ILogManager _logManager = default!;
+    [Dependency] private readonly IPlayerManager _playerManager = default!;
+    [Dependency] private readonly IGameTiming _gameTiming = default!;
+
+    private ISawmill _sawmill = default!;
+
+    private const string InternalDateFormat = "yyyy-MM-dd";
+
+    [ViewVariables]
+    private TimeSpan? _mobAttachmentTime;
+
+    /// <summary>
+    /// The total amount of time played today, in minutes.
+    /// </summary>
+    [ViewVariables]
+    public float PlaytimeMinutesToday
+    {
+        get
+        {
+            var cvarValue = _configurationManager.GetCVar(CCVars.PlaytimeMinutesToday);
+            if (_mobAttachmentTime == null)
+                return cvarValue;
+
+            return cvarValue + (float)(_gameTiming.RealTime - _mobAttachmentTime.Value).TotalMinutes;
+        }
+    }
+
+    public void Initialize()
+    {
+        _sawmill = _logManager.GetSawmill("clientplaytime");
+        _clientNetManager.Connected += OnConnected;
+
+        // The downside to relying on playerattached and playerdetached is that unsaved playtime won't be saved in the event of a crash
+        // But then again, the config doesn't get saved in the event of a crash, either, so /shrug
+        // Playerdetached gets called on quit, though, so at least that's covered.
+        _playerManager.LocalPlayerAttached += OnPlayerAttached;
+        _playerManager.LocalPlayerDetached += OnPlayerDetached;
+    }
+
+    private void OnConnected(object? sender, NetChannelArgs args)
+    {
+        var datatimey = DateTime.Now;
+        _sawmill.Info($"Current day: {datatimey.Day} Current Date: {datatimey.Date.ToString(InternalDateFormat)}");
+
+        var recordedDateString = _configurationManager.GetCVar(CCVars.PlaytimeLastConnectDate);
+        var formattedDate = datatimey.Date.ToString(InternalDateFormat);
+
+        if (formattedDate == recordedDateString)
+            return;
+
+        _configurationManager.SetCVar(CCVars.PlaytimeMinutesToday, 0);
+        _configurationManager.SetCVar(CCVars.PlaytimeLastConnectDate, formattedDate);
+    }
+
+    private void OnPlayerAttached(EntityUid entity)
+    {
+        _mobAttachmentTime = _gameTiming.RealTime;
+    }
+
+    private void OnPlayerDetached(EntityUid entity)
+    {
+        if (_mobAttachmentTime == null)
+            return;
+
+        var newTimeValue = PlaytimeMinutesToday;
+
+        _mobAttachmentTime = null;
+
+        var timeDiffMinutes = newTimeValue - _configurationManager.GetCVar(CCVars.PlaytimeMinutesToday);
+        if (timeDiffMinutes < 0)
+        {
+            _sawmill.Error("Time differential on player detachment somehow less than zero!");
+            return;
+        }
+
+        // At less than 1 minute of time diff, there's not much point, and saving regardless will brick tests
+        // The reason this isn't checking for 0 is because TotalMinutes is fractional, rather than solely whole minutes
+        if (timeDiffMinutes < 1)
+            return;
+
+        _configurationManager.SetCVar(CCVars.PlaytimeMinutesToday, newTimeValue);
+
+        _sawmill.Info($"Recorded {timeDiffMinutes} minutes of living playtime!");
+
+        _configurationManager.SaveToFile(); // We don't like that we have to save the entire config just to store playtime stats '^'
+    }
+}

--- a/Content.Shared/CCVar/CCVars.Misc.cs
+++ b/Content.Shared/CCVar/CCVars.Misc.cs
@@ -94,4 +94,19 @@ public sealed partial class CCVars
     /// </summary>
     public static readonly CVarDef<float> PointingCooldownSeconds =
         CVarDef.Create("pointing.cooldown_seconds", 0.5f, CVar.SERVERONLY);
+
+    /// <summary>
+    ///     The last time the client recorded a valid connection to a game server.
+    ///     Used in conjunction with <see cref="PlaytimeMinutesToday"/> to track how long the player has been playing for the given day.
+    /// </summary>
+    public static readonly CVarDef<string> PlaytimeLastConnectDate =
+        CVarDef.Create("playtime.last_connect_date", "", CVar.CLIENTONLY | CVar.ARCHIVE);
+
+    /// <summary>
+    ///     The total minutes that the client has spent since the date of last connection.
+    ///     This is reset to 0 when the last connect date is updated.
+    ///     Do not read this value directly, use <code>ClientsidePlaytimeTrackingManager</code> instead.
+    /// </summary>
+    public static readonly CVarDef<float> PlaytimeMinutesToday =
+        CVarDef.Create("playtime.minutes_today", 0f, CVar.CLIENTONLY | CVar.ARCHIVE);
 }

--- a/Resources/Locale/en-US/lobby/lobby-state.ftl
+++ b/Resources/Locale/en-US/lobby/lobby-state.ftl
@@ -21,3 +21,11 @@ lobby-state-song-text = Playing: [color=white]{$songTitle}[/color] by [color=whi
 lobby-state-song-no-song-text = No lobby song playing.
 lobby-state-song-unknown-title = [color=dimgray]Unknown title[/color]
 lobby-state-song-unknown-artist = [color=dimgray]Unknown artist[/color]
+lobby-state-playtime-comment-normal =
+    You've spent {$hours} {$hours ->
+    [1]hour
+    *[other]hours
+    } ingame today. Remember to take breaks!
+lobby-state-playtime-comment-concerning = You've played for {$hours} hours today. Please take a break.
+lobby-state-playtime-comment-grasstouchless = {$hours} hours. Consider logging off to attend to your needs.
+lobby-state-playtime-comment-selfdestructive = {$hours} hours.


### PR DESCRIPTION
All credits to the original author, deathride58 on Github.
Licensed under MIT.

## About the PR
<!-- What did you change? -->
Ported playtime reminders from https://github.com/space-wizards/space-station-14/pull/36483.

After 1 hour of playing, a playtime reminder will show up (example below) reminding the user to take breaks. This does not affect gameplay or anything besides the lobby screen. 
![image](https://github.com/user-attachments/assets/06fb7060-280e-4f43-80e3-b46962a6f69a)

The only change I made was removing the final post-12 hour comment altogether to prevent 'achievement-hunting' for it.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I am simply not capable of putting this into words better than the original author did in their proposal. Please read it here.
https://github.com/space-wizards/docs/pull/439

## Technical details
<!-- Summary of code changes for easier review. -->
FROM THE ORIGINAL PR:
"This takes the straight-forward, low-maintenance, self-contained approach of implementing this. Additionally, this is clientside, meaning this data will transfer across servers that port this PR.

A pair of CVars are added. One to keep track of the date that the client last logged into a server (playtime.last_connect_date), and another to keep track of the minutes spent ingame as a living mob (playtime.minutes_today).

These are tracked by ClientsidePlaytimeTracking, which tracks playtime by listening to the client being attached and detached to mobs. When the client is attached to a living mob, the current timestamp is recorded. When the client is detached, the minutes between the current time and the recorded time are added onto the minutes_today cvar. This isn't perfectly accurate, but it's plenty accurate enough for the purposes of this PR.

Additionally, whenever the client connects to a server, the last connect date is compared to the current date. If it doesn't match, then minutes_today is reset to 0, and the last connect date is set to the current date."

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Bhijn and Myr
- add: In interest of raising awareness of addiction to the game, the lobby will now display your current playtime on a given day once it exceeds a threshold.