### PR TITLE
Ports showing TEG theoretical supply on inspect from Wizden

### DIFF
--- a/Content.Server/Power/Generation/Teg/TegSystem.cs
+++ b/Content.Server/Power/Generation/Teg/TegSystem.cs
@@ -96,7 +96,12 @@ public sealed class TegSystem : EntitySystem
         else
         {
             var supplier = Comp<PowerSupplierComponent>(uid);
-            args.PushMarkup(Loc.GetString("teg-generator-examine-power", ("power", supplier.CurrentSupply)));
+
+            using (args.PushGroup(nameof(TegGeneratorComponent)))
+            {
+                args.PushMarkup(Loc.GetString("teg-generator-examine-power", ("power", supplier.CurrentSupply)));
+                args.PushMarkup(Loc.GetString("teg-generator-examine-power-max-output", ("power", supplier.MaxSupply)));
+            }
         }
     }
 

--- a/Resources/Locale/en-US/power/teg.ftl
+++ b/Resources/Locale/en-US/power/teg.ftl
@@ -1,2 +1,3 @@
-﻿teg-generator-examine-power = It's generating [color=yellow]{ POWERWATTS($power) }[/color].
+﻿teg-generator-examine-power = It's currently supplying [color=yellow]{ POWERWATTS($power) }[/color].
+teg-generator-examine-power-max-output = It's capable of supplying [color=yellow]{ POWERWATTS($power) }[/color].
 teg-generator-examine-connection = To function, a [color=white]circulator[/color] must be attached on both sides.


### PR DESCRIPTION
## About the PR
One commit port (https://github.com/space-wizards/space-station-14/pull/37957). Simply adds a line to the TEG's inspect which shows theoretical supply.

## Why / Balance
Allows atmos techs to get better info on TEG supply, potentially allowing for better fine-tuning of gas inputs for optimization. See Wizden PR for a more in-depth look on the addition.

## Technical details
"We just use PushGroup to push info on the TEG's current max supply." - https://github.com/space-wizards/space-station-14/pull/37957

## Media
<img width="892" height="753" alt="image" src="https://github.com/user-attachments/assets/8a99b46e-44bf-4be1-bc1c-1d1bd9f454e2" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A

**Changelog**
:cl:
- add: The TEG now shows its capable peak power output on inspect, making it easier for engineers to match the TEG's power output with the current grid demand (to save fuel!).