### PR TITLE
Paradox Clone improvements: PDAs etc.

### DIFF
--- a/Content.Server/Cloning/CloningSystem.Subscriptions.cs
+++ b/Content.Server/Cloning/CloningSystem.Subscriptions.cs
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2025 GreyMaria <mariomister541@gmail.com>
 // SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
 // SPDX-FileCopyrightText: 2025 pa.pecherskij <pa.pecherskij@interfax.ru>
 // SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>

--- a/Content.Server/Cloning/CloningSystem.cs
+++ b/Content.Server/Cloning/CloningSystem.cs
@@ -130,7 +130,19 @@ public sealed partial class CloningSystem : EntitySystem
         var cloningEv = new Shared.Cloning.Events.CloningEvent(settings, clone.Value);
         RaiseLocalEvent(original, ref cloningEv); // used for datafields that cannot be directly copied
 
-        // Add equipment first so that SetEntityName also renames the ID card.
+        // funkystation: let's rename the clone first, since we're manually cloning ID and PDA names
+        var originalName = Name(original);
+        if (TryComp<NameModifierComponent>(original, out var nameModComp)) // if the originals name was modified, use the unmodified name
+            originalName = nameModComp.BaseName;
+
+        // This will properly set the BaseName and EntityName for the clone.
+        // Adding the component first before renaming will make sure RefreshNameModifers is called.
+        // Without this the name would get reverted to Urist.
+        // If the clone has no name modifiers, NameModifierComponent will be removed again.
+        EnsureComp<NameModifierComponent>(clone.Value);
+        _metaData.SetEntityName(clone.Value, originalName);
+
+        // funkystation: ok NOW let's copy equipment and such
         if (settings.CopyEquipment != null)
             CopyEquipment(original, clone.Value, settings.CopyEquipment.Value, settings.Whitelist, settings.Blacklist);
 
@@ -142,17 +154,6 @@ public sealed partial class CloningSystem : EntitySystem
         // copy implants and their storage contents
         if (settings.CopyImplants)
             CopyImplants(original, clone.Value, settings.CopyInternalStorage, settings.Whitelist, settings.Blacklist);
-
-        var originalName = Name(original);
-        if (TryComp<NameModifierComponent>(original, out var nameModComp)) // if the originals name was modified, use the unmodified name
-            originalName = nameModComp.BaseName;
-
-        // This will properly set the BaseName and EntityName for the clone.
-        // Adding the component first before renaming will make sure RefreshNameModifers is called.
-        // Without this the name would get reverted to Urist.
-        // If the clone has no name modifiers, NameModifierComponent will be removed again.
-        EnsureComp<NameModifierComponent>(clone.Value);
-        _metaData.SetEntityName(clone.Value, originalName);
 
         _adminLogger.Add(LogType.Chat, LogImpact.Medium, $"The body of {original:player} was cloned as {clone.Value:player}");
         return true;

--- a/Content.Server/Cloning/CloningSystem.cs
+++ b/Content.Server/Cloning/CloningSystem.cs
@@ -36,6 +36,7 @@
 // SPDX-FileCopyrightText: 2024 TemporalOroboros <TemporalOroboros@gmail.com>
 // SPDX-FileCopyrightText: 2024 gluesniffler <159397573+gluesniffler@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 GreyMaria <mariomister541@gmail.com>
 // SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
 // SPDX-FileCopyrightText: 2025 pa.pecherskij <pa.pecherskij@interfax.ru>
 // SPDX-FileCopyrightText: 2025 slarticodefast <161409025+slarticodefast@users.noreply.github.com>


### PR DESCRIPTION
## About the PR
More things have special cloning handling in CloningSystem! PDAs (and their contents) and ID cards (and their accesses and NanoChat ID number and chat history) get copied.

Fixes #1163.

## Why / Balance
less metagaming!!! wooo!!!

Also bringing the PDA cloning in line with the other "exact state of things" cloning is a good thing. Pushes it further and further toward social deduction.

## Technical details
Additional `CloningItemEvent` subscriptions were added to handle `IdCardComponent`, `AccessComponent`, `PdaComponent`, and `NanoChatCardComponent`. These items, if not properly set up, will result in differences that can out Paradox Clones.

The `NanoChatCardComponent` in particular copies the original's NanoChat card number, causing messages sent to the original to also be sent to the clone. The clone's NanoChat card is unlisted, preventing a duplicate entry in the NanoChat list. Message history is copied as well.

`CloningSystem.TryCloning` has been slightly rearranged to account for the fact that the code is now manually handling ID copying.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.


**Changelog**
:cl:
- tweak: Paradox Clone improvements to greatly reduce the area of attack on identifying the fake
