### PR TITLE
Lower HFR power draw

### DIFF
--- a/Content.Server/_Funkystation/HFR/Systems/HypertorusFusionReactorSystem.cs
+++ b/Content.Server/_Funkystation/HFR/Systems/HypertorusFusionReactorSystem.cs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2025 LaCumbiaDelCoronavirus <90893484+LaCumbiaDelCoronavirus@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 Steve <marlumpy@gmail.com>
 // SPDX-FileCopyrightText: 2025 marc-pelletier <113944176+marc-pelletier@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 //

--- a/Content.Server/_Funkystation/HFR/Systems/HypertorusFusionReactorSystem.cs
+++ b/Content.Server/_Funkystation/HFR/Systems/HypertorusFusionReactorSystem.cs
@@ -133,7 +133,7 @@ namespace Content.Server._Funkystation.Atmos.HFR.Systems
                 }
                 if (TryComp<ApcPowerReceiverComponent>(core.ConsoleUid.Value, out var consolePower))
                 {
-                    consolePower.Load = isActive ? 250000f : (core.PowerLevel > 0 ? consolePower.Load : 350f);
+                    consolePower.Load = isActive ? 100000f : (core.PowerLevel > 0 ? consolePower.Load : 350f);
                 }
                 if (isActive)
                 {

--- a/Resources/Prototypes/_Funkystation/Entities/Structures/Machines/Atmospherics/hfr.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Structures/Machines/Atmospherics/hfr.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2025 LaCumbiaDelCoronavirus <90893484+LaCumbiaDelCoronavirus@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Steve <marlumpy@gmail.com>
 # SPDX-FileCopyrightText: 2025 marc-pelletier <113944176+marc-pelletier@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 #

--- a/Resources/Prototypes/_Funkystation/Entities/Structures/Machines/Atmospherics/hfr.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Structures/Machines/Atmospherics/hfr.yml
@@ -415,7 +415,7 @@
       - Antinoblium significantly increases the power of the mix.
       - High heat capacity gases are harder to heat or cool.
       - Low heat capacity gases are easier to heat or cool.
-      - The machine consumes 250 KW of power when running, so prepare the station power accordingly before turning on the HFR.
+      - The machine consumes 100 KW of power when running, so prepare the station power accordingly before turning on the HFR.
       - Setting up multiple power generators is highly recommended before running the HFR.
       - In a power shortage, the fusion reaction continues, but cooling stops.
       - In the event of a sustained power outage, cut all power to the HFR until power issues are sorted.


### PR DESCRIPTION
## About the PR
Lowers the power draw for the HFR from 250kW to 100kW.

## Why / Balance
There are already many obstacles to atmos techs setting up the HFR. Making sure your power network can support it will still be one of them but it shouldn't be as much of an issue as it is. With it lowered to 100kW, any secondary power generator, like the AME or the solar arrays on most stations, should be enough to safely run it, allowing you to even separate it from the main power network entirely if you wish. 

## Technical details
None

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None

**Changelog**
:cl:
- tweak: HFR power draw has been lowered from 250kW to 100kW
