### PR TITLE
Ports increased borg density from Wizden

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -25,7 +25,7 @@
         shape:
           !type:PhysShapeCircle
           radius: 0.35
-        density: 150
+        density: 300
         mask:
         - MobMask
         layer:


### PR DESCRIPTION
## About the PR
Ported https://github.com/space-wizards/space-station-14/pull/38232, which increased borg drag speeds.

## Why / Balance
"This was changed due to Borgs being extremely reliant on dragging, yet having a drag speed lower than that of a regular human, (in-between a dwarfs drag speed & a humans drag speed) making for a frustrating experience as several Borg types, when they were obligated to drag something (ie. crit crew, corpses, ordered to drag a heavy object) and had to spend several minutes moving at a snails-pace." - https://github.com/space-wizards/space-station-14/pull/38232

## Technical details
One-line yaml change.

## Media
N/A

See original PR if you wish to see relevant media.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A

**Changelog**
:cl:
- tweak: Increased borg drag speed, now equivalent to Diona speeds.
