### PR TITLE
Buffed the artifact module for borgs

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/borg_modules.yml
@@ -622,6 +622,11 @@
   - type: ItemBorgModule
     items:
     - NodeScanner
+    - BorgDropper
+    - Beaker
+    - Beaker
+    - SprayBottle
+    - borgArtifactPouch
   - type: BorgModuleIcon
     icon: { sprite: Interface/Actions/actions_borg.rsi, state: node-scanner-module }
 

--- a/Resources/Prototypes/_Funkystation/Entities/Objects/Specific/Science/artifact_pouch.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Objects/Specific/Science/artifact_pouch.yml
@@ -1,0 +1,21 @@
+- type: entity
+  name: Artifact Pouch
+  id: borgArtifactPouch
+  parent: BaseStorageItem
+  description: A bag for the easy collection of processed artifact fragments.
+  components:
+  - type: Sprite
+    sprite: Objects/Specific/Mining/ore_bag.rsi
+    state: icon
+  - type: Item
+    size: Ginormous
+  - type: Storage
+    maxItemSize: Normal
+    grid:
+    - 0,0,9,3
+    quickInsert: true
+    areaInsert: true
+    whitelist:
+      tags:
+        - ArtifactFragment
+  - type: Dumpable


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Buffed the artifact module for borgs, giving it a dropper, two beakers, a spray bottle, and a unique orebag prototype that only holds artifact fragments. (Sprite needed)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Currently, the artifact module is completely useless. While it had at least some use pre-artifact rework to know what node you're on, it's no longer useful. It's generally a waste of a slot for something that only gives one item, of which has basically no utility.

The two seperate beakers are for holding two liquids, (in cases of duo water and liquid plasma nodes). Dropper is for collection of spills, or more advanced liquid management with artis.

The ore bag is so that borgs are able to collect crushed fragments and recycle without crew aid. (Salv borgs can do this already also with their standard ore bag)

Lastly, the spray bottle is for activation of liquid nodes with more efficiency, setting to 1u, or for the use of artifaxium on multiple artifacts when that is fixed for the artifact rework.

## Technical details
<!-- Summary of code changes for easier review. -->
No code changes. New prototype is added to the funky namespace.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Buffed the Artifact borg module!

