### PR TITLE
Add 'soloing' to chatbox filter checkboxes

### DIFF
--- a/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterCheckbox.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterCheckbox.cs
@@ -1,5 +1,7 @@
 ﻿using Content.Shared.Chat;
+using Robust.Client.UserInterface;
 using Robust.Client.UserInterface.Controls;
+using Robust.Shared.Input;
 
 namespace Content.Client.UserInterface.Systems.Chat.Controls;
 
@@ -8,6 +10,8 @@ public sealed class ChannelFilterCheckbox : CheckBox
     public readonly ChatChannel Channel;
 
     public bool IsHidden => Parent == null;
+
+    public event Action<ChannelFilterCheckbox>? OnRightClicked;
 
     public ChannelFilterCheckbox(ChatChannel channel)
     {
@@ -29,5 +33,12 @@ public sealed class ChannelFilterCheckbox : CheckBox
     public void UpdateUnreadCount(int? unread)
     {
         UpdateText(unread);
+    }
+
+    protected override void KeyBindDown(GUIBoundKeyEventArgs args)
+    {
+        base.KeyBindDown(args);
+        if (args.Function == EngineKeyFunctions.UIRightClick)
+            OnRightClicked?.Invoke(this);
     }
 }

--- a/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.xaml.cs
+++ b/Content.Client/UserInterface/Systems/Chat/Controls/ChannelFilterPopup.xaml.cs
@@ -92,6 +92,7 @@ public sealed partial class ChannelFilterPopup : Popup
                 checkbox = new ChannelFilterCheckbox(channel);
                 _filterStates.Add(channel, checkbox);
                 checkbox.OnPressed += CheckboxPressed;
+                checkbox.OnRightClicked += CheckboxSolo;
                 checkbox.Pressed = true;
             }
 
@@ -118,6 +119,28 @@ public sealed partial class ChannelFilterPopup : Popup
     {
         var checkbox = (ChannelFilterCheckbox) args.Button;
         OnChannelFilter?.Invoke(checkbox.Channel, checkbox.Pressed);
+    }
+
+    private void CheckboxSolo(ChannelFilterCheckbox checkbox)
+    {
+        // Assume they are all inactive until proven otherwise.
+        var allOthersInactive = true;
+
+        foreach (var channel in ChannelFilterOrder)
+        {
+            if (channel == checkbox.Channel)
+                continue;
+
+            if (IsActive(channel))
+                allOthersInactive = false;
+        }
+
+        // If we right click on this checkbox and it is already solo'd
+        // we set them all back to active,  way to quickly "undo" the soloing of the checkbox.
+        foreach (var channel in ChannelFilterOrder)
+            SetActive(channel, allOthersInactive);
+
+        SetActive(checkbox.Channel, true);
     }
 
     private void HighlightsEntered(ButtonEventArgs _args)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Adds the ability to right click and 'solo' a filter in the chatbox. It leaves that which you right clicked active, and disables all the other ones. You can undo it if you right-click it again while all the other channels are inactive. (If you have solo'd a channel and enabled a few others you can just right click any checkbox twice to re-enable all the channels and un-solo it).

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Because it is annoying doing it manually as a player and especially as an admin.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
https://github.com/user-attachments/assets/00a5ff92-5a3a-4e05-ad71-0a9b4e7ad48e

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->




**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

Let me know if you want a changelog entry for this.
