### PR TITLE
mapping changeloge

### DIFF
--- a/Resources/Changelog/Admin.yml
+++ b/Resources/Changelog/Admin.yml
@@ -1039,4 +1039,4 @@ Entries:
   time: '2025-04-14T15:37:59.0000000+00:00'
   url: https://github.com/space-wizards/space-station-14/pull/33548
 Name: Admin
-Order: 1
+Order: 2

--- a/Resources/Changelog/Maps.yml
+++ b/Resources/Changelog/Maps.yml
@@ -1,0 +1,9 @@
+﻿Order: 1
+Entries:
+- author: ArtisticRoomba
+  changes:
+  - message: The mapping changelog has been added! This primarily serves as a way to make players aware of large changes or important fixes to maps, without cluttering the main changelog.
+    type: Add
+  id: 1
+  time: '2025-02-03T01:29:24.112Z'
+

--- a/Resources/Locale/en-US/changelog/changelog-window.ftl
+++ b/Resources/Locale/en-US/changelog/changelog-window.ftl
@@ -14,3 +14,4 @@ changelog-button-new-entries = Changelog (new!)
 changelog-tab-title-Changelog = Changelog
 changelog-tab-title-Admin = Admin
 changelog-tab-title-Funkylog = Funkylog
+changelog-tab-title-Maps = Maps


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->

support for multiple cls is already there, just needed to add the yml file itself. it *should* work without editing the bot at all? im not sure cuz ive never fucked with it 

add `ADMIN:` or `MAPS:` under the cl emote to designate which cl it goes to. probably also works with gooblog....? `GOOBCHANGELOG:` ?? idk

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
MAPS: 
- add: Added fun! 
