### PR TITLE
Obscenely high roundstart budget fixed

### DIFF
--- a/Content.Server/_DV/Cargo/Components/StationLogisticStatsDatabaseComponent.cs
+++ b/Content.Server/_DV/Cargo/Components/StationLogisticStatsDatabaseComponent.cs
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2024 BombasterDS <115770678+BombasterDS@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
+// SPDX-FileCopyrightText: 2025 GreyMaria <mariomister541@gmail.com>
 // SPDX-FileCopyrightText: 2025 corresp0nd <46357632+corresp0nd@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 //

--- a/Content.Server/_DV/Cargo/Components/StationLogisticStatsDatabaseComponent.cs
+++ b/Content.Server/_DV/Cargo/Components/StationLogisticStatsDatabaseComponent.cs
@@ -5,7 +5,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 
-using Content.Shared.Cargo;
+using Content.Server._DV.Cargo.Systems;
 using Content.Shared.CartridgeLoader.Cartridges;
 
 namespace Content.Server._DV.Cargo.Components;
@@ -13,7 +13,7 @@ namespace Content.Server._DV.Cargo.Components;
 /// <summary>
 /// Added to the abstract representation of a station to track stats related to mail delivery and income
 /// </summary>
-[RegisterComponent, Access(typeof(SharedCargoSystem))]
+[RegisterComponent, Access(typeof(LogisticStatsSystem))]
 public sealed partial class StationLogisticStatsComponent : Component
 {
     [DataField]

--- a/Content.Server/_DV/Cargo/Systems/LogisticStatsSystem.cs
+++ b/Content.Server/_DV/Cargo/Systems/LogisticStatsSystem.cs
@@ -11,7 +11,7 @@ using JetBrains.Annotations;
 
 namespace Content.Server._DV.Cargo.Systems;
 
-public sealed partial class LogisticStatsSystem : SharedCargoSystem
+public sealed partial class LogisticStatsSystem : EntitySystem
 {
     public override void Initialize()
     {

--- a/Content.Server/_DV/Cargo/Systems/LogisticStatsSystem.cs
+++ b/Content.Server/_DV/Cargo/Systems/LogisticStatsSystem.cs
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2024 BombasterDS <115770678+BombasterDS@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
+// SPDX-FileCopyrightText: 2025 GreyMaria <mariomister541@gmail.com>
 // SPDX-FileCopyrightText: 2025 corresp0nd <46357632+corresp0nd@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 //

--- a/Content.Shared/Cargo/SharedCargoSystem.cs
+++ b/Content.Shared/Cargo/SharedCargoSystem.cs
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: 2023 Checkraze <71046427+Cheackraze@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2023 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2023 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 GreyMaria <mariomister541@gmail.com>
 // SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
 // SPDX-FileCopyrightText: 2025 pa.pecherskij <pa.pecherskij@interfax.ru>
 // SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>

--- a/Content.Shared/Cargo/SharedCargoSystem.cs
+++ b/Content.Shared/Cargo/SharedCargoSystem.cs
@@ -26,7 +26,7 @@ public abstract class SharedCargoSystem : EntitySystem
     {
         base.Initialize();
 
-        //SubscribeLocalEvent<StationBankAccountComponent, MapInitEvent>(OnMapInit);
+        SubscribeLocalEvent<StationBankAccountComponent, MapInitEvent>(OnMapInit);
     }
 
     private void OnMapInit(Entity<StationBankAccountComponent> ent, ref MapInitEvent args)


### PR DESCRIPTION
## About the PR
Fixed an issue causing roundstart station budget to skyrocket higher and higher the longer the server was running.

## Why / Balance
_[SALARY CUTTING NOISES]_

## Technical details
so THAT'S why that line was commented out

went and peeked at dV to see what they did to their own systems to account for departmental accounts, did what they did, reasonable enough fix

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Roundstart budget no longer balloons out of control.
