### PR TITLE
I :heart: :man_cook: :fire: :+1: :pray:

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
@@ -4,7 +4,7 @@
     sprite: Objects/Consumable/Food/Baked/pizza.rsi
     state: margherita-slice
   product: CrateFoodPizza
-  cost: 450
+  cost: 4000
   category: cargoproduct-category-name-food
   group: market
 
@@ -14,7 +14,7 @@
     sprite: Objects/Consumable/Food/Baked/pizza.rsi
     state: margherita
   product: CrateFoodPizzaLarge
-  cost: 1800
+  cost: 16000
   category: cargoproduct-category-name-food
   group: market
 
@@ -24,7 +24,7 @@
     sprite: Objects/Consumable/Food/snacks.rsi
     state: nutribrick
   product: CrateFoodMRE
-  cost: 1000
+  cost: 4500
   category: cargoproduct-category-name-food
   group: market
 
@@ -64,7 +64,7 @@
     sprite: Objects/Consumable/Drinks/cola.rsi
     state: icon
   product: CrateFoodSoftdrinks
-  cost: 1200
+  cost: 4000
   category: cargoproduct-category-name-food
   group: market
 
@@ -74,7 +74,7 @@
     sprite: Objects/Consumable/Drinks/colabottle.rsi
     state: icon
   product: CrateFoodSoftdrinksLarge
-  cost: 2400
+  cost: 10000
   category: cargoproduct-category-name-food
   group: market
 
@@ -86,6 +86,6 @@
     sprite: Objects/Consumable/Food/Baked/donkpocket.rsi
     state: plain
   product: CrateFoodRandomDonkPocket
-  cost: 1000
+  cost: 2000
   category: cargoproduct-category-name-food
   group: market

--- a/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_food.yml
@@ -64,7 +64,7 @@
     sprite: Objects/Consumable/Drinks/cola.rsi
     state: icon
   product: CrateFoodSoftdrinks
-  cost: 4000
+  cost: 3500
   category: cargoproduct-category-name-food
   group: market
 
@@ -74,7 +74,7 @@
     sprite: Objects/Consumable/Drinks/colabottle.rsi
     state: icon
   product: CrateFoodSoftdrinksLarge
-  cost: 10000
+  cost: 6750
   category: cargoproduct-category-name-food
   group: market
 
@@ -86,6 +86,6 @@
     sprite: Objects/Consumable/Food/Baked/donkpocket.rsi
     state: plain
   product: CrateFoodRandomDonkPocket
-  cost: 2000
+  cost: 1500
   category: cargoproduct-category-name-food
   group: market


### PR DESCRIPTION
## About the PR
I increased the prices for pre-prepared food and drinks from the request computer.

## Why / Balance
As the prices currently are, people (including cargo (and salv)) can just buy food, and completely ignore the chef. While they can still buy food, they have to earn that pizza party with fundraisers now :fire: 

## Technical details
Oh holiest YAML paladin Miiiiiiish(@DevilishMilk), I took it upon mineself to follow in your holy path, and edited the YAMLs to suit my needs!

## Media
![image](https://github.com/user-attachments/assets/3a232565-0728-4ba1-95ad-77e97efd9757)


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl: amethystowo
- tweak: Increased pre-prepared food and drink prices. Get to fundraising for that pizza party!
