### PR TITLE
Craftable canisters

### DIFF
--- a/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
@@ -8,8 +8,8 @@
 # SPDX-FileCopyrightText: 2023 lapatison <100279397+lapatison@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 Ilya246 <57039557+Ilya246@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 MODERN <87994977+modern-nm@users.noreply.github.com>
-# SPDX-FileCopyrightText: 2024 Steve <marlumpy@gmail.com>
 # SPDX-FileCopyrightText: 2024 marc-pelletier <113944176+marc-pelletier@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Steve <marlumpy@gmail.com>
 # SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2025 pa.pecherskij <pa.pecherskij@interfax.ru>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>

--- a/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
+++ b/Resources/Prototypes/Catalog/Cargo/cargo_atmospherics.yml
@@ -22,7 +22,7 @@
     sprite: Structures/Storage/canister.rsi
     state: grey
   product: AirCanister
-  cost: 1100
+  cost: 600 # Funky
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -32,7 +32,7 @@
     sprite: Structures/Storage/canister.rsi
     state: blue
   product: OxygenCanister
-  cost: 1100
+  cost: 600 # Funky
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -42,7 +42,7 @@
     sprite: Structures/Storage/canister.rsi
     state: blue
   product: LiquidOxygenCanister
-  cost: 2500
+  cost: 2000 # Funky
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -52,7 +52,7 @@
     sprite: Structures/Storage/canister.rsi
     state: red
   product: NitrogenCanister
-  cost: 1100
+  cost: 600 # Funky
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -62,7 +62,7 @@
     sprite: Structures/Storage/canister.rsi
     state: red
   product: LiquidNitrogenCanister
-  cost: 2500
+  cost: 2000 # Funky
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -72,7 +72,7 @@
     sprite: Structures/Storage/canister.rsi
     state: black
   product: CarbonDioxideCanister
-  cost: 2200 # Until someone fixes it co2 can be used to oneshot people so it's more expensive
+  cost: 1700 # Until someone fixes it co2 can be used to oneshot people so it's more expensive
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -82,7 +82,7 @@
     sprite: Structures/Storage/canister.rsi
     state: black
   product: LiquidCarbonDioxideCanister
-  cost: 4000
+  cost: 3500 # Funky
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -92,19 +92,19 @@
     sprite: Structures/Storage/canister.rsi
     state: yellow
   product: StorageCanister
-  cost: 1010 # No gases in it so it's cheaper
+  cost: 510 # Funky - 500 cheaper since it is craftable
   category: cargoproduct-category-name-atmospherics
   group: market
 
-#- type: cargoProduct
-#  id: AtmosphericsWaterVapor
-#  icon:
-#    sprite: Structures/Storage/canister.rsi
-#    state: water_vapor
-#  product: WaterVaporCanister
-#  cost: 2600
-#  category: cargoproduct-category-name-atmospherics
-#  group: market
+- type: cargoProduct
+  id: AtmosphericsWaterVapor
+  icon:
+    sprite: Structures/Storage/canister.rsi
+    state: water_vapor
+  product: WaterVaporCanister
+  cost: 2100
+  category: cargoproduct-category-name-atmospherics
+  group: market
 
 - type: cargoProduct
   id: AtmosphericsPlasma
@@ -112,7 +112,7 @@
     sprite: Structures/Storage/canister.rsi
     state: orange
   product: PlasmaCanister
-  cost: 4000
+  cost: 3500 # Funky
   category: cargoproduct-category-name-atmospherics
   group: market
 
@@ -133,6 +133,6 @@
     sprite: Structures/Storage/canister.rsi
     state: purple
   product: BZCanister
-  cost: 6500
+  cost: 6000
   category: cargoproduct-category-name-atmospherics
   group: market

--- a/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -39,6 +39,7 @@
 # SPDX-FileCopyrightText: 2024 Velcroboy <107660393+IamVelcroboy@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 lapatison <100279397+lapatison@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Checkraze <71046427+Cheackraze@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Steve <marlumpy@gmail.com>
 # SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2025 marc-pelletier <113944176+marc-pelletier@users.noreply.github.com>

--- a/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -150,7 +150,7 @@
           components:
             - GasTank
     - type: StaticPrice
-      price: 125 # Frontier: 200<125
+      price: 250 # Funky
     - type: AccessReader
 #      access: [["Atmospherics"], ["Engineering"], ["Research"], ["Captain"]] # Frontier
     - type: Construction # Frontier

--- a/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -150,9 +150,12 @@
           components:
             - GasTank
     - type: StaticPrice
-      price: 200
+      price: 125 # Frontier: 200<125
     - type: AccessReader
-      access: [["Atmospherics"], ["Engineering"], ["Research"]]
+#      access: [["Atmospherics"], ["Engineering"], ["Research"], ["Captain"]] # Frontier
+    - type: Construction # Frontier
+      graph: NFStorageCanister # Frontier
+      node: storagecanister # Frontier
     - type: Lock
       locked: false
     - type: GuideHelp

--- a/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Canisters/gas_canisters.yml
@@ -152,7 +152,7 @@
     - type: StaticPrice
       price: 250 # Funky
     - type: AccessReader
-#      access: [["Atmospherics"], ["Engineering"], ["Research"], ["Captain"]] # Frontier
+      access: [["Atmospherics"], ["Engineering"], ["Research"], ["Captain"]]
     - type: Construction # Frontier
       graph: NFStorageCanister # Frontier
       node: storagecanister # Frontier

--- a/Resources/Prototypes/_NF/Recipes/Construction/Graphs/utilities/storage_canister.yml
+++ b/Resources/Prototypes/_NF/Recipes/Construction/Graphs/utilities/storage_canister.yml
@@ -1,0 +1,33 @@
+- type: constructionGraph
+  id: NFStorageCanister
+  start: start
+  graph:
+  - node: start
+    edges:
+    - to: storagecanister
+      steps:
+      - material: Plasteel
+        amount: 5
+        doAfter: 5
+
+  - node: storagecanister
+    entity: StorageCanister
+    edges:
+    - to: start
+      conditions:
+      - !type:EntityAnchored
+        anchored: false
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetPlasteel1
+        amount: 5
+      - !type:DeleteEntity
+      steps:
+      - tool: Screwing
+        doAfter: 1
+      - tool: Cutting
+        doAfter: 1
+      - tool: Welding
+        doAfter: 5
+      - tool: Prying
+        doAfter: 2

--- a/Resources/Prototypes/_NF/Recipes/Construction/Graphs/utilities/storage_canister.yml
+++ b/Resources/Prototypes/_NF/Recipes/Construction/Graphs/utilities/storage_canister.yml
@@ -20,7 +20,7 @@
       completed:
       - !type:SpawnPrototype
         prototype: SheetPlasteel1
-        amount: 5
+        amount: 3
       - !type:DeleteEntity
       steps:
       - tool: Screwing

--- a/Resources/Prototypes/_NF/Recipes/Construction/Graphs/utilities/storage_canister.yml
+++ b/Resources/Prototypes/_NF/Recipes/Construction/Graphs/utilities/storage_canister.yml
@@ -7,7 +7,7 @@
     - to: storagecanister
       steps:
       - material: Plasteel
-        amount: 3
+        amount: 5
         doAfter: 5
 
   - node: storagecanister
@@ -20,7 +20,7 @@
       completed:
       - !type:SpawnPrototype
         prototype: SheetPlasteel1
-        amount: 3
+        amount: 5
       - !type:DeleteEntity
       steps:
       - tool: Screwing

--- a/Resources/Prototypes/_NF/Recipes/Construction/Graphs/utilities/storage_canister.yml
+++ b/Resources/Prototypes/_NF/Recipes/Construction/Graphs/utilities/storage_canister.yml
@@ -1,3 +1,9 @@
+# SPDX-FileCopyrightText: 2025 Checkraze <71046427+Cheackraze@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Steve <marlumpy@gmail.com>
+# SPDX-FileCopyrightText: 2025 Whatstone <whatston3@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: constructionGraph
   id: NFStorageCanister
   start: start

--- a/Resources/Prototypes/_NF/Recipes/Construction/Graphs/utilities/storage_canister.yml
+++ b/Resources/Prototypes/_NF/Recipes/Construction/Graphs/utilities/storage_canister.yml
@@ -7,7 +7,7 @@
     - to: storagecanister
       steps:
       - material: Plasteel
-        amount: 5
+        amount: 3
         doAfter: 5
 
   - node: storagecanister

--- a/Resources/Prototypes/_NF/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/_NF/Recipes/Construction/utilities.yml
@@ -1,0 +1,14 @@
+#Atmos lives in the utilities category and so too shall Canisters
+- type: construction
+  name: storage canister
+  id: NFStorageCanister
+  description: A hefty canister for storing medium amounts of atmospheric gasses.
+  graph: NFStorageCanister
+  startNode: start
+  targetNode: storagecanister
+  category: construction-category-utilities
+  placementMode: SnapgridCenter
+  canBuildInImpassable: false
+  icon:
+    sprite: _NF/Structures/Storage/canister.rsi
+    state: storage

--- a/Resources/Prototypes/_NF/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/_NF/Recipes/Construction/utilities.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2025 Checkraze <71046427+Cheackraze@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Steve <marlumpy@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 #Atmos lives in the utilities category and so too shall Canisters
 - type: construction
   name: storage canister

--- a/Resources/Prototypes/_NF/Recipes/Construction/utilities.yml
+++ b/Resources/Prototypes/_NF/Recipes/Construction/utilities.yml
@@ -10,5 +10,5 @@
   placementMode: SnapgridCenter
   canBuildInImpassable: false
   icon:
-    sprite: _NF/Structures/Storage/canister.rsi
-    state: storage
+    sprite: Structures/Storage/canister.rsi
+    state: yellow


### PR DESCRIPTION
## About the PR
Port of craftable gas canisters from frontier. Canisters can be crafted or broken down for 5 plasteel. The storage canister, and all other gas canisters are also now 500 specos cheaper to order through cargo. 

## Why / Balance
Canisters shouldn't be as rare a commodity as they are. 

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None

**Changelog**
:cl:
- add: Gas canisters can now be constructed and deconstructed.