### PR TITLE
Heretic ascension

### DIFF
--- a/Content.Client/_Goobstation/Heretic/Ritual.CustomBehaviors.cs
+++ b/Content.Client/_Goobstation/Heretic/Ritual.CustomBehaviors.cs
@@ -9,6 +9,7 @@ namespace Content.Client.Heretic;
 
 public sealed partial class RitualAshAscendBehavior : RitualSacrificeBehavior { }
 public sealed partial class RitualMuteGhoulifyBehavior : RitualSacrificeBehavior { }
+public sealed partial class RitualAscensionBehavior : RitualSacrificeBehavior { }
 
 [Virtual] public partial class RitualSacrificeBehavior : RitualCustomBehavior
 {

--- a/Content.Server/_Goobstation/Heretic/Ritual/CustomBehavior.Ascension.cs
+++ b/Content.Server/_Goobstation/Heretic/Ritual/CustomBehavior.Ascension.cs
@@ -1,0 +1,64 @@
+using Content.Shared.Heretic.Prototypes;
+using Content.Server.Objectives.Components;
+using Content.Shared.Mind;
+
+namespace Content.Server.Heretic.Ritual;
+
+/// <summary>
+///     Verify is the heretic has completed its objectives.
+///     Return true if so.
+/// </summary>
+[Virtual]
+public partial class RitualAscensionBehavior : RitualCustomBehavior
+{
+    /// <summary>
+    ///     Should we count only targets?
+    /// </summary>
+    [DataField]
+    public bool OnlyTargets = false;
+
+    protected List<EntityUid> uids = new();
+
+    public override bool Execute(RitualData args, out string? outstr)
+    {
+        var mindSystem = args.EntityManager.System<SharedMindSystem>();
+        // get objectives
+        if (mindSystem.TryGetMind(args.Performer, out var mindId, out var mind))
+        {
+            if (mindSystem.TryFindObjective((mindId, mind), "HereticSacrificeObjective", out var crewObj)
+                && args.EntityManager.TryGetComponent<HereticSacrificeConditionComponent>(crewObj, out var crewObjComp)
+                && args.EntityManager.TryGetComponent<NumberObjectiveComponent>(crewObj, out var numberObj))
+            {
+                var requiredSacrifices = numberObj.Target;
+                if (crewObjComp.Sacrificed < requiredSacrifices)
+                {
+                    outstr = Loc.GetString("heretic-ritual-fail-ascension");
+                    return false;
+                }
+            }
+
+            if (mindSystem.TryFindObjective((mindId, mind), "HereticSacrificeHeadObjective", out var crewHeadObj)
+                && args.EntityManager.TryGetComponent<HereticSacrificeConditionComponent>(crewHeadObj,
+                    out var crewHeadObjComp)
+                && args.EntityManager.TryGetComponent<NumberObjectiveComponent>(crewHeadObj, out var numberHeadObj))
+            {
+                var requiredSacrifices = numberHeadObj.Target;
+                if (crewHeadObjComp.Sacrificed < requiredSacrifices)
+                {
+                    outstr = Loc.GetString("heretic-ritual-fail-ascension");
+                    return false;
+                }
+            }
+
+            outstr = null;
+            return true;
+        }
+
+        outstr = null;
+        return false;
+    }
+    public override void Finalize(RitualData args)
+    {
+        // do nothing
+    }
+}

--- a/Content.Server/_Goobstation/Heretic/Ritual/CustomBehavior.Ascension.cs
+++ b/Content.Server/_Goobstation/Heretic/Ritual/CustomBehavior.Ascension.cs
@@ -11,14 +11,6 @@ namespace Content.Server.Heretic.Ritual;
 [Virtual]
 public partial class RitualAscensionBehavior : RitualCustomBehavior
 {
-    /// <summary>
-    ///     Should we count only targets?
-    /// </summary>
-    [DataField]
-    public bool OnlyTargets = false;
-
-    protected List<EntityUid> uids = new();
-
     public override bool Execute(RitualData args, out string? outstr)
     {
         var mindSystem = args.EntityManager.System<SharedMindSystem>();

--- a/Resources/Locale/en-US/_Goobstation/Heretic/heretic/rituals.ftl
+++ b/Resources/Locale/en-US/_Goobstation/Heretic/heretic/rituals.ftl
@@ -24,6 +24,7 @@ heretic-ritual-fail-reagentpuddle = There is no {$reagentname} here.
 heretic-ritual-fail-temperature-hot = It's too hot here.
 heretic-ritual-fail-temperature-cold = It isn't cold enough here.
 heretic-ritual-fail-sacrifice-ash = There are either too few dead, or burning.
+heretic-ritual-fail-ascension = You must complete your objectives first.
 
 ## side quests
 heretic-ritual-side-knowledge = Ritual of Knowledge

--- a/Resources/Prototypes/_Goobstation/Heretic/Heretic/heretic_rituals.yml
+++ b/Resources/Prototypes/_Goobstation/Heretic/Heretic/heretic_rituals.yml
@@ -87,6 +87,7 @@
     sprite: _Goobstation/Heretic/abilities_heretic.rsi
     state: ashlord_rite2
   customBehaviors:
+  - !type:RitualAscensionBehavior
   - !type:RitualAshAscendBehavior
     min: 3
     max: 3
@@ -189,6 +190,7 @@
     sprite: _Goobstation/Heretic/abilities_heretic.rsi
     state: final_hymn
   customBehaviors:
+  - !type:RitualAscensionBehavior
   - !type:RitualSacrificeBehavior
     min: 4
     max: 4
@@ -221,6 +223,7 @@
     sprite: Interface/Alerts/temperature.rsi
     state: cold3
   customBehaviors:
+  - !type:RitualAscensionBehavior
   - !type:RitualSacrificeBehavior
     min: 3
     max: 3


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
The heretic must complete all its sacrifices objectives in order to ascend.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Currently, heretics can passively gain knowledge through rifts and unlock their ascension ritual fairly easily. During that time, security can do very little to prevent them, as part of the removal of EOC, since the heretic doesn't need to commit any crimes (apart from trespassing). Once the heretic unlocked its final ritual, he simply needs to collect three bodies to trigger the ascension, potentially wiping the entire station without giving security a chance to prevent it.
It is very often to see a heretic ascending without completing its tasks, which is weird considering ascending should be the final goal.
This change aims to stop heretics from being a passive antagonists until they go loud through ascension, and gives a chance for security to have an actual reason to stop them before it's too late.
## Technical details
<!-- Summary of code changes for easier review. -->
Added a new condition for heretic ascension, which check if they have completed their sacrifice objectives.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Heretic are required to complete their objectives first before ascending
