### PR TITLE
Down_with_the_revolution

### DIFF
--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -5,10 +5,11 @@
     Changeling: 0.03 # Goobstation unique antag
     Traitorling: 0.12 # 2 antags but less of each type applies for all hybrid modes, they all need 30 pop. Also makes lower pops roll more traitor games.
     Nukeops: 0.15
-    Revolutionary: 0.15 # Maybe 0.08 after wiz/cult?
-    Survival: 0.04 # funky hi im putting something here because everything else has a comment
+    Wizard: 0.05 # funky turning wizard back on
+    Revolutionary: 0.05 # funky from 0.15 to 0.05 after cult and wizard
+    Survival: 0.05 # funky hi im putting something here because everything else has a comment
     Blob: 0.05 #funky Blobmode
     BlobTraitor: 0.1 #funky Blobmode
-    CosmicCult: 0.11
+    CosmicCult: 0.15
 
 


### PR DESCRIPTION
Reduced revolutionaries by 10% and added 5% to wizard, 4% to cosmic cult, and 1% to survival so all game modes are even 5% ratios.

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Reduced revolution, and added 5% to the now functional Wizard game mode, as well as 4% to cosmic cult and 1% to survival so the odds of each game mode now all evenly end in 5s. 

## Why / Balance
Revolution is the least liked and least feature-complete game mode. Since wizard now works on Funky, and shouldn't be as round-breaking as it was previously, we can try to experiment with the occasional wizard again.

## Technical details
Just updating secret weights.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
- add: Added Wizard game mode back to the game mode pool
- tweak: Reduced odds of revolution game mode
