### PR TITLE
Fix cluwne IPC test fails

### DIFF
--- a/Content.Server/Administration/Commands/SetOutfitCommand.cs
+++ b/Content.Server/Administration/Commands/SetOutfitCommand.cs
@@ -168,7 +168,7 @@ namespace Content.Server.Administration.Commands
 
             if (entityManager.HasComponent<EncryptionKeyHolderComponent>(target))
             {
-                var encryption = new InternalEncryptionKeySpawner();
+                var encryption = entityManager.System<InternalEncryptionKeySpawner>();
                 encryption.TryInsertEncryptionKey(target, startingGear, entityManager);
             }
             


### PR DESCRIPTION
## About the PR
After doing an archaeological exploration of the fucking `SpawnAndDeleteAllEntities` test fail, I eventually tracked down the bug to an issue where `InternalEncryptionKeySpawner` was being Created Anew Every Time instead of being Accessed Properly. The actual `InternalEncryptionKeySpawner` system factually must be accessed via `entityManager.System<T>()`, avoiding a dumbass scenario where `EntityManager` turns up null in the middle of calling `TryInsertEncryptionKey`.

Fixes #1037.

## Why / Balance
💩🧹

## Technical details
💩💩💩💩🧹

Yes, I checked if this worked by spawning a fuckton of cluwnes and by manually setting assorted outfits on an IPC and prying the keys to see what went in.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
no cl no fun
