### PR TITLE
fixed bug causing desword failures

### DIFF
--- a/Content.Shared/Item/SharedItemSystem.cs
+++ b/Content.Shared/Item/SharedItemSystem.cs
@@ -18,6 +18,9 @@
 // SPDX-FileCopyrightText: 2024 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Dia <diatomic.ge@gmail.com>
+// SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
+// SPDX-FileCopyrightText: 2025 ferynn <witchy.girl.me@gmail.com>
+// SPDX-FileCopyrightText: 2025 sleepyyapril <123355664+sleepyyapril@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 sleepyyapril <flyingkarii@gmail.com>
 // SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 //

--- a/Content.Shared/Item/SharedItemSystem.cs
+++ b/Content.Shared/Item/SharedItemSystem.cs
@@ -278,46 +278,44 @@ public abstract class SharedItemSystem : EntitySystem
         if (Container.TryGetContainingContainer((uid, null, null), out var container) &&
             !_handsSystem.IsHolding(container.Owner, uid)) // Funkystation - Don't move items in hands.
         {
+            // Funkystation - Check if the item is in a pocket.
+            var wasInPocket = false;
 
+            if (container == null || !_inventory.TryGetContainerSlotEnumerator(container.Owner, out var enumerator, SlotFlags.POCKET))
+                return;
+
+            while (enumerator.NextItem(out var slotItem, out var slot))
+            {
+                if (slotItem == uid)
+                    continue;
+
+                // Funkystation - We found it in a pocket.
+                wasInPocket = true;
+
+                if (_inventory.CanEquip(container.Owner, uid, slot.Name, out var _, slot))
+                    continue;
+
+                // Funkystation - It no longer fits, so try to hand it to whoever toggled it.
+                _transform.AttachToGridOrMap(uid);
+                _handsSystem.PickupOrDrop(args.User, uid, animate: true);
+            }
+
+            var exists = TryComp(container.Owner, out StorageComponent? storage);
+
+            if (!wasInPocket && exists) // Goobstation - reinsert item in storage because size changed
+            {
+                _transform.AttachToGridOrMap(uid);
+                return;
+            }
+
+            if (storage == null
+                || !_storage.Insert(container.Owner, uid, out _, null, storage, false))
+                return;
+
+            // Funkystation - It didn't fit, so try to hand it to whoever toggled it.
+            _handsSystem.PickupOrDrop(args.User, uid, animate: false);
+
+            Dirty(uid, item);
         }
-
-        // Funkystation - Check if the item is in a pocket.
-        var wasInPocket = false;
-
-        if (container == null || !_inventory.TryGetContainerSlotEnumerator(container.Owner, out var enumerator, SlotFlags.POCKET))
-            return;
-
-        while (enumerator.NextItem(out var slotItem, out var slot))
-        {
-            if (slotItem == uid)
-                continue;
-
-            // Funkystation - We found it in a pocket.
-            wasInPocket = true;
-
-            if (_inventory.CanEquip(container.Owner, uid, slot.Name, out var _, slot))
-                continue;
-
-            // Funkystation - It no longer fits, so try to hand it to whoever toggled it.
-            _transform.AttachToGridOrMap(uid);
-            _handsSystem.PickupOrDrop(args.User, uid, animate: true);
-        }
-
-        var exists = TryComp(container.Owner, out StorageComponent? storage);
-
-        if (!wasInPocket && exists) // Goobstation - reinsert item in storage because size changed
-        {
-            _transform.AttachToGridOrMap(uid);
-            return;
-        }
-
-        if (storage == null
-            || !_storage.Insert(container.Owner, uid, out _, null, storage, false))
-            return;
-
-        // Funkystation - It didn't fit, so try to hand it to whoever toggled it.
-        _handsSystem.PickupOrDrop(args.User, uid, animate: false);
-
-        Dirty(uid, item);
     }
 }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->

Put code block back in conditional statement that it needed to be in. Fixed desword bug.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Fixed technical bug.

## Technical details
<!-- Summary of code changes for easier review. -->

Desword stopped working after this [pr](https://github.com/funky-station/funky-station/pull/1164) which cleaned up code in the file. The block was out of a conditional it was meant to be in though. I put the code block back in the enclosing conditional, and it works again.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="898" height="664" alt="Screenshot 2025-08-07 164505" src="https://github.com/user-attachments/assets/054e5871-0d32-44e2-a15b-774deea5205e" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed code bug causing desword to fail

