### PR TITLE
fix hypernob visual bug

### DIFF
--- a/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Hotspot.cs
+++ b/Content.Server/Atmos/EntitySystems/AtmosphereSystem.Hotspot.cs
@@ -67,8 +67,9 @@ namespace Content.Server.Atmos.EntitySystems
                 ExcitedGroupResetCooldowns(tile.ExcitedGroup);
 
             if ((tile.Hotspot.Temperature < Atmospherics.FireMinimumTemperatureToExist) || (tile.Hotspot.Volume <= 1f)
-                || tile.Air == null || tile.Air.GetMoles(Gas.Oxygen) < 0.5f || (tile.Air.GetMoles(Gas.Plasma) < 0.5f && tile.Air.GetMoles(Gas.Tritium) < 0.5f && tile.Air.GetMoles(Gas.Hydrogen) < 0.5f
-                && tile.Air.GetMoles(Gas.HyperNoblium) > 5f))  // Assmos - /tg/ gases
+               || (tile.Air == null || tile.Air.GetMoles(Gas.Oxygen) < 0.5f || (tile.Air.GetMoles(Gas.Plasma) < 0.5f
+               && tile.Air.GetMoles(Gas.Tritium) < 0.5f && tile.Air.GetMoles(Gas.Hydrogen) < 0.5f)
+               || tile.Air.GetMoles(Gas.HyperNoblium) > 5f))  // Assmos - /tg/ gases
             {
                 tile.Hotspot = new Hotspot();
                 InvalidateVisuals(ent, tile);


### PR DESCRIPTION
## About the PR
Fixes a minor visual bug where the fire overlay would remain on a tile after hypernob stopped the reaction. 

## Why / Balance
Bugfix

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Fire visuals will no longer remain on tiles with more than 5 mols of hypernoblium present. 