### PR TITLE
Roundstart weight tweaks

### DIFF
--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -34,14 +34,12 @@
 - type: weightedRandom # All dual antag gamemodes are goobstation
   id: Secret
   weights:
-    Traitor: 0.25 # Goobstation
-    Changeling: 0.03 # Goobstation unique antag
+    Traitor: 0.32
+    Changeling: 0.13 # Goobstation unique antag
     Traitorling: 0.12 # 2 antags but less of each type applies for all hybrid modes, they all need 30 pop. Also makes lower pops roll more traitor games.
     Nukeops: 0.15
-    Revolutionary: 0.15 # Maybe 0.08 after wiz/cult?
-    Survival: 0.04 # funky hi im putting something here because everything else has a comment
-    Blob: 0.05 #funky Blobmode
-    BlobTraitor: 0.1 #funky Blobmode
-    CosmicCult: 0.11
+    Revolutionary: 0.10 # Maybe 0.08 after wiz/cult?
+    Survival: 0.08 # funky hi im putting something here because everything else has a comment
+    CosmicCult: 0.10
 
 

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -23,6 +23,7 @@
 # SPDX-FileCopyrightText: 2024 username <113782077+whateverusername0@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 wafehling <wafehling@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 yglop <95057024+yglop@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 DevilishMilk <michaellapjr@gmail.com>
 # SPDX-FileCopyrightText: 2025 Mish <bluscout78@yahoo.com>
 # SPDX-FileCopyrightText: 2025 Skye <57879983+Rainbeon@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -34,12 +34,12 @@
 - type: weightedRandom # All dual antag gamemodes are goobstation
   id: Secret
   weights:
-    Traitor: 0.32
+    Traitor: 0.30
     Changeling: 0.13 # Goobstation unique antag
     Traitorling: 0.12 # 2 antags but less of each type applies for all hybrid modes, they all need 30 pop. Also makes lower pops roll more traitor games.
     Nukeops: 0.15
     Revolutionary: 0.10 # Maybe 0.08 after wiz/cult?
-    Survival: 0.08 # funky hi im putting something here because everything else has a comment
+    Survival: 0.10 # funky hi im putting something here because everything else has a comment
     CosmicCult: 0.10
 
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Modified Secret roundstart weightings.
Completely removed Blob and Blobtraitor from the roundstart pool.
Bumped Revolutionaries from 15% to 10%
Added the remainder of these over to Traitor, changeling, and Survival.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Staff discussion from a few days ago.
For blob rounds:
Blob always feels underwhelming as an inherent roundstart gamemode due to hinging the round on one person, and works best as a midround antagonist where it serves as a diversion of time and resources to the main antagonists of the round. That's not to say it's not incredibly powerful if ignored.
Revolutionaries are my favorite gamemode, but they can be pretty exhausting and slug-festy. Lowering the chances of it rolling makes it feel more special when it does roll, IMO.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Miiish
- tweak: Tweaked roundstart event weightings. TL;DR Revs down, Blobs down, Traitors, Changeling, Survival, up.
