### PR TITLE
Add LOOC budget

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.LoocBudget.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.LoocBudget.cs
@@ -1,0 +1,125 @@
+﻿using Content.Shared._Funkystation.CCVars;
+using Content.Shared.Chat;
+using Robust.Shared.Console;
+using Robust.Shared.Network;
+using Robust.Shared.Player;
+
+namespace Content.Server.Chat.Systems;
+
+// Funkystation
+public partial class ChatSystem
+{
+    private sealed class LoocBudget
+    {
+        public int Budget;
+        public int SentMessages;
+        public bool CanSendLooc => SentMessages <= Budget;
+    }
+
+    private Dictionary<NetUserId, LoocBudget> _loocBudgets = new();
+
+    private CompletionResult SetLoocBudgetHelper(IConsoleShell shell, string[] args)
+    {
+        return args.Length switch
+        {
+            1 => CompletionResult.FromHintOptions(CompletionHelper.SessionNames(),
+                Loc.GetString("cmd-looc-budget-1")),
+            2 => CompletionResult.FromHint(Loc.GetString("cmd-looc-budget-2")),
+            3 => CompletionResult.FromHint(Loc.GetString("cmd-looc-budget-3")),
+            4 => CompletionResult.FromHint(Loc.GetString("cmd-looc-budget-4")),
+            _ => CompletionResult.Empty,
+        };
+    }
+
+    /// <summary>
+    /// args: session: user, int: budget, bool: refill budget, bool: inform user
+    /// </summary>
+    /// <param name="shell"></param>
+    /// <param name="argstr"></param>
+    /// <param name="args"></param>
+    private void SetLoocBudget(IConsoleShell shell, string argstr, string[] args)
+    {
+        if (!_configurationManager.GetCVar(CCVars_Funky.LoocBudgetEnabled))
+            return;
+
+        void SetBudget(ICommonSession player)
+        {
+            // Get the existing budget or make one or bail out if something goes really wrong.
+            if (!_loocBudgets.TryGetValue(player.UserId, out var playerBudget))
+            {
+                if (_loocBudgets.TryAdd(player.UserId, new LoocBudget() { }))
+                    playerBudget = _loocBudgets[player.UserId];
+                else
+                    return;
+            }
+
+            // Set their new budget. (Max LOOC messages they can send per round)
+            playerBudget.Budget = int.Parse(args[1]);
+
+            // Reset/refill their budget?
+            if (args.Length >= 3 && bool.Parse(args[2]))
+                playerBudget.SentMessages = 0;
+
+            // Should we let them know their budget has been changed?
+            if (args.Length < 4 || !bool.Parse(args[3]))
+                return;
+
+            var messageContent = Loc.GetString("hud-chatbox-looc-budget-refilled", ("count", playerBudget.Budget));
+            var wrappedMessage = Loc.GetString("chat-manager-server-wrap-message", ("message", messageContent));
+            _chatManager.ChatMessageToOne(ChatChannel.Server,
+                messageContent,
+                wrappedMessage,
+                default,
+                false,
+                player.Channel,
+                Color.Red);
+        }
+
+        if (args.Length < 2)
+        {
+            shell.WriteLine(Loc.GetString("cmd-looc-budget-help"));
+            return;
+        }
+
+        if (args[0] == "all")
+        {
+            foreach(var session in _playerManager.Sessions)
+                SetBudget(session);
+        }
+        else if (!_playerManager.TryGetSessionByUsername(args[0], out var player))
+            shell.WriteLine(Loc.GetString("cmd-looc-budget-error-no-user"));
+        else
+            SetBudget(player);
+    }
+
+    private void TrySendLoocWithBudget(EntityUid source, ICommonSession player, string message, bool hideChat)
+    {
+        var maxLoocAllowed = _configurationManager.GetCVar(CCVars_Funky.DefaultLoocBudget);
+        if (!_loocBudgets.ContainsKey(player.UserId))
+        {
+            _loocBudgets.TryAdd(player.UserId,
+                new LoocBudget()
+                    { Budget= maxLoocAllowed, SentMessages = 0});
+        }
+
+        if (!_loocBudgets.TryGetValue(player.UserId, out var playerBudget))
+            return;
+
+        playerBudget.SentMessages++;
+        if (playerBudget.CanSendLooc)
+            SendLOOC(source, player, message, hideChat);
+        else
+        {
+            var messageContent = Loc.GetString("hud-chatbox-looc-budget-spent", ("count", playerBudget.Budget));
+            var wrappedMessage = Loc.GetString("chat-manager-server-wrap-message", ("message", messageContent));
+            _chatManager.ChatMessageToOne(ChatChannel.Server,
+                message,
+                wrappedMessage,
+                default,
+                false,
+                player.Channel,
+                Color.Red);
+        }
+
+    }
+}

--- a/Content.Server/Chat/Systems/ChatSystem.LoocBudget.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.LoocBudget.cs
@@ -1,4 +1,8 @@
-﻿using Content.Shared._Funkystation.CCVars;
+// SPDX-FileCopyrightText: 2025 duston <66768086+dch-GH@users.noreply.github.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using Content.Shared._Funkystation.CCVars;
 using Content.Shared.Chat;
 using Robust.Shared.Console;
 using Robust.Shared.Network;

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -66,6 +66,7 @@ using Content.Server.Speech.Prototypes;
 using Content.Server.Speech.EntitySystems;
 using Content.Server.Station.Components;
 using Content.Server.Station.Systems;
+using Content.Shared._Funkystation.CCVars;
 using Content.Shared.ActionBlocker;
 using Content.Shared.Administration;
 using Content.Shared.CCVar;
@@ -118,8 +119,9 @@ public sealed partial class ChatSystem : SharedChatSystem
     [Dependency] private readonly ReplacementAccentSystem _wordreplacement = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
     [Dependency] private readonly ExamineSystemShared _examineSystem = default!;
-	[Dependency] private readonly AnnounceTtsSystem _announceTtsSystem = default!;
+    [Dependency] private readonly AnnounceTtsSystem _announceTtsSystem = default!;
     [Dependency] private readonly SharedContainerSystem _containers = default!;
+    [Dependency] private readonly IConsoleHost _conHost = default!;
 
     public const int VoiceRange = 10; // how far voice goes in world units
     public const int WhisperClearRange = 2; // how far whisper goes while still being understandable, in world units
@@ -139,12 +141,20 @@ public sealed partial class ChatSystem : SharedChatSystem
         Subs.CVar(_configurationManager, CCVars.DeadLoocEnabled, OnDeadLoocEnabledChanged, true);
         Subs.CVar(_configurationManager, CCVars.CritLoocEnabled, OnCritLoocEnabledChanged, true);
 
+        // Funkystation
+        _conHost.RegisterCommand("looc_budget",
+            Loc.GetString("cmd-looc-budget-desc"),
+            Loc.GetString("cmd-looc-budget-help"),
+            SetLoocBudget,
+            SetLoocBudgetHelper);
+
         SubscribeLocalEvent<GameRunLevelChangedEvent>(OnGameChange);
     }
 
     private void OnLoocEnabledChanged(bool val)
     {
-        if (_loocEnabled == val) return;
+        if (_loocEnabled == val)
+            return;
 
         _loocEnabled = val;
         _chatManager.DispatchServerAnnouncement(
@@ -153,11 +163,14 @@ public sealed partial class ChatSystem : SharedChatSystem
 
     private void OnDeadLoocEnabledChanged(bool val)
     {
-        if (_deadLoocEnabled == val) return;
+        if (_deadLoocEnabled == val)
+            return;
 
         _deadLoocEnabled = val;
         _chatManager.DispatchServerAnnouncement(
-            Loc.GetString(val ? "chat-manager-dead-looc-chat-enabled-message" : "chat-manager-dead-looc-chat-disabled-message"));
+            Loc.GetString(val
+                ? "chat-manager-dead-looc-chat-enabled-message"
+                : "chat-manager-dead-looc-chat-disabled-message"));
     }
 
     private void OnCritLoocEnabledChanged(bool val)
@@ -167,7 +180,9 @@ public sealed partial class ChatSystem : SharedChatSystem
 
         _critLoocEnabled = val;
         _chatManager.DispatchServerAnnouncement(
-            Loc.GetString(val ? "chat-manager-crit-looc-chat-enabled-message" : "chat-manager-crit-looc-chat-disabled-message"));
+            Loc.GetString(val
+                ? "chat-manager-crit-looc-chat-enabled-message"
+                : "chat-manager-crit-looc-chat-disabled-message"));
     }
 
     private void OnGameChange(GameRunLevelChangedEvent ev)
@@ -201,13 +216,24 @@ public sealed partial class ChatSystem : SharedChatSystem
         EntityUid source,
         string message,
         InGameICChatType desiredType,
-        bool hideChat, bool hideLog = false,
+        bool hideChat,
+        bool hideLog = false,
         IConsoleShell? shell = null,
-        ICommonSession? player = null, string? nameOverride = null,
+        ICommonSession? player = null,
+        string? nameOverride = null,
         bool checkRadioPrefix = true,
         bool ignoreActionBlocker = false)
     {
-        TrySendInGameICMessage(source, message, desiredType, hideChat ? ChatTransmitRange.HideChat : ChatTransmitRange.Normal, hideLog, shell, player, nameOverride, checkRadioPrefix, ignoreActionBlocker);
+        TrySendInGameICMessage(source,
+            message,
+            desiredType,
+            hideChat ? ChatTransmitRange.HideChat : ChatTransmitRange.Normal,
+            hideLog,
+            shell,
+            player,
+            nameOverride,
+            checkRadioPrefix,
+            ignoreActionBlocker);
     }
 
     /// <summary>
@@ -232,12 +258,17 @@ public sealed partial class ChatSystem : SharedChatSystem
         string? nameOverride = null,
         bool checkRadioPrefix = true,
         bool ignoreActionBlocker = false
-        )
+    )
     {
         if (HasComp<GhostComponent>(source))
         {
             // Ghosts can only send dead chat messages, so we'll forward it to InGame OOC.
-            TrySendInGameOOCMessage(source, message, InGameOOCChatType.Dead, range == ChatTransmitRange.HideChat, shell, player);
+            TrySendInGameOOCMessage(source,
+                message,
+                InGameOOCChatType.Dead,
+                range == ChatTransmitRange.HideChat,
+                shell,
+                player);
             return;
         }
 
@@ -278,10 +309,16 @@ public sealed partial class ChatSystem : SharedChatSystem
         bool shouldCapitalize = (desiredType != InGameICChatType.Emote);
         bool shouldPunctuate = _configurationManager.GetCVar(CCVars.ChatPunctuation);
         // Capitalizing the word I only happens in English, so we check language here
-        bool shouldCapitalizeTheWordI = (!CultureInfo.CurrentCulture.IsNeutralCulture && CultureInfo.CurrentCulture.Parent.Name == "en")
+        bool shouldCapitalizeTheWordI =
+            (!CultureInfo.CurrentCulture.IsNeutralCulture && CultureInfo.CurrentCulture.Parent.Name == "en")
             || (CultureInfo.CurrentCulture.IsNeutralCulture && CultureInfo.CurrentCulture.Name == "en");
 
-        message = SanitizeInGameICMessage(source, message, out var emoteStr, shouldCapitalize, shouldPunctuate, shouldCapitalizeTheWordI);
+        message = SanitizeInGameICMessage(source,
+            message,
+            out var emoteStr,
+            shouldCapitalize,
+            shouldPunctuate,
+            shouldCapitalizeTheWordI);
 
         // Was there an emote in the message? If so, send it.
         if (player != null && emoteStr != message && emoteStr != null)
@@ -313,7 +350,12 @@ public sealed partial class ChatSystem : SharedChatSystem
                 SendEntityWhisper(source, message, range, null, nameOverride, hideLog, ignoreActionBlocker);
                 break;
             case InGameICChatType.Emote:
-                SendEntityEmote(source, message, range, nameOverride, hideLog: hideLog, ignoreActionBlocker: ignoreActionBlocker);
+                SendEntityEmote(source,
+                    message,
+                    range,
+                    nameOverride,
+                    hideLog: hideLog,
+                    ignoreActionBlocker: ignoreActionBlocker);
                 break;
         }
     }
@@ -325,7 +367,7 @@ public sealed partial class ChatSystem : SharedChatSystem
         bool hideChat,
         IConsoleShell? shell = null,
         ICommonSession? player = null
-        )
+    )
     {
         if (!CanSendInGame(message, shell, player))
             return;
@@ -342,7 +384,8 @@ public sealed partial class ChatSystem : SharedChatSystem
 
         var sendType = type;
         // If dead player LOOC is disabled, unless you are an admin with Moderator perms, send dead messages to dead chat
-        if ((_adminManager.IsAdmin(player) && _adminManager.HasAdminFlag(player, AdminFlags.Moderator)) // Override if admin
+        if ((_adminManager.IsAdmin(player) &&
+             _adminManager.HasAdminFlag(player, AdminFlags.Moderator)) // Override if admin
             || _deadLoocEnabled
             || (!HasComp<GhostComponent>(source) && !_mobStateSystem.IsDead(source))) // Check that player is not dead
         {
@@ -360,7 +403,12 @@ public sealed partial class ChatSystem : SharedChatSystem
                 SendDeadChat(source, player, message, hideChat);
                 break;
             case InGameOOCChatType.Looc:
-                SendLOOC(source, player, message, hideChat);
+                // Funkystation - LOOC budget
+                if (_configurationManager.GetCVar(CCVars_Funky.LoocBudgetEnabled))
+                    TrySendLoocWithBudget(source, player, message, hideChat);
+                else
+                    SendLOOC(source, player, message, hideChat);
+
                 break;
         }
     }
@@ -380,28 +428,35 @@ public sealed partial class ChatSystem : SharedChatSystem
         bool playSound = true,
         SoundSpecifier? announcementSound = null,
         Color? colorOverride = null,
-		List<string>? announcementWords = null
-        )
+        List<string>? announcementWords = null
+    )
     {
         sender ??= Loc.GetString("chat-manager-sender-announcement");
 
-        var wrappedMessage = Loc.GetString("chat-manager-sender-announcement-wrap-message", ("sender", sender), ("message", FormattedMessage.EscapeText(message)));
+        var wrappedMessage = Loc.GetString("chat-manager-sender-announcement-wrap-message",
+            ("sender", sender),
+            ("message", FormattedMessage.EscapeText(message)));
         _chatManager.ChatMessageToAll(ChatChannel.Radio, message, wrappedMessage, default, false, true, colorOverride);
         if (playSound)
         {
-			if (announcementWords != null)
-			{
-				_announceTtsSystem.QueueTtsMessage(null, announcementWords, DefaultAnnouncementSound);
-			}
-			else
-			{
-				_audio.PlayGlobal(announcementSound == null ? DefaultAnnouncementSound : _audio.ResolveSound(announcementSound), Filter.Broadcast(), true, AudioParams.Default.WithVolume(-2f));
-			}
+            if (announcementWords != null)
+            {
+                _announceTtsSystem.QueueTtsMessage(null, announcementWords, DefaultAnnouncementSound);
+            }
+            else
+            {
+                _audio.PlayGlobal(
+                    announcementSound == null ? DefaultAnnouncementSound : _audio.ResolveSound(announcementSound),
+                    Filter.Broadcast(),
+                    true,
+                    AudioParams.Default.WithVolume(-2f));
+            }
         }
-		else if (announcementWords != null)
-		{
-			_announceTtsSystem.QueueTtsMessage(null, announcementWords);
-		}
+        else if (announcementWords != null)
+        {
+            _announceTtsSystem.QueueTtsMessage(null, announcementWords);
+        }
+
         _adminLogger.Add(LogType.Chat, LogImpact.Low, $"Global station announcement from {sender}: {message}");
     }
 
@@ -426,12 +481,25 @@ public sealed partial class ChatSystem : SharedChatSystem
     {
         sender ??= Loc.GetString("chat-manager-sender-announcement");
 
-        var wrappedMessage = Loc.GetString("chat-manager-sender-announcement-wrap-message", ("sender", sender), ("message", FormattedMessage.EscapeText(message)));
-        _chatManager.ChatMessageToManyFiltered(filter, ChatChannel.Radio, message, wrappedMessage, source ?? default, false, true, colorOverride);
+        var wrappedMessage = Loc.GetString("chat-manager-sender-announcement-wrap-message",
+            ("sender", sender),
+            ("message", FormattedMessage.EscapeText(message)));
+        _chatManager.ChatMessageToManyFiltered(filter,
+            ChatChannel.Radio,
+            message,
+            wrappedMessage,
+            source ?? default,
+            false,
+            true,
+            colorOverride);
         if (playSound)
         {
-            _audio.PlayGlobal(announcementSound?.ToString() ?? DefaultAnnouncementSound, filter, true, AudioParams.Default.WithVolume(-2f));
+            _audio.PlayGlobal(announcementSound?.ToString() ?? DefaultAnnouncementSound,
+                filter,
+                true,
+                AudioParams.Default.WithVolume(-2f));
         }
+
         _adminLogger.Add(LogType.Chat, LogImpact.Low, $"Station Announcement from {sender}: {message}");
     }
 
@@ -444,17 +512,19 @@ public sealed partial class ChatSystem : SharedChatSystem
     /// <param name="playDefaultSound">Play the announcement sound</param>
     /// <param name="colorOverride">Optional color for the announcement message</param>
     public void DispatchStationAnnouncement(
-		EntityUid source,
-		string message,
-		string? sender = null,
-		bool playDefaultSound = true,
-		SoundSpecifier? announcementSound = null,
-		Color? colorOverride = null,
-		List<string>? announcementWords = null)
+        EntityUid source,
+        string message,
+        string? sender = null,
+        bool playDefaultSound = true,
+        SoundSpecifier? announcementSound = null,
+        Color? colorOverride = null,
+        List<string>? announcementWords = null)
     {
         sender ??= Loc.GetString("chat-manager-sender-announcement");
 
-        var wrappedMessage = Loc.GetString("chat-manager-sender-announcement-wrap-message", ("sender", sender), ("message", FormattedMessage.EscapeText(message)));
+        var wrappedMessage = Loc.GetString("chat-manager-sender-announcement-wrap-message",
+            ("sender", sender),
+            ("message", FormattedMessage.EscapeText(message)));
         var station = _stationSystem.GetOwningStation(source);
 
         if (station == null)
@@ -463,21 +533,32 @@ public sealed partial class ChatSystem : SharedChatSystem
             return;
         }
 
-        if (!EntityManager.TryGetComponent<StationDataComponent>(station, out var stationDataComp)) return;
+        if (!EntityManager.TryGetComponent<StationDataComponent>(station, out var stationDataComp))
+            return;
 
         var filter = _stationSystem.GetInStation(stationDataComp);
 
-        _chatManager.ChatMessageToManyFiltered(filter, ChatChannel.Radio, message, wrappedMessage, source, false, true, colorOverride);
+        _chatManager.ChatMessageToManyFiltered(filter,
+            ChatChannel.Radio,
+            message,
+            wrappedMessage,
+            source,
+            false,
+            true,
+            colorOverride);
 
         if (playDefaultSound)
         {
-            _audio.PlayGlobal(announcementSound == null ? DefaultAnnouncementSound : _audio.GetSound(announcementSound), Filter.Broadcast(), true, AudioParams.Default.WithVolume(-2f));
+            _audio.PlayGlobal(announcementSound == null ? DefaultAnnouncementSound : _audio.GetSound(announcementSound),
+                Filter.Broadcast(),
+                true,
+                AudioParams.Default.WithVolume(-2f));
         }
 
         if (announcementWords != null && TryGetAiCore(source, out var aiCore))
-		{
-			_announceTtsSystem.QueueTtsMessage(aiCore!, announcementWords);
-		}
+        {
+            _announceTtsSystem.QueueTtsMessage(aiCore!, announcementWords);
+        }
 
         _adminLogger.Add(LogType.Chat, LogImpact.Low, $"Station Announcement on {station} from {sender}: {message}");
     }
@@ -493,7 +574,7 @@ public sealed partial class ChatSystem : SharedChatSystem
         string? nameOverride,
         bool hideLog = false,
         bool ignoreActionBlocker = false
-        )
+    )
     {
         if (!_actionBlocker.CanSpeak(source) && !ignoreActionBlocker)
             return;
@@ -523,7 +604,8 @@ public sealed partial class ChatSystem : SharedChatSystem
 
         name = FormattedMessage.EscapeText(name);
 
-        var wrappedMessage = Loc.GetString(speech.Bold ? "chat-manager-entity-say-bold-wrap-message" : "chat-manager-entity-say-wrap-message",
+        var wrappedMessage = Loc.GetString(
+            speech.Bold ? "chat-manager-entity-say-bold-wrap-message" : "chat-manager-entity-say-wrap-message",
             ("entityName", name),
             ("verb", Loc.GetString(_random.Pick(speech.SpeechVerbStrings))),
             ("fontType", speech.FontId),
@@ -543,17 +625,23 @@ public sealed partial class ChatSystem : SharedChatSystem
         if (originalMessage == message)
         {
             if (name != Name(source))
-                _adminLogger.Add(LogType.Chat, LogImpact.Low, $"Say from {ToPrettyString(source):user} as {name}: {originalMessage}.");
+                _adminLogger.Add(LogType.Chat,
+                    LogImpact.Low,
+                    $"Say from {ToPrettyString(source):user} as {name}: {originalMessage}.");
             else
-                _adminLogger.Add(LogType.Chat, LogImpact.Low, $"Say from {ToPrettyString(source):user}: {originalMessage}.");
+                _adminLogger.Add(LogType.Chat,
+                    LogImpact.Low,
+                    $"Say from {ToPrettyString(source):user}: {originalMessage}.");
         }
         else
         {
             if (name != Name(source))
-                _adminLogger.Add(LogType.Chat, LogImpact.Low,
+                _adminLogger.Add(LogType.Chat,
+                    LogImpact.Low,
                     $"Say from {ToPrettyString(source):user} as {name}, original: {originalMessage}, transformed: {message}.");
             else
-                _adminLogger.Add(LogType.Chat, LogImpact.Low,
+                _adminLogger.Add(LogType.Chat,
+                    LogImpact.Low,
                     $"Say from {ToPrettyString(source):user}, original: {originalMessage}, transformed: {message}.");
         }
     }
@@ -566,7 +654,7 @@ public sealed partial class ChatSystem : SharedChatSystem
         string? nameOverride,
         bool hideLog = false,
         bool ignoreActionBlocker = false
-        )
+    )
     {
         if (!_actionBlocker.CanSpeak(source) && !ignoreActionBlocker)
             return;
@@ -591,13 +679,16 @@ public sealed partial class ChatSystem : SharedChatSystem
             RaiseLocalEvent(source, nameEv);
             name = nameEv.VoiceName;
         }
+
         name = FormattedMessage.EscapeText(name);
 
         var wrappedMessage = Loc.GetString("chat-manager-entity-whisper-wrap-message",
-            ("entityName", name), ("message", FormattedMessage.EscapeText(message)));
+            ("entityName", name),
+            ("message", FormattedMessage.EscapeText(message)));
 
         var wrappedobfuscatedMessage = Loc.GetString("chat-manager-entity-whisper-wrap-message",
-            ("entityName", nameIdentity), ("message", FormattedMessage.EscapeText(obfuscatedMessage)));
+            ("entityName", nameIdentity),
+            ("message", FormattedMessage.EscapeText(obfuscatedMessage)));
 
         var wrappedUnknownMessage = Loc.GetString("chat-manager-entity-whisper-unknown-wrap-message",
             ("message", FormattedMessage.EscapeText(obfuscatedMessage)));
@@ -615,16 +706,36 @@ public sealed partial class ChatSystem : SharedChatSystem
                 continue; // Won't get logged to chat, and ghosts are too far away to see the pop-up, so we just won't send it to them.
 
             if (data.Range <= WhisperClearRange)
-                _chatManager.ChatMessageToOne(ChatChannel.Whisper, message, wrappedMessage, source, false, session.Channel);
+                _chatManager.ChatMessageToOne(ChatChannel.Whisper,
+                    message,
+                    wrappedMessage,
+                    source,
+                    false,
+                    session.Channel);
             //If listener is too far, they only hear fragments of the message
             else if (_examineSystem.InRangeUnOccluded(source, listener, WhisperMuffledRange))
-                _chatManager.ChatMessageToOne(ChatChannel.Whisper, obfuscatedMessage, wrappedobfuscatedMessage, source, false, session.Channel);
+                _chatManager.ChatMessageToOne(ChatChannel.Whisper,
+                    obfuscatedMessage,
+                    wrappedobfuscatedMessage,
+                    source,
+                    false,
+                    session.Channel);
             //If listener is too far and has no line of sight, they can't identify the whisperer's identity
             else
-                _chatManager.ChatMessageToOne(ChatChannel.Whisper, obfuscatedMessage, wrappedUnknownMessage, source, false, session.Channel);
+                _chatManager.ChatMessageToOne(ChatChannel.Whisper,
+                    obfuscatedMessage,
+                    wrappedUnknownMessage,
+                    source,
+                    false,
+                    session.Channel);
         }
 
-        _replay.RecordServerMessage(new ChatMessage(ChatChannel.Whisper, message, wrappedMessage, GetNetEntity(source), null, MessageRangeHideChatForReplay(range)));
+        _replay.RecordServerMessage(new ChatMessage(ChatChannel.Whisper,
+            message,
+            wrappedMessage,
+            GetNetEntity(source),
+            null,
+            MessageRangeHideChatForReplay(range)));
 
         var ev = new EntitySpokeEvent(source, message, channel, obfuscatedMessage);
         RaiseLocalEvent(source, ev, true);
@@ -632,18 +743,24 @@ public sealed partial class ChatSystem : SharedChatSystem
             if (originalMessage == message)
             {
                 if (name != Name(source))
-                    _adminLogger.Add(LogType.Chat, LogImpact.Low, $"Whisper from {ToPrettyString(source):user} as {name}: {originalMessage}.");
+                    _adminLogger.Add(LogType.Chat,
+                        LogImpact.Low,
+                        $"Whisper from {ToPrettyString(source):user} as {name}: {originalMessage}.");
                 else
-                    _adminLogger.Add(LogType.Chat, LogImpact.Low, $"Whisper from {ToPrettyString(source):user}: {originalMessage}.");
+                    _adminLogger.Add(LogType.Chat,
+                        LogImpact.Low,
+                        $"Whisper from {ToPrettyString(source):user}: {originalMessage}.");
             }
             else
             {
                 if (name != Name(source))
-                    _adminLogger.Add(LogType.Chat, LogImpact.Low,
-                    $"Whisper from {ToPrettyString(source):user} as {name}, original: {originalMessage}, transformed: {message}.");
+                    _adminLogger.Add(LogType.Chat,
+                        LogImpact.Low,
+                        $"Whisper from {ToPrettyString(source):user} as {name}, original: {originalMessage}, transformed: {message}.");
                 else
-                    _adminLogger.Add(LogType.Chat, LogImpact.Low,
-                    $"Whisper from {ToPrettyString(source):user}, original: {originalMessage}, transformed: {message}.");
+                    _adminLogger.Add(LogType.Chat,
+                        LogImpact.Low,
+                        $"Whisper from {ToPrettyString(source):user}, original: {originalMessage}, transformed: {message}.");
             }
     }
 
@@ -656,7 +773,7 @@ public sealed partial class ChatSystem : SharedChatSystem
         bool checkEmote = true,
         bool ignoreActionBlocker = false,
         NetUserId? author = null
-        )
+    )
     {
         if (!_actionBlocker.CanEmote(source) && !ignoreActionBlocker)
             return;
@@ -676,7 +793,9 @@ public sealed partial class ChatSystem : SharedChatSystem
         SendInVoiceRange(ChatChannel.Emotes, action, wrappedMessage, source, range, author);
         if (!hideLog)
             if (name != Name(source))
-                _adminLogger.Add(LogType.Chat, LogImpact.Low, $"Emote from {ToPrettyString(source):user} as {name}: {action}");
+                _adminLogger.Add(LogType.Chat,
+                    LogImpact.Low,
+                    $"Emote from {ToPrettyString(source):user} as {name}: {action}");
             else
                 _adminLogger.Add(LogType.Chat, LogImpact.Low, $"Emote from {ToPrettyString(source):user}: {action}");
     }
@@ -688,9 +807,11 @@ public sealed partial class ChatSystem : SharedChatSystem
 
         if (_adminManager.IsAdmin(player))
         {
-            if (!_adminLoocEnabled) return;
+            if (!_adminLoocEnabled)
+                return;
         }
-        else if (!_loocEnabled) return;
+        else if (!_loocEnabled)
+            return;
 
         // If crit player LOOC is disabled, don't send the message at all.
         if (!_critLoocEnabled && _mobStateSystem.IsCritical(source))
@@ -700,7 +821,12 @@ public sealed partial class ChatSystem : SharedChatSystem
             ("entityName", name),
             ("message", FormattedMessage.EscapeText(message)));
 
-        SendInVoiceRange(ChatChannel.LOOC, message, wrappedMessage, source, hideChat ? ChatTransmitRange.HideChat : ChatTransmitRange.Normal, player.UserId);
+        SendInVoiceRange(ChatChannel.LOOC,
+            message,
+            wrappedMessage,
+            source,
+            hideChat ? ChatTransmitRange.HideChat : ChatTransmitRange.Normal,
+            player.UserId);
         _adminLogger.Add(LogType.Chat, LogImpact.Low, $"LOOC from {player:Player}: {message}");
     }
 
@@ -726,8 +852,16 @@ public sealed partial class ChatSystem : SharedChatSystem
             _adminLogger.Add(LogType.Chat, LogImpact.Low, $"Dead chat from {player:Player}: {message}");
         }
 
-        _chatManager.ChatMessageToMany(ChatChannel.Dead, message, wrappedMessage, source, hideChat, true, clients.ToList(), author: player.UserId);
+        _chatManager.ChatMessageToMany(ChatChannel.Dead,
+            message,
+            wrappedMessage,
+            source,
+            hideChat,
+            true,
+            clients.ToList(),
+            author: player.UserId);
     }
+
     #endregion
 
     #region Utility
@@ -751,7 +885,9 @@ public sealed partial class ChatSystem : SharedChatSystem
     ///     Checks if a target as returned from GetRecipients should receive the message.
     ///     Keep in mind data.Range is -1 for out of range observers.
     /// </summary>
-    private MessageRangeCheckResult MessageRangeCheck(ICommonSession session, ICChatRecipientData data, ChatTransmitRange range)
+    private MessageRangeCheckResult MessageRangeCheck(ICommonSession session,
+        ICChatRecipientData data,
+        ChatTransmitRange range)
     {
         var initialResult = MessageRangeCheckResult.Full;
         switch (range)
@@ -760,15 +896,20 @@ public sealed partial class ChatSystem : SharedChatSystem
                 initialResult = MessageRangeCheckResult.Full;
                 break;
             case ChatTransmitRange.GhostRangeLimit:
-                initialResult = (data.Observer && data.Range < 0 && !_adminManager.IsAdmin(session)) ? MessageRangeCheckResult.HideChat : MessageRangeCheckResult.Full;
+                initialResult = (data.Observer && data.Range < 0 && !_adminManager.IsAdmin(session))
+                    ? MessageRangeCheckResult.HideChat
+                    : MessageRangeCheckResult.Full;
                 break;
             case ChatTransmitRange.HideChat:
                 initialResult = MessageRangeCheckResult.HideChat;
                 break;
             case ChatTransmitRange.NoGhosts:
-                initialResult = (data.Observer && !_adminManager.IsAdmin(session)) ? MessageRangeCheckResult.Disallowed : MessageRangeCheckResult.Full;
+                initialResult = (data.Observer && !_adminManager.IsAdmin(session))
+                    ? MessageRangeCheckResult.Disallowed
+                    : MessageRangeCheckResult.Full;
                 break;
         }
+
         var insistHideChat = data.HideChatOverride ?? false;
         var insistNoHideChat = !(data.HideChatOverride ?? true);
         if (insistHideChat && initialResult == MessageRangeCheckResult.Full)
@@ -802,7 +943,12 @@ public sealed partial class ChatSystem : SharedChatSystem
     /// <summary>
     ///     Sends a chat message to the given players in range of the source entity.
     /// </summary>
-    private void SendInVoiceRange(ChatChannel channel, string message, string wrappedMessage, EntityUid source, ChatTransmitRange range, NetUserId? author = null)
+    private void SendInVoiceRange(ChatChannel channel,
+        string message,
+        string wrappedMessage,
+        EntityUid source,
+        ChatTransmitRange range,
+        NetUserId? author = null)
     {
         foreach (var (session, data) in GetRecipients(source, VoiceRange))
         {
@@ -810,10 +956,21 @@ public sealed partial class ChatSystem : SharedChatSystem
             if (entRange == MessageRangeCheckResult.Disallowed)
                 continue;
             var entHideChat = entRange == MessageRangeCheckResult.HideChat;
-            _chatManager.ChatMessageToOne(channel, message, wrappedMessage, source, entHideChat, session.Channel, author: author);
+            _chatManager.ChatMessageToOne(channel,
+                message,
+                wrappedMessage,
+                source,
+                entHideChat,
+                session.Channel,
+                author: author);
         }
 
-        _replay.RecordServerMessage(new ChatMessage(channel, message, wrappedMessage, GetNetEntity(source), null, MessageRangeHideChatForReplay(range)));
+        _replay.RecordServerMessage(new ChatMessage(channel,
+            message,
+            wrappedMessage,
+            GetNetEntity(source),
+            null,
+            MessageRangeHideChatForReplay(range)));
     }
 
     /// <summary>
@@ -843,7 +1000,12 @@ public sealed partial class ChatSystem : SharedChatSystem
     }
 
     // ReSharper disable once InconsistentNaming
-    private string SanitizeInGameICMessage(EntityUid source, string message, out string? emoteStr, bool capitalize = true, bool punctuate = false, bool capitalizeTheWordI = true)
+    private string SanitizeInGameICMessage(EntityUid source,
+        string message,
+        out string? emoteStr,
+        bool capitalize = true,
+        bool punctuate = false,
+        bool capitalizeTheWordI = true)
     {
         var newMessage = SanitizeMessageReplaceWords(message.Trim());
 
@@ -913,7 +1075,8 @@ public sealed partial class ChatSystem : SharedChatSystem
 
     public string SanitizeMessageReplaceWords(string message)
     {
-        if (string.IsNullOrEmpty(message)) return message;
+        if (string.IsNullOrEmpty(message))
+            return message;
 
         var msg = message;
 
@@ -950,7 +1113,8 @@ public sealed partial class ChatSystem : SharedChatSystem
             var observer = ghostHearing.HasComponent(playerEntity);
 
             // even if they are a ghost hearer, in some situations we still need the range
-            if (sourceCoords.TryDistance(EntityManager, transformEntity.Coordinates, out var distance) && distance < voiceGetRange)
+            if (sourceCoords.TryDistance(EntityManager, transformEntity.Coordinates, out var distance) &&
+                distance < voiceGetRange)
             {
                 recipients.Add(player, new ICChatRecipientData(distance, observer));
                 continue;
@@ -995,6 +1159,7 @@ public sealed partial class ChatSystem : SharedChatSystem
         {
             sb.Append(_random.Pick(charOptions));
         }
+
         return sb.ToString();
     }
 
@@ -1005,7 +1170,10 @@ public sealed partial class ChatSystem : SharedChatSystem
 ///     This event is raised before chat messages are sent out to clients. This enables some systems to send the chat
 ///     messages to otherwise out-of view entities (e.g. for multiple viewports from cameras).
 /// </summary>
-public record ExpandICChatRecipientsEvent(EntityUid Source, float VoiceRange, Dictionary<ICommonSession, ChatSystem.ICChatRecipientData> Recipients)
+public record ExpandICChatRecipientsEvent(
+    EntityUid Source,
+    float VoiceRange,
+    Dictionary<ICommonSession, ChatSystem.ICChatRecipientData> Recipients)
 {
 }
 
@@ -1087,10 +1255,13 @@ public enum ChatTransmitRange : byte
 {
     /// Acts normal, ghosts can hear across the map, etc.
     Normal,
+
     /// Normal but ghosts are still range-limited.
     GhostRangeLimit,
+
     /// Hidden from the chat window.
     HideChat,
+
     /// Ghosts can't hear or see it at all. Regular players can if in-range.
     NoGhosts
 }

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -49,6 +49,7 @@
 // SPDX-FileCopyrightText: 2024 ike709 <ike709@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 kbarkevich <24629810+kbarkevich@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
+// SPDX-FileCopyrightText: 2025 duston <66768086+dch-GH@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 //

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -397,6 +397,9 @@ public sealed partial class ChatSystem : SharedChatSystem
         if (!_critLoocEnabled && _mobStateSystem.IsCritical(source))
             return;
 
+        if (TryComp<AdminFrozenComponent>(source, out var frozenComponent) && frozenComponent.Muted)
+            return;
+
         switch (sendType)
         {
             case InGameOOCChatType.Dead:

--- a/Content.Shared/_Funkystation/CCVars/CCVars.Funky.cs
+++ b/Content.Shared/_Funkystation/CCVars/CCVars.Funky.cs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2025 Steve <marlumpy@gmail.com>
+// SPDX-FileCopyrightText: 2025 duston <66768086+dch-GH@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 marc-pelletier <113944176+marc-pelletier@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 misghast <51974455+misterghast@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>

--- a/Content.Shared/_Funkystation/CCVars/CCVars.Funky.cs
+++ b/Content.Shared/_Funkystation/CCVars/CCVars.Funky.cs
@@ -24,4 +24,18 @@ public sealed class CCVars_Funky
     /// </summary>
     public static readonly CVarDef<bool> BluespaceGasEnabled =
         CVarDef.Create("funky.bluespace_gas_enabled", true, CVar.SERVER | CVar.REPLICATED);
+
+    /// <summary>
+    /// If the LOOC message budget system should be enabled.
+    /// Defaults to true.
+    /// </summary>
+    public static readonly CVarDef<bool> LoocBudgetEnabled =
+        CVarDef.Create("funky.looc_budget_enabled", true, CVar.SERVER | CVar.REPLICATED);
+
+    /// <summary>
+    /// How many LOOC messages each player can send per round.
+    /// Defaults to 20.
+    /// </summary>
+    public static readonly CVarDef<int> DefaultLoocBudget =
+        CVarDef.Create("funky.looc_budget_default", 20, CVar.SERVER | CVar.REPLICATED);
 }

--- a/Resources/Locale/en-US/_Funkystation/looc-budget.ftl
+++ b/Resources/Locale/en-US/_Funkystation/looc-budget.ftl
@@ -1,0 +1,12 @@
+hud-chatbox-looc-budget-spent = You have spent your LOOC message budget of {$count} messages. You can no longer speak in LOOC for the remainder of the round.
+hud-chatbox-looc-budget-refilled = Your LOOC budget has been set to {$count} messages.
+
+cmd-looc-budget-desc = Set a user's LOOC message budget.
+cmd-looc-budget-help = looc_budget <user | all> <budget> <refill budget> <inform user>
+cmd-looc-budget-1 = <user | all>
+cmd-looc-budget-2 = new budget to give the player (max sendable LOOC messages)
+cmd-looc-budget-3 = should the user's sent message count be reset to 0? (refills budget)
+cmd-looc-budget-4 = display a message to the user to inform them their budget has been refilled
+
+cmd-looc-budget-error-no-user = User not found.
+

--- a/Resources/engineCommandPerms.yml
+++ b/Resources/engineCommandPerms.yml
@@ -14,6 +14,7 @@
 # SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2024 lizelive <github@lize.live>
 # SPDX-FileCopyrightText: 2024 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 duston <66768086+dch-GH@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT

--- a/Resources/engineCommandPerms.yml
+++ b/Resources/engineCommandPerms.yml
@@ -112,6 +112,7 @@
   - listplayers
   - tp
   - tpto
+  - looc_budget
 
 - Flags: FUN
   Commands:


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->
Applied formatting to `ChatSystem.cs` (it was completely messed up).
Added `ChatSystem.LoocBudget.cs` to handle looc budget stuff.
Added two cvars `funky.looc_budget_enabled`: if the LOOC budget system is enabled and `funky.looc_budget_default`: the default budget for each player.
Added admin console command `looc_budget` to set a player or everyone's LOOC budget.  Usage is as follows:
`looc_budget <user | all> <budget> <refill budget> <inform user>`
where user is the target, budget is the new budget to set (the max LOOC messages), refill budget is a bool which when set to true will reset the player's sent LOOC message counter back to zero, inform user is a bool which when set to true will give the user a message telling them they have had their LOOC budget adjusted and to what number.

`looc_budget all 2 true true` Set everyone's LOOC budget to 2 message, refill it (reset counter), and let them know it was changed.
`looc_budget Miish 1 true` Set a user's LOOC budget to 1 message, refill it (reset counter), but don't let them know it was changed.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="293" height="128" alt="image" src="https://github.com/user-attachments/assets/30bad353-9c4d-4df0-8419-6d56257647c9" />
<img width="398" height="218" alt="image" src="https://github.com/user-attachments/assets/40b3b972-0338-4889-8cac-8767267fa942" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added LOOC message budget to limit the total amount of LOOC messages players can send per round. Defaults to 20 messages. 