### PR TITLE
Fix cryoxadone on plants causing plants to stop fruiting

### DIFF
--- a/Content.Server/EntityEffects/Effects/PlantMetabolism/PlantCryoxadone.cs
+++ b/Content.Server/EntityEffects/Effects/PlantMetabolism/PlantCryoxadone.cs
@@ -24,6 +24,7 @@ public sealed partial class PlantCryoxadone : EntityEffect
         else
             deviation = (int) (seed.Maturation / seed.GrowthStages);
         plantHolderComp.Age -= deviation;
+        plantHolderComp.LastProduce = plantHolderComp.Age;
         plantHolderComp.SkipAging++;
         plantHolderComp.ForceUpdate = true;
     }


### PR DESCRIPTION
## About the PR
Cryoxadone will no longer prevent plants from producing fruit when expected if they were de-aged later in their life cycle.

(This fixes #1150.)

## Why / Balance
🌱

## Technical details
This just sets LastProduce to the resulting Age of the plant. This is 1:1 with Wizden code on the same matter.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Cryoxadone no longer causes plants to cease fruiting in certain circumstances.
