### PR TITLE
Flesh out diona medication

### DIFF
--- a/Resources/Prototypes/Reagents/botany.yml
+++ b/Resources/Prototypes/Reagents/botany.yml
@@ -163,6 +163,29 @@
   flavor: bitter
   color: "#3CB371"
   physicalDesc: reagent-physical-desc-sickly
+  metabolisms: # Funky - expanded diona medication
+    Poison:
+      metabolismRate: 1
+      effects:
+      - !type:HealthChange
+        damage:
+          types:
+            Poison: 2
+      - !type:CreateEntityReactionEffect
+        entity: MobDionaNymph
+        conditions:
+        - !type:OrganType
+          type: Plant
+        - !type:ReagentThreshold
+          min: 40
+      - !type:AdjustReagent
+        reagent: Sedin
+        amount: -20
+        conditions:
+        - !type:OrganType
+          type: Plant
+        - !type:ReagentThreshold
+          min: 40
   plantMetabolism:
     - !type:PlantAdjustHealth
       amount: -2
@@ -217,6 +240,17 @@
         damage:
           types:
             Caustic: 1
+        conditions:
+        - !type:OrganType # Funky - flesh out diona medication
+          type: Plant
+          shouldHave: false
+    Food: # Funky - flesh out diona medication
+      effects:
+      - !type:SatiateHunger
+        factor: 1
+        conditions:
+        - !type:OrganType
+          type: Plant
     Gas:
       effects:
       - !type:HealthChange
@@ -316,3 +350,18 @@
         damage:
           types:
             Caustic: 1
+        conditions:
+        - !type:OrganType # Funky - flesh out diona medication
+          type: Plant
+          shouldHave: false
+    Medicine: # Funky - flesh out diona medication
+      effects:
+      - !type:HealthChange
+        damage:
+          types:
+            Heat: -2
+            Cold: -2
+            Shock: -2
+        conditions:
+        - !type:OrganType
+          type: Plant


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
This gives ammonia, sedin, and diethylamine diona-specific effects to bring them in line with the other botanical chemicals.
Ammonia simply acts like weaker EZ nutrient, diethylamine is a mild all-burn similar to robust harvest being a mild all-brute, and Sedin deals toxin, but also will cause new nymphs to form when dosed high enough.

## Why / Balance
This brings all botanical reagents in line with each other in that they have unique effects for dionae.

## Technical details
- modify some reagent prototypes

## Media
![grafik](https://github.com/user-attachments/assets/e42de912-6b7a-4d6a-b29b-4091038f0ed6)
![grafik](https://github.com/user-attachments/assets/a056c6b0-3b7d-4e61-a05a-7f18b26aa23e)
![grafik](https://github.com/user-attachments/assets/7f8f6330-7c33-492d-b67b-dc49b24d2b21)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Dionae now have unique reactions to ammonia, sedin, and diethylamine.
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
