### PR TITLE
Cooling down the void heretic a bit

### DIFF
--- a/Content.Server/_Goobstation/Heretic/Abilities/HereticAbilitySystem.Void.cs
+++ b/Content.Server/_Goobstation/Heretic/Abilities/HereticAbilitySystem.Void.cs
@@ -77,7 +77,7 @@ public sealed partial class HereticAbilitySystem : EntitySystem
             _stun.TryKnockdown(pookie, TimeSpan.FromSeconds(2f), true);
 
             if (TryComp<TemperatureComponent>(pookie, out var temp))
-                _temperature.ForceChangeTemperature(pookie, temp.CurrentTemperature - 50f, temp);
+                _temperature.ForceChangeTemperature(pookie, temp.CurrentTemperature - 25f, temp);
 
             if (TryComp<DamageableComponent>(pookie, out var damage))
             {
@@ -97,7 +97,7 @@ public sealed partial class HereticAbilitySystem : EntitySystem
             _stun.TryKnockdown(pookie, TimeSpan.FromSeconds(2f), true);
 
             if (TryComp<TemperatureComponent>(pookie, out var temp))
-                _temperature.ForceChangeTemperature(pookie, temp.CurrentTemperature - 60f, temp);
+                _temperature.ForceChangeTemperature(pookie, temp.CurrentTemperature - 25f, temp);
 
             if (TryComp<DamageableComponent>(pookie, out var damage))
             {
@@ -123,7 +123,7 @@ public sealed partial class HereticAbilitySystem : EntitySystem
         foreach (var pookie in topPriority)
         {
             if (TryComp<TemperatureComponent>(pookie, out var temp))
-                _temperature.ForceChangeTemperature(pookie, temp.CurrentTemperature - 100f, temp);
+                _temperature.ForceChangeTemperature(pookie, temp.CurrentTemperature - 50f, temp);
 
             if (TryComp<DamageableComponent>(pookie, out var damage))
             {
@@ -137,7 +137,7 @@ public sealed partial class HereticAbilitySystem : EntitySystem
         foreach (var pookie in midPriority)
         {
             if (TryComp<TemperatureComponent>(pookie, out var temp))
-                _temperature.ForceChangeTemperature(pookie, temp.CurrentTemperature - 60f, temp);
+                _temperature.ForceChangeTemperature(pookie, temp.CurrentTemperature - 30f, temp);
 
             if (TryComp<DamageableComponent>(pookie, out var damage))
             {

--- a/Content.Server/_Goobstation/Heretic/EntitySystems/AristocratSystem.cs
+++ b/Content.Server/_Goobstation/Heretic/EntitySystems/AristocratSystem.cs
@@ -53,7 +53,7 @@ public sealed partial class AristocratSystem : EntitySystem
         if (mix != null)
         {
             mix.Temperature -= 500f;
-            mix.RemoveRatio(0.5f);
+            mix.RemoveRatio(0.75f);
         }
 
         // replace certain things with their winter analogue

--- a/Content.Server/_Goobstation/Heretic/EntitySystems/MansusGraspSystem.cs
+++ b/Content.Server/_Goobstation/Heretic/EntitySystems/MansusGraspSystem.cs
@@ -84,7 +84,7 @@ public sealed partial class MansusGraspSystem : EntitySystem
 
             case "Void":
                 if (TryComp<TemperatureComponent>(target, out var temp))
-                    _temperature.ForceChangeTemperature(target, temp.CurrentTemperature - 200f, temp);
+                    _temperature.ForceChangeTemperature(target, temp.CurrentTemperature - 100f, temp);
                 _statusEffect.TryAddStatusEffect<MutedComponent>(target, "Muted", TimeSpan.FromSeconds(8), false);
                 break;
 

--- a/Content.Server/_Goobstation/Magic/ImmovableVoidRodSystem.cs
+++ b/Content.Server/_Goobstation/Magic/ImmovableVoidRodSystem.cs
@@ -68,7 +68,7 @@ public sealed partial class ImmovableVoidRodSystem : EntitySystem
         //This is a certified Funkystation addition :fire:
 
         if (TryComp<TemperatureComponent>(args.OtherEntity, out var temp))
-            _temperature.ForceChangeTemperature(args.OtherEntity, temp.CurrentTemperature - 70f, temp);
+            _temperature.ForceChangeTemperature(args.OtherEntity, temp.CurrentTemperature - 35f, temp);
 
         if (TryComp<DamageableComponent>(args.OtherEntity, out var damage))
         {


### PR DESCRIPTION
## About the PR
I halved all the temperature decreases on the void heretic's attacks. I also increased the amount of air removed when they ascend by a moderate amount.

## Why / Balance
This will hopefully make void a bit less grossly overpowered. That, or this will expose all new issues with void. Who knows! Development is exciting!

## Technical details
Edited float values in a handful of CS files.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- 
**Changelog**
:cl: amethystowo
- tweak: Reduced the temperature decrease on the Void Heretic's abilities by about half.
