### PR TITLE
Fix LOOC budget not being reset after round end

### DIFF
--- a/Content.Server/Chat/Systems/ChatSystem.LoocBudget.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.LoocBudget.cs
@@ -44,7 +44,10 @@ public partial class ChatSystem
     private void SetLoocBudget(IConsoleShell shell, string argstr, string[] args)
     {
         if (!_configurationManager.GetCVar(CCVars_Funky.LoocBudgetEnabled))
+        {
+            shell.WriteLine(Loc.GetString("cmd-looc-budget-disabled-message"));
             return;
+        }
 
         void SetBudget(ICommonSession player)
         {
@@ -87,7 +90,7 @@ public partial class ChatSystem
 
         if (args[0] == "all")
         {
-            foreach(var session in _playerManager.Sessions)
+            foreach (var session in _playerManager.Sessions)
                 SetBudget(session);
         }
         else if (!_playerManager.TryGetSessionByUsername(args[0], out var player))
@@ -103,7 +106,7 @@ public partial class ChatSystem
         {
             _loocBudgets.TryAdd(player.UserId,
                 new LoocBudget()
-                    { Budget= maxLoocAllowed, SentMessages = 0});
+                    { Budget = maxLoocAllowed, SentMessages = 0 });
         }
 
         if (!_loocBudgets.TryGetValue(player.UserId, out var playerBudget))
@@ -124,6 +127,62 @@ public partial class ChatSystem
                 player.Channel,
                 Color.Red);
         }
+    }
 
+    private CompletionResult GetLoocBudgetHelper(IConsoleShell shell, string[] args)
+    {
+        return args.Length switch
+        {
+            1 => CompletionResult.FromHintOptions(CompletionHelper.SessionNames(),
+                Loc.GetString("cmd-looc-budget-1")),
+            _ => CompletionResult.Empty,
+        };
+    }
+
+    /// <summary>
+    /// args: session: user, int: budget, bool: refill budget, bool: inform user
+    /// </summary>
+    /// <param name="shell"></param>
+    /// <param name="argstr"></param>
+    /// <param name="args"></param>
+    private void GetLoocBudget(IConsoleShell shell, string argstr, string[] args)
+    {
+        if (!_configurationManager.GetCVar(CCVars_Funky.LoocBudgetEnabled))
+        {
+            shell.WriteLine(Loc.GetString("cmd-looc-budget-disabled-message"));
+            return;
+        }
+
+        void GetBudget(ICommonSession player)
+        {
+            if (!_loocBudgets.TryGetValue(player.UserId, out var playerBudget))
+                return;
+
+            shell.WriteLine(Loc.GetString("cmd-looc-budget-get-result",
+                ("player", player.Name),
+                ("spent", playerBudget.SentMessages),
+                ("budget", playerBudget.Budget)));
+        }
+
+        if (args.Length < 1)
+        {
+            shell.WriteLine(Loc.GetString("cmd-looc-budget-help"));
+            return;
+        }
+
+        if (args[0] == "all")
+        {
+            foreach (var session in _playerManager.Sessions)
+                GetBudget(session);
+        }
+        else if (!_playerManager.TryGetSessionByUsername(args[0], out var player))
+            shell.WriteLine(Loc.GetString("cmd-looc-budget-error-no-user"));
+        else
+            GetBudget(player);
+    }
+
+    private void ResetLoocBudget()
+    {
+        _loocBudgets.Clear();
     }
 }

--- a/Content.Server/Chat/Systems/ChatSystem.LoocBudget.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.LoocBudget.cs
@@ -140,7 +140,7 @@ public partial class ChatSystem
     }
 
     /// <summary>
-    /// args: session: user, int: budget, bool: refill budget, bool: inform user
+    /// args: session: user
     /// </summary>
     /// <param name="shell"></param>
     /// <param name="argstr"></param>

--- a/Content.Server/Chat/Systems/ChatSystem.cs
+++ b/Content.Server/Chat/Systems/ChatSystem.cs
@@ -149,6 +149,12 @@ public sealed partial class ChatSystem : SharedChatSystem
             SetLoocBudget,
             SetLoocBudgetHelper);
 
+        _conHost.RegisterCommand("looc_budget_get",
+            Loc.GetString("cmd-looc-budget-get-desc"),
+            Loc.GetString("cmd-looc-budget-get-help"),
+            GetLoocBudget,
+            GetLoocBudgetHelper);
+
         SubscribeLocalEvent<GameRunLevelChangedEvent>(OnGameChange);
     }
 
@@ -198,6 +204,7 @@ public sealed partial class ChatSystem : SharedChatSystem
             case GameRunLevel.PreRoundLobby:
                 if (!_configurationManager.GetCVar(CCVars.OocEnableDuringRound))
                     _configurationManager.SetCVar(CCVars.OocEnabled, true);
+                ResetLoocBudget();
                 break;
         }
     }

--- a/Resources/Locale/en-US/_Funkystation/looc-budget.ftl
+++ b/Resources/Locale/en-US/_Funkystation/looc-budget.ftl
@@ -10,3 +10,8 @@ cmd-looc-budget-4 = display a message to the user to inform them their budget ha
 
 cmd-looc-budget-error-no-user = User not found.
 
+cmd-looc-budget-disabled-message = LOOC budget is disabled.
+cmd-looc-budget-get-result = Player {$player} has spent {$spent} of their LOOC budget of {$budget}.
+cmd-looc-budget-get-help = looc_budget_get <user | all>
+cmd-looc-budget-get-desc = Get the current LOOC budget and spent messages of a player.
+

--- a/Resources/engineCommandPerms.yml
+++ b/Resources/engineCommandPerms.yml
@@ -114,6 +114,7 @@
   - tp
   - tpto
   - looc_budget
+  - looc_budget_get
 
 - Flags: FUN
   Commands:


### PR DESCRIPTION
Add looc_budget_get to quickly query a player's LOOC budget

<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- fix: Fixed LOOC budget not being reset after round end.
-->
