### PR TITLE
Funking up Wizard

### DIFF
--- a/Resources/Prototypes/Catalog/spellbook_catalog.yml
+++ b/Resources/Prototypes/Catalog/spellbook_catalog.yml
@@ -273,40 +273,39 @@
   description: spellbook-event-summon-ghosts-description
   productAction: ActionSummonGhosts
   cost:
-    WizCoin: 2 #Funky: Making this cost wizcoins, so people have to want ghosts to buy it.
+    WizCoin: 1 #Funky: Making this cost a wizcoin, so a wizard that wants ghosts has to invest something to get ghosts
   categories:
   - SpellbookEvents
   conditions:
   - !type:ListingLimitedStockCondition
     stock: 1
 
-#Funky: Disabling this spell
-#- type: listing
-#  id: SpellbookEventSummonGuns
-#  name: spellbook-event-summon-guns-name
-#  description: spellbook-event-summon-guns-description
-#  productAction: ActionSummonGuns
-#  cost:
-#    WizCoin: 2
-#  categories:
-#  - SpellbookEvents
-#  conditions:
-#  - !type:ListingLimitedStockCondition
-#    stock: 1
+- type: listing
+  id: SpellbookEventSummonGuns
+  name: spellbook-event-summon-guns-name
+  description: spellbook-event-summon-guns-description
+  productAction: ActionSummonGuns
+  cost:
+    WizCoin: 2
+  categories:
+  - SpellbookEvents
+  conditions:
+  - !type:ListingLimitedStockCondition
+    stock: 1
 
-#Funky: Disabling this spell
-#- type: listing
-#  id: SpellbookEventSummonMagic
-#  name: spellbook-event-summon-magic-name
-#  description: spellbook-event-summon-magic-description
-#  productAction: ActionSummonMagic
-#  cost:
-#    WizCoin: 2
-#  categories:
-#  - SpellbookEvents
-#  conditions:
-#  - !type:ListingLimitedStockCondition
-#    stock: 1
+Funky: Disabling this spell
+- type: listing
+  id: SpellbookEventSummonMagic
+  name: spellbook-event-summon-magic-name
+  description: spellbook-event-summon-magic-description
+  productAction: ActionSummonMagic
+  cost:
+    WizCoin: 2
+  categories:
+  - SpellbookEvents
+  conditions:
+  - !type:ListingLimitedStockCondition
+    stock: 1
 
 # Upgrades
 - type: listing

--- a/Resources/Prototypes/Catalog/spellbook_catalog.yml
+++ b/Resources/Prototypes/Catalog/spellbook_catalog.yml
@@ -13,18 +13,19 @@
   - !type:ListingLimitedStockCondition
     stock: 1
 
-- type: listing
-  id: SpellbookRodForm
-  name: spellbook-polymorph-rod-name
-  description: spellbook-polymorph-rod-desc
-  productAction: ActionPolymorphWizardRod
-  cost:
-    WizCoin: 3
-  categories:
-  - SpellbookOffensive
-  conditions:
-  - !type:ListingLimitedStockCondition
-    stock: 1
+#Funky: Disabling this spell
+#- type: listing
+#  id: SpellbookRodForm
+#  name: spellbook-polymorph-rod-name
+#  description: spellbook-polymorph-rod-desc
+#  productAction: ActionPolymorphWizardRod
+#  cost:
+#    WizCoin: 3
+#  categories:
+#  - SpellbookOffensive
+#  conditions:
+#  - !type:ListingLimitedStockCondition
+#    stock: 1
 
 - type: listing
   id: SpellbookSmite
@@ -272,38 +273,40 @@
   description: spellbook-event-summon-ghosts-description
   productAction: ActionSummonGhosts
   cost:
-    WizCoin: 0
+    WizCoin: 2 #Funky: Making this cost wizcoins, so people have to want ghosts to buy it.
   categories:
   - SpellbookEvents
   conditions:
   - !type:ListingLimitedStockCondition
     stock: 1
 
-- type: listing
-  id: SpellbookEventSummonGuns
-  name: spellbook-event-summon-guns-name
-  description: spellbook-event-summon-guns-description
-  productAction: ActionSummonGuns
-  cost:
-    WizCoin: 2
-  categories:
-  - SpellbookEvents
-  conditions:
-  - !type:ListingLimitedStockCondition
-    stock: 1
+#Funky: Disabling this spell
+#- type: listing
+#  id: SpellbookEventSummonGuns
+#  name: spellbook-event-summon-guns-name
+#  description: spellbook-event-summon-guns-description
+#  productAction: ActionSummonGuns
+#  cost:
+#    WizCoin: 2
+#  categories:
+#  - SpellbookEvents
+#  conditions:
+#  - !type:ListingLimitedStockCondition
+#    stock: 1
 
-- type: listing
-  id: SpellbookEventSummonMagic
-  name: spellbook-event-summon-magic-name
-  description: spellbook-event-summon-magic-description
-  productAction: ActionSummonMagic
-  cost:
-    WizCoin: 2
-  categories:
-  - SpellbookEvents
-  conditions:
-  - !type:ListingLimitedStockCondition
-    stock: 1
+#Funky: Disabling this spell
+#- type: listing
+#  id: SpellbookEventSummonMagic
+#  name: spellbook-event-summon-magic-name
+#  description: spellbook-event-summon-magic-description
+#  productAction: ActionSummonMagic
+#  cost:
+#    WizCoin: 2
+#  categories:
+#  - SpellbookEvents
+#  conditions:
+#  - !type:ListingLimitedStockCondition
+#    stock: 1
 
 # Upgrades
 - type: listing

--- a/Resources/Prototypes/Catalog/spellbook_catalog.yml
+++ b/Resources/Prototypes/Catalog/spellbook_catalog.yml
@@ -13,20 +13,6 @@
   - !type:ListingLimitedStockCondition
     stock: 1
 
-#Funky: Disabling this spell
-#- type: listing
-#  id: SpellbookRodForm
-#  name: spellbook-polymorph-rod-name
-#  description: spellbook-polymorph-rod-desc
-#  productAction: ActionPolymorphWizardRod
-#  cost:
-#    WizCoin: 3
-#  categories:
-#  - SpellbookOffensive
-#  conditions:
-#  - !type:ListingLimitedStockCondition
-#    stock: 1
-
 - type: listing
   id: SpellbookSmite
   name: spellbook-smite-name
@@ -187,6 +173,19 @@
   - !type:ListingLimitedStockCondition
     stock: 1
 
+- type: listing
+  id: SpellbookMindSwap
+  name: spellbook-mind-swap-name
+  description: spellbook-mind-swap-description
+  productAction: ActionMindSwap
+  cost:
+    WizCoin: 2
+  categories:
+  - SpellbookUtility
+  conditions:
+  - !type:ListingLimitedStockCondition
+    stock: 1                       
+    
 # Equipment
 - type: listing
   id: SpellbookWandDoor
@@ -293,7 +292,6 @@
   - !type:ListingLimitedStockCondition
     stock: 1
 
-Funky: Disabling this spell
 - type: listing
   id: SpellbookEventSummonMagic
   name: spellbook-event-summon-magic-name

--- a/Resources/Prototypes/Magic/event_spells.yml
+++ b/Resources/Prototypes/Magic/event_spells.yml
@@ -20,13 +20,13 @@
   components:
   - type: Magic
   - type: InstantAction
-    useDelay: 300
+    useDelay: 600 #Funky: Doubling delay on more guns
     itemIconStyle: BigAction
     icon:
       sprite: Objects/Weapons/Guns/Rifles/ak.rsi
       state: base
     event: !type:RandomGlobalSpawnSpellEvent
-      #makeSurvivorAntagonist: true #Funky: Disabling survivor antagonist
+      makeSurvivorAntagonist: false #Funky: Disabling survivor antagonist
       spawns:
       - id: WeaponPistolViper
         orGroup: Guns
@@ -179,13 +179,13 @@
   components:
   - type: Magic
   - type: InstantAction
-    useDelay: 300
+    useDelay: 600 #Funky: Doubling delay on more magic items
     itemIconStyle: BigAction
     icon:
       sprite: Objects/Magic/magicactions.rsi
       state: magicmissile
     event: !type:RandomGlobalSpawnSpellEvent
-      #makeSurvivorAntagonist: true #Funky: Disabling survivor antagonist
+      makeSurvivorAntagonist: false #Funky: Disabling survivor antagonist
       spawns:
       - id: SpawnSpellbook
         orGroup: Magics

--- a/Resources/Prototypes/Magic/event_spells.yml
+++ b/Resources/Prototypes/Magic/event_spells.yml
@@ -26,7 +26,7 @@
       sprite: Objects/Weapons/Guns/Rifles/ak.rsi
       state: base
     event: !type:RandomGlobalSpawnSpellEvent
-      makeSurvivorAntagonist: true
+      #makeSurvivorAntagonist: true #Funky: Disabling survivor antagonist
       spawns:
       - id: WeaponPistolViper
         orGroup: Guns
@@ -48,8 +48,8 @@
         orGroup: Guns
       - id: WeaponRifleAk
         orGroup: Guns
-      - id: WeaponRifleM90GrenadeLauncher
-        orGroup: Guns
+      #- id: WeaponRifleM90GrenadeLauncher #Funky: Extremely likely to destroy the station
+      #  orGroup: Guns
       - id: WeaponRifleLecter
         orGroup: Guns
       - id: WeaponShotgunBulldog
@@ -84,10 +84,10 @@
         orGroup: Guns
       - id: WeaponPistolFlintlock
         orGroup: Guns
-      - id: WeaponLauncherChinaLake
-        orGroup: Guns
-      - id: WeaponLauncherRocket
-        orGroup: Guns
+      #- id: WeaponLauncherChinaLake #Funky: Extremely likely to destroy the station
+      #  orGroup: Guns
+      #- id: WeaponLauncherRocket #Funky: Extremely likely to destroy the station
+      #  orGroup: Guns
       - id: WeaponLauncherPirateCannon
         orGroup: Guns
       - id: WeaponTetherGun
@@ -158,6 +158,18 @@
         orGroup: Guns
       - id: RevolverCapGunFake
         orGroup: Guns
+      - id: WeaponRevolverHristov #Funky
+        orGroup: Guns
+      - id: WeaponRifleFoam #Funky
+        orGroup: Guns
+      - id: BowHardlight #Funky
+        orGroup: Guns
+      - id: MiniatureEnergyCrossbow #Funky
+        orGroup: Guns
+      - id: WeaponPlasmaRifle #Funky
+        orGroup: Guns
+      - id: WeaponEnergyRevolver #Funky
+        orGroup: Guns        
       speech: action-speech-spell-summon-guns
 
 - type: entity
@@ -173,7 +185,7 @@
       sprite: Objects/Magic/magicactions.rsi
       state: magicmissile
     event: !type:RandomGlobalSpawnSpellEvent
-      makeSurvivorAntagonist: true
+      #makeSurvivorAntagonist: true #Funky: Disabling survivor antagonist
       spawns:
       - id: SpawnSpellbook
         orGroup: Magics
@@ -183,18 +195,18 @@
         orGroup: Magics
       - id: KnockSpellbook
         orGroup: Magics
-      - id: FireballSpellbook
-        orGroup: Magics
+      #- id: FireballSpellbook #Funky: Extremely likely to destroy the station
+      #  orGroup: Magics
       - id: WeaponWandPolymorphCarp
         orGroup: Magics
       - id: WeaponWandPolymorphMonkey
         orGroup: Magics
-      - id: WeaponWandFireball
-        orGroup: Magics
+      #- id: WeaponWandFireball #Funky: Extremely likely to destroy the station
+      #  orGroup: Magics
       - id: WeaponWandPolymorphDoor
         orGroup: Magics
-      - id: WeaponWandCluwne
-        orGroup: Magics
+      #- id: WeaponWandCluwne # Funky: Disabling instant kill spells
+      #  orGroup: Magics
       - id: WeaponWandPolymorphBread
         orGroup: Magics
       - id: WeaponStaffHealing


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Removed Rod from wizard's spellbook, and changed summon spells for Funky. Now both summon-guns and summon-magic will not make players free agents. Also added new unique funky guns to the gun pools, and removed station-destroying effects from both pools (no explosives like china-lake or fireball) and instakill effects. Hopefully makes wizard into a state where we can re-add it to the gamemode pool (as a separate PR).

## Why / Balance
Making Wizard more MRP friendly

## Technical details
Commented out some lines, added yml for the new guns, and flipped a true to a false for the make-antag flag.
Also added the Mind Swap spell that was added to Wizden after our last merge, we have the back-end code for it to work, so why not?

## Media
Casting Summon Guns, did not make 2nd connected user into an antag. Same for summon magic.
![image](https://github.com/user-attachments/assets/9f2fcb1a-a47f-4ac2-8afb-00f967b47e1a)

Rod spell removed
![image](https://github.com/user-attachments/assets/ce9ac05e-f850-4404-a930-be969e717da6)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A

**Changelog**
:cl:
- remove: Removed Rod from Wizard Spells
- added: Added Mindswap spell to Wizard
- tweak: Wizard Spells no longer make players free agents
