### PR TITLE
webedit ops: flashbang bounty patch

### DIFF
--- a/Resources/Prototypes/_Funkystation/Catalog/Bounties/bountyCategories.yml
+++ b/Resources/Prototypes/_Funkystation/Catalog/Bounties/bountyCategories.yml
@@ -646,8 +646,8 @@
     maxAmount: 8
     rewardPer: 700
     whitelist:
-      tags:
-      - GrenadeFlashBang
+      components:
+      - Flashbang
   - name: bounty-item-sidearm
     minAmount: 3
     maxAmount: 5


### PR DESCRIPTION
## About the PR
Had a round where Flashbangs weren't being recognized properly in a bounty. This should fix that.

## Why / Balance
Mald PR between myself and the round's Quartermaster because we had this bounty fail.

## Technical details
GrenadeFlashBang tag refers to the clusterbang. Flashbang component refers exclusively to the Flashbang. Using the component in the bounty is an easy enough change which should have zero repercussions.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
no cl no fun