### PR TITLE
Ports fixes to mops, rags, and towels interacting with drains from Wizden

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Multiple/towel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Multiple/towel.yml
@@ -26,6 +26,9 @@
     unequipSound: 
   - type: Spillable
     solution: absorbed
+    spillWhenThrown: false
+  - type: DrainableSolution
+    solution: absorbed
   - type: Absorbent
     pickupAmount: 15
   - type: SolutionContainerManager

--- a/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Janitorial/janitor.yml
@@ -85,6 +85,9 @@
       collection: MetalThud
   - type: Spillable
     solution: absorbed
+    spillWhenThrown: false
+  - type: DrainableSolution
+    solution: absorbed
   - type: Wieldable
   - type: IncreaseDamageOnWield
     damage:
@@ -138,6 +141,9 @@
       soundHit:
          collection: MetalThud
     - type: Spillable
+      solution: absorbed
+      spillWhenThrown: false
+    - type: DrainableSolution
       solution: absorbed
     - type: Wieldable
     - type: IncreaseDamageOnWield
@@ -367,6 +373,9 @@
       maxFillLevels: 3
       fillBaseName: fill-
     - type: Spillable
+      solution: absorbed
+      spillWhenThrown: false
+    - type: DrainableSolution
       solution: absorbed
     - type: MeleeWeapon
       soundNoDamage:


### PR DESCRIPTION
## About the PR
Ports (https://github.com/space-wizards/space-station-14/pull/38252) fixes to mops, rags, and towels not being able to interact with drains.

## Why / Balance
This is technically a janitor buff if you think about it hard enough.

For what it's worth, the mops/rags/towels don't click to drain into drains. It's a verb.

## Technical details
"Added DrainableSolution component to mops, rags, and towels. Additionally changed the SpillWhenThrown flag to false for Spillable (Adding the DrainableSolution component suddenly made these items spill when thrown otherwise)." - https://github.com/space-wizards/space-station-14/pull/38252

## Media
N/A

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A

**Changelog**
:cl:
- fix: Fixed mops, rags, and towels being unable to be properly emptied into drains
