### PR TITLE
Removes sunglasses, combat gloves, and one medkit from the Salvage shuttle

### DIFF
--- a/Resources/Maps/Shuttles/mining.yml
+++ b/Resources/Maps/Shuttles/mining.yml
@@ -1022,7 +1022,6 @@ entities:
           ents:
           - 105
           - 102
-          - 103
           - 108
           - 109
           - 106
@@ -1032,46 +1031,6 @@ entities:
     - type: Physics
       angularDamping: 0
       linearDamping: 0
-- proto: ClothingEyesGlassesMercenary
-  entities:
-  - uid: 110
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -4.556146,0.61211896
-      parent: 1
-  - uid: 111
-    components:
-    - type: Transform
-      pos: -5.040521,-2.4816308
-      parent: 1
-- proto: ClothingHandsMercGlovesCombat
-  entities:
-  - uid: 112
-    components:
-    - type: Transform
-      pos: -5.009271,-2.8722558
-      parent: 1
-  - uid: 113
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -3.9155211,-1.294131
-      parent: 1
-  - uid: 114
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -5.071771,0.58086896
-      parent: 1
-- proto: ClothingShoesBootsMercFilled
-  entities:
-  - uid: 115
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: -4.487769,-1.3110876
-      parent: 1
 - proto: ComfyChair
   entities:
   - uid: 116
@@ -1544,30 +1503,9 @@ entities:
         192:
         - - Pressed
           - Toggle
-- proto: MedkitCombat
-  entities:
-  - uid: 172
-    components:
-    - type: Transform
-      pos: -1.695888,0.31600714
-      parent: 1
-    - type: CollisionWake
-      enabled: False
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-    - type: Conveyed
 - proto: MedkitFilled
   entities:
   - uid: 102
-    components:
-    - type: Transform
-      parent: 100
-    - type: Physics
-      angularDamping: 0
-      linearDamping: 0
-      canCollide: False
-  - uid: 103
     components:
     - type: Transform
       parent: 100
@@ -1633,34 +1571,6 @@ entities:
     components:
     - type: Transform
       pos: 0.5,-0.5
-      parent: 1
-- proto: PlushieCarp
-  entities:
-  - uid: 175
-    components:
-    - type: Transform
-      pos: -4.227768,-4.1683164
-      parent: 1
-- proto: PlushieHolocarp
-  entities:
-  - uid: 176
-    components:
-    - type: Transform
-      pos: -3.4606028,2.4596853
-      parent: 1
-- proto: PlushieMagicarp
-  entities:
-  - uid: 177
-    components:
-    - type: Transform
-      pos: -4.5001245,2.3815603
-      parent: 1
-- proto: PlushieRainbowCarp
-  entities:
-  - uid: 178
-    components:
-    - type: Transform
-      pos: -2.536034,5.40928
       parent: 1
 - proto: PowerCellMediumPrinted
   entities:


### PR DESCRIPTION

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Removed free sunglasses, free combat gloves (insuls), and one medkit pre-mapped into the Salvage shuttle.
It still has the 3 holoflare pistols, jetpack, 1 medkit, and the handheld mass scanner.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Access roundstart to very powerful items (flash protection and full shock protection) should be reserved for the departments that should mainly be interacting with those mechanics (Security and Engineering respectively for examples.)

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
![image](https://github.com/user-attachments/assets/7597b098-dffd-4d33-ba89-4e16f65262d4)

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Miiish
- remove: Removes sunglasses, combat gloves, and 1 medkit from the Salvage shuttle.
