### PR TITLE
:boom: :cat: :boom: :bird: 

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/felinid.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Mobs/Species/felinid.yml
@@ -91,6 +91,7 @@
     - FootstepSound
     - DoorBumpOpener
     - FelinidEmotes
+    - AnomalyHost
 
 - type: entity
   save: false

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/harpy.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/harpy.yml
@@ -160,6 +160,7 @@
     - FootstepSound
     - DoorBumpOpener
     - HarpyEmotes
+    - AnomalyHost
   - type: StepTriggerImmune
     whitelist:
       types:


### PR DESCRIPTION
## About the PR
I added the AnomalyHost tag to felinids and harpies to fix a bug where they could not be infected with an anomaly. While I have not tested this, there's no reason this fix should not work.

## Why / Balance
Fixing bugs is good :godo:.

## Technical details
I added the AnomalyHost tag to felinid.yml and harpy.yml

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl: amethystowo
- fix: Fixed a bug where felinids and harpies could not become the host of infection anomalies.
