### PR TITLE
Rev reduce

### DIFF
--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -5,7 +5,7 @@
     Changeling: 0.05 # Goobstation unique antag
     Traitorling: 0.12 # 2 antags but less of each type applies for all hybrid modes, they all need 30 pop. Also makes lower pops roll more traitor games.
     Nukeops: 0.15
-    Revolutionary: 0.10 # Maybe 0.08 after wiz/cult?
+    Revolutionary: 0.05 # Maybe 0.08 after wiz/cult?
     Survival: 0.10 # funky hi im putting something here because everything else has a comment
     Blob: 0.05 #funky Blobmode
     BlobTraitor: 0.1 #funky Blobmode

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -2,13 +2,13 @@
   id: Secret
   weights:
     Traitor: 0.25 # Goobstation
-    Changeling: 0.03 # Goobstation unique antag
+    Changeling: 0.05 # Goobstation unique antag
     Traitorling: 0.12 # 2 antags but less of each type applies for all hybrid modes, they all need 30 pop. Also makes lower pops roll more traitor games.
     Nukeops: 0.15
-    Revolutionary: 0.15 # Maybe 0.08 after wiz/cult?
-    Survival: 0.04 # funky hi im putting something here because everything else has a comment
+    Revolutionary: 0.10 # Maybe 0.08 after wiz/cult?
+    Survival: 0.10 # funky hi im putting something here because everything else has a comment
     Blob: 0.05 #funky Blobmode
     BlobTraitor: 0.1 #funky Blobmode
-    CosmicCult: 0.11
+    CosmicCult: 0.13
 
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Changed the weights to be closer to Wizden's rate for Revolution and Survival, making them the same 5% and 10% respectively.

## Why / Balance
Funky has a very high chance of conversion antags. 26% of rounds had some kind of conversion antag. Revolution being 3x more common than other MRP servers.

## Technical details
Removed 10% of revolution gamemode chances and spread the chances among Survival (+6%), Cosmic cult (+2%), and Changeling (+2%)

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
Reduced frequency of Revolution