### PR TITLE
Kills the Throngler Plushie

### DIFF
--- a/Resources/Maps/_Harmony/centcomm.yml
+++ b/Resources/Maps/_Harmony/centcomm.yml
@@ -32763,13 +32763,6 @@ entities:
     - type: Transform
       pos: 53.483402,34.619392
       parent: 1
-- proto: PlushieThrongler
-  entities:
-  - uid: 2572
-    components:
-    - type: Transform
-      pos: 59.594227,19.558416
-      parent: 1
 - proto: PortableGeneratorJrPacman
   entities:
   - uid: 2758

--- a/Resources/Prototypes/_Goobstation/Mail/mailDeliveries.yml
+++ b/Resources/Prototypes/_Goobstation/Mail/mailDeliveries.yml
@@ -39,7 +39,7 @@
     MailPlushie: 0.9
     MailNFVagueThreat: 0.45
     MailFigurines: 0.9
-    MailPlushieThrongler: 0.1
+    MailPlushieThrongler: 0.01 # funky - I HATE YOU I HATE YOU I HATE YOU I HATE YOU
     MailInstrumentSmall: 0.9
     MailCritters: 0.5
     MailFlowers: 0.8


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
Removes the Plushie Throngler from CentComm; makes it 10x as rare as it currently is through mail.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I hate fun.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Miiish
- remove: Removed the throngler plushie from CentComm