### PR TITLE
Remove hydrogen formation from pluox rad reaction

### DIFF
--- a/Content.Server/_Funkystation/Atmos/Reactions/PluoxiumRadiationProductionReaction.cs
+++ b/Content.Server/_Funkystation/Atmos/Reactions/PluoxiumRadiationProductionReaction.cs
@@ -3,27 +3,14 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 using Content.Server.Atmos.EntitySystems;
-using Content.Server.NodeContainer;
-using Content.Server.NodeContainer.Nodes;
 using Content.Server.NodeContainer.NodeGroups;
 using Content.Server.Radiation.Components;
-using Content.Server.Radiation.Events;
-using Content.Shared.Radiation.Systems;
 using Content.Shared.Atmos;
 using Content.Shared.Atmos.Reactions;
-using Content.Shared.Radiation.Components;
 using JetBrains.Annotations;
-using Robust.Shared.Map;
-using Robust.Server.GameObjects; 
 using Robust.Shared.Timing; 
-using Robust.Shared.Serialization; 
-using Robust.Shared.IoC;
-using Content.Shared.Stacks;
 using Content.Server.Radiation.Systems;
-using System.Linq;
-using System.Numerics;
 using Robust.Shared.Map.Components;
-using Robust.Shared.GameObjects;
 using Content.Server.Atmos.Components;
 
 
@@ -90,9 +77,7 @@ public sealed partial class PluoxiumRadiationProductionReaction : IGasReactionEf
         if (radiationLevel < RadiationThreshold)
             return ReactionResult.Reacting; 
 
-        float[] efficiencies = { radiationLevel, initCO2, initO2 * 2f };
-        Array.Sort(efficiencies);
-        float producedAmount = efficiencies[0];
+        float producedAmount = Math.Min(radiationLevel, Math.Min(initCO2, initO2 * 2f));
 
         float co2Removed = producedAmount;
         float oxyRemoved = producedAmount * 0.5f;
@@ -104,13 +89,9 @@ public sealed partial class PluoxiumRadiationProductionReaction : IGasReactionEf
         if (producedAmount <= 0) 
             return ReactionResult.Reacting;
 
-        float pluoxProduced = producedAmount;
-        float hydroProduced = producedAmount * 0.01f;
-
         mixture.AdjustMoles(Gas.CarbonDioxide, -co2Removed);
         mixture.AdjustMoles(Gas.Oxygen, -oxyRemoved);
-        mixture.AdjustMoles(Gas.Pluoxium, pluoxProduced);
-        mixture.AdjustMoles(Gas.Hydrogen, hydroProduced);
+        mixture.AdjustMoles(Gas.Pluoxium, producedAmount);
 
         float energyReleased = producedAmount * Atmospherics.PluoxiumProductionEnergy;
         float heatCap = atmosphereSystem.GetHeatCapacity(mixture, true);

--- a/Content.Server/_Funkystation/Atmos/Reactions/PluoxiumTritiumProductionReaction.cs
+++ b/Content.Server/_Funkystation/Atmos/Reactions/PluoxiumTritiumProductionReaction.cs
@@ -28,9 +28,7 @@ public sealed partial class PluoxiumTritiumProductionReaction : IGasReactionEffe
         var initCO2 = mixture.GetMoles(Gas.CarbonDioxide);
         var initTrit = mixture.GetMoles(Gas.Tritium);
 
-        float[] efficiencies = [5f, initCO2, initO2 * 2f, initTrit * 100f];
-        Array.Sort(efficiencies);
-        var producedAmount = efficiencies[0];
+        float producedAmount = Math.Min(5f, Math.Min(initCO2, Math.Min(initO2 * 2f, initTrit * 100f)));
 
         if (producedAmount <= 0)
             return ReactionResult.NoReaction;

--- a/Resources/Prototypes/Atmospherics/reactions.yml
+++ b/Resources/Prototypes/Atmospherics/reactions.yml
@@ -207,7 +207,7 @@
 
 - type: gasReaction
   id: PluoxiumRadiationProduction
-  priority: 3
+  priority: 4
   minimumTemperature: 50.0
   maximumTemperature: 273.15
   minimumRequirements:


### PR DESCRIPTION
## About the PR
Removes hydrogen formation from the pluoxium radiation production reaction. Hydrogen in the original reaction was always just tritium depleted of radiation. Without tritium there should be no hydrogen. Was left behind by mistake. 

Also just cleans up the code a bit and places the radiation reaction at a lower priority than the tritium reaction. 

## Why / Balance
Fix and cleanup

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None
