### PR TITLE
Add radiation healing to vodka

### DIFF
--- a/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
+++ b/Resources/Prototypes/Reagents/Consumable/Drink/alcohol.yml
@@ -229,6 +229,10 @@
       - !type:AdjustReagent
         reagent: Ethanol
         amount: 0.2
+      - !type:HealthChange
+        damage:
+          types:
+            Radiation: -1.0    
 
 - type: reagent
   id: CoffeeLiqueur


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Vodka now heals 1 radiation damage per 1u metabolized.

## Why / Balance
Radiation crates and closets already contain vodka as a STALKER reference, might as well go all the way. New way for engis to work off that 30-40 radiation damage from the SM or singu without walking all the way to medbay. Still a worse option than actual medicine. Drunk atmos techs make for funny roleplay,

## Technical details
YAML changes only. Added !type:HealthChange to vodka in alcohol.yml.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Added radiation healing to vodka
