### PR TITLE
Magistrate PDA sprite fix

### DIFF
--- a/Resources/Prototypes/_Funkystation/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Objects/Devices/pda.yml
@@ -14,6 +14,11 @@
       whitelist:
         tags:
         - Write
+  - type: Appearance
+    appearanceDataInit:
+      enum.PdaVisuals.PdaType:
+        !type:String
+        pda-iaa
   - type: PdaBorderColor
     borderColor: "#6f6192"
   - type: Icon
@@ -36,6 +41,11 @@
       whitelist:
         tags:
         - Write
+  - type: Appearance
+    appearanceDataInit:
+      enum.PdaVisuals.PdaType:
+        !type:String
+        pda-magi
   - type: PdaBorderColor
     borderColor: "#6f6192"
   - type: Icon


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Fixes the magistrate PDA sprite

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Currently, it falls back to the IAA PDA sprite as the current pda fallback sprite is the IAA pda.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Miiish
- fix: Fixed the magistrate's PDA appearance.