### PR TITLE
Prevent setting ID card accesses twice when spawning players in jobs

### DIFF
--- a/Content.Server/Station/Systems/StationSpawningSystem.cs
+++ b/Content.Server/Station/Systems/StationSpawningSystem.cs
@@ -27,6 +27,7 @@ using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
 using Robust.Shared.Utility;
 using Content.Server._EinsteinEngines.Silicon.IPC; // Goobstation
+using Content.Server.Access.Components; // Funkystation
 
 namespace Content.Server.Station.Systems;
 
@@ -269,6 +270,10 @@ public sealed class StationSpawningSystem : SharedStationSpawningSystem
         }
 
         _accessSystem.SetAccessToJob(cardId, jobPrototype, extendedAccess);
+
+        // funkystation: prevent setting PresetIdCard accesses; we just GOT our accesses, remember?
+        if (TryComp<PresetIdCardComponent>(cardId, out _))
+            RemComp<PresetIdCardComponent>(cardId);
 
         if (pdaComponent != null)
             _pdaSystem.SetOwner(idUid.Value, pdaComponent, entity, characterName);


### PR DESCRIPTION
## About the PR
See title. When players are spawned into station jobs via roundstart or latejoin, their PDA's ID card is assigned a job, including accesses. This means we don't need to run PresetIdCard and assign the ID card a job, including accesses, because it's already done.

This is ostensibly an upstream bug and I will be filing it as such on Wizden. I won't claim to know the best way to solve this; if they have a better idea, feel free to pull that when they fix it.

_I do not know if this somehow breaks some weird edge case somewhere._ All I did was check to make sure that NTR's accesses are correct and that the game doesn't implode.

This PR fixes #1078.

## Why / Balance
This fixes an issue with the Nanotrasen Representative, who uses a CentComm PDA, of which its accesses normally don't match Nanotrasen Representative's accesses (true AA versus basic AA + command + CentComm).

Also, it's incredibly silly to set accesses _twice_ when spawning an ID card attached to a player that has a job.

## Technical details
trycomp? remcomp. it's apparently that easy.

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Nanotrasen Representative's ID now correctly receives its intended job title and accesses instead of becoming All Access.
