### PR TITLE
implicit radio channels

### DIFF
--- a/Content.Server/Implants/RadioImplantSystem.cs
+++ b/Content.Server/Implants/RadioImplantSystem.cs
@@ -32,7 +32,7 @@ public sealed class RadioImplantSystem : EntitySystem
         var activeRadio = EnsureComp<ActiveRadioComponent>(args.Implanted.Value);
         foreach (var channel in ent.Comp.RadioChannels)
         {
-            if (activeRadio.Channels.Add(channel))
+            if (activeRadio.IntrinsicChannels.Add(channel))
                 ent.Comp.ActiveAddedChannels.Add(channel);
         }
 
@@ -41,7 +41,7 @@ public sealed class RadioImplantSystem : EntitySystem
         var intrinsicRadioTransmitter = EnsureComp<IntrinsicRadioTransmitterComponent>(args.Implanted.Value);
         foreach (var channel in ent.Comp.RadioChannels)
         {
-            if (intrinsicRadioTransmitter.Channels.Add(channel))
+            if (intrinsicRadioTransmitter.IntrinsicChannels.Add(channel))
                 ent.Comp.TransmitterAddedChannels.Add(channel);
         }
     }
@@ -55,7 +55,7 @@ public sealed class RadioImplantSystem : EntitySystem
         {
             foreach (var channel in ent.Comp.ActiveAddedChannels)
             {
-                activeRadioComponent.Channels.Remove(channel);
+                activeRadioComponent.IntrinsicChannels.Remove(channel);
             }
             ent.Comp.ActiveAddedChannels.Clear();
 
@@ -70,7 +70,7 @@ public sealed class RadioImplantSystem : EntitySystem
 
         foreach (var channel in ent.Comp.TransmitterAddedChannels)
         {
-            radioTransmitterComponent.Channels.Remove(channel);
+            radioTransmitterComponent.IntrinsicChannels.Remove(channel);
         }
         ent.Comp.TransmitterAddedChannels.Clear();
 

--- a/Content.Server/Radio/Components/ActiveRadioComponent.cs
+++ b/Content.Server/Radio/Components/ActiveRadioComponent.cs
@@ -6,7 +6,6 @@
 //
 // SPDX-License-Identifier: MIT
 
-using System.Linq;
 using Content.Shared.Radio;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Set;
 
@@ -29,8 +28,6 @@ public sealed partial class ActiveRadioComponent : Component
     /// </summay>
     [DataField("intrinsicChannels", customTypeSerializer: typeof(PrototypeIdHashSetSerializer<RadioChannelPrototype>))]
     public HashSet<string> IntrinsicChannels = new();
-
-    public IEnumerable<string> AllChannels => Channels.Union(IntrinsicChannels);
 
     /// <summary>
     /// A toggle for globally receiving all radio channels.

--- a/Content.Server/Radio/Components/ActiveRadioComponent.cs
+++ b/Content.Server/Radio/Components/ActiveRadioComponent.cs
@@ -6,6 +6,7 @@
 //
 // SPDX-License-Identifier: MIT
 
+using System.Linq;
 using Content.Shared.Radio;
 using Robust.Shared.Serialization.TypeSerializers.Implementations.Custom.Prototype.Set;
 
@@ -22,6 +23,14 @@ public sealed partial class ActiveRadioComponent : Component
     /// </summary>
     [DataField("channels", customTypeSerializer: typeof(PrototypeIdHashSetSerializer<RadioChannelPrototype>))]
     public HashSet<string> Channels = new();
+
+    /// <summary>
+    ///     The channels that this radio will always listen on.
+    /// </summay>
+    [DataField("intrinsicChannels", customTypeSerializer: typeof(PrototypeIdHashSetSerializer<RadioChannelPrototype>))]
+    public HashSet<string> IntrinsicChannels = new();
+
+    public IEnumerable<string> AllChannels => Channels.Union(IntrinsicChannels);
 
     /// <summary>
     /// A toggle for globally receiving all radio channels.

--- a/Content.Server/Radio/Components/IntrinsicRadioTransmitterComponent.cs
+++ b/Content.Server/Radio/Components/IntrinsicRadioTransmitterComponent.cs
@@ -4,6 +4,7 @@
 //
 // SPDX-License-Identifier: MIT
 
+using System.Linq;
 using Content.Server.Chat.Systems;
 using Content.Shared.Chat;
 using Content.Shared.Radio;
@@ -19,5 +20,14 @@ namespace Content.Server.Radio.Components;
 public sealed partial class IntrinsicRadioTransmitterComponent : Component
 {
     [DataField("channels", customTypeSerializer: typeof(PrototypeIdHashSetSerializer<RadioChannelPrototype>))]
-    public HashSet<string> Channels = new() { SharedChatSystem.CommonChannel };
+    public HashSet<string> Channels = new();
+
+    
+    /// <summary>
+    ///     The channels that this radio will always be able to talk to.
+    /// </summay>
+    [DataField("intrinsicChannels", customTypeSerializer: typeof(PrototypeIdHashSetSerializer<RadioChannelPrototype>))]
+    public HashSet<string> IntrinsicChannels = new();
+
+    public IEnumerable<string> AllChannels => Channels.Union(IntrinsicChannels);
 }

--- a/Content.Server/Radio/Components/IntrinsicRadioTransmitterComponent.cs
+++ b/Content.Server/Radio/Components/IntrinsicRadioTransmitterComponent.cs
@@ -4,7 +4,6 @@
 //
 // SPDX-License-Identifier: MIT
 
-using System.Linq;
 using Content.Server.Chat.Systems;
 using Content.Shared.Chat;
 using Content.Shared.Radio;
@@ -29,5 +28,4 @@ public sealed partial class IntrinsicRadioTransmitterComponent : Component
     [DataField("intrinsicChannels", customTypeSerializer: typeof(PrototypeIdHashSetSerializer<RadioChannelPrototype>))]
     public HashSet<string> IntrinsicChannels = new();
 
-    public IEnumerable<string> AllChannels => Channels.Union(IntrinsicChannels);
 }

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -24,7 +24,6 @@
 //
 // SPDX-License-Identifier: MIT
 
-using System.Linq;
 using Content.Server.Administration.Logs;
 using Content.Server.Chat.Systems;
 using Content.Server.Power.Components;
@@ -203,7 +202,7 @@ public sealed class RadioSystem : EntitySystem
     }
 
     private bool CanTalkChannel(EntityUid uid, string channelId){
-        if (TryComp<IntrinsicRadioTransmitterComponent>(uid, out var intrinsicTransmitter) && intrinsicTransmitter.AllChannels.Contains(channelId))
+        if (TryComp<IntrinsicRadioTransmitterComponent>(uid, out var intrinsicTransmitter) && (intrinsicTransmitter.IntrinsicChannels.Contains(channelId) || intrinsicTransmitter.Channels.Contains(channelId)))
             return true;
 
         return false;
@@ -211,7 +210,7 @@ public sealed class RadioSystem : EntitySystem
 
     private bool CanListenChannel(EntityUid uid, string channelId){
 
-        if (TryComp<ActiveRadioComponent>(uid, out var activeRadio) && activeRadio.AllChannels.Contains(channelId))
+        if (TryComp<ActiveRadioComponent>(uid, out var activeRadio) && (activeRadio.IntrinsicChannels.Contains(channelId) || activeRadio.Channels.Contains(channelId)))
             return true;
 
         return false;

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -24,6 +24,7 @@
 //
 // SPDX-License-Identifier: MIT
 
+using System.Linq;
 using Content.Server.Administration.Logs;
 using Content.Server.Chat.Systems;
 using Content.Server.Power.Components;
@@ -71,7 +72,7 @@ public sealed class RadioSystem : EntitySystem
 
     private void OnIntrinsicSpeak(EntityUid uid, IntrinsicRadioTransmitterComponent component, EntitySpokeEvent args)
     {
-        if (args.Channel != null && component.Channels.Contains(args.Channel.ID))
+        if (args.Channel != null && CanTalkChannel(uid, args.Channel.ID))
         {
             SendRadioMessage(uid, args.Message, args.Channel, uid);
             args.Channel = null; // prevent duplicate messages from other listeners.
@@ -152,7 +153,7 @@ public sealed class RadioSystem : EntitySystem
         {
             if (!radio.ReceiveAllChannels)
             {
-                if (!radio.Channels.Contains(channel.ID) || (TryComp<IntercomComponent>(receiver, out var intercom) &&
+                if (!CanListenChannel(receiver, channel.ID) || (TryComp<IntercomComponent>(receiver, out var intercom) &&
                                                              !intercom.SupportedChannels.Contains(channel.ID)))
                     continue;
             }
@@ -198,6 +199,21 @@ public sealed class RadioSystem : EntitySystem
                 return true;
             }
         }
+        return false;
+    }
+
+    private bool CanTalkChannel(EntityUid uid, string channelId){
+        if (TryComp<IntrinsicRadioTransmitterComponent>(uid, out var intrinsicTransmitter) && intrinsicTransmitter.AllChannels.Contains(channelId))
+            return true;
+
+        return false;
+    }
+
+    private bool CanListenChannel(EntityUid uid, string channelId){
+
+        if (TryComp<ActiveRadioComponent>(uid, out var activeRadio) && activeRadio.AllChannels.Contains(channelId))
+            return true;
+
         return false;
     }
 }

--- a/Content.Server/_DV/CosmicCult/Abilities/CosmicFragmentationSystem.cs
+++ b/Content.Server/_DV/CosmicCult/Abilities/CosmicFragmentationSystem.cs
@@ -123,14 +123,14 @@ public sealed class CosmicFragmentationSystem : EntitySystem
             return;
         if (args.Lawset.Id == "CosmicCultLaws")
         {
-            radio.Channels.Add(_cultRadio);
-            transmitter.Channels.Add(_cultRadio);
+            radio.IntrinsicChannels.Add(_cultRadio);
+            transmitter.IntrinsicChannels.Add(_cultRadio);
             _antag.SendBriefing(args.Target, Loc.GetString("cosmiccult-ai-subverted-briefing"), Color.FromHex("#4cabb3"), null);
         }
         else
         {
-            radio.Channels.Remove(_cultRadio);
-            transmitter.Channels.Remove(_cultRadio);
+            radio.IntrinsicChannels.Remove(_cultRadio);
+            transmitter.IntrinsicChannels.Remove(_cultRadio);
         }
     }
 }

--- a/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
+++ b/Content.Server/_DV/CosmicCult/CosmicCultRuleSystem.cs
@@ -624,8 +624,8 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
 
         var transmitter = EnsureComp<IntrinsicRadioTransmitterComponent>(uid);
         var radio = EnsureComp<ActiveRadioComponent>(uid);
-        radio.Channels.Add("CosmicRadio");
-        transmitter.Channels.Add("CosmicRadio");
+        radio.IntrinsicChannels.Add("CosmicRadio");
+        transmitter.IntrinsicChannels.Add("CosmicRadio");
 
         if (_mind.TryGetSession(mindId, out var session))
         {
@@ -762,9 +762,9 @@ public sealed class CosmicCultRuleSystem : GameRuleSystem<CosmicCultRuleComponen
         foreach (var actionEnt in uid.Comp.ActionEntities) _actions.RemoveAction(actionEnt);
 
         if (TryComp<IntrinsicRadioTransmitterComponent>(uid, out var transmitter))
-            transmitter.Channels.Remove("CosmicRadio");
+            transmitter.IntrinsicChannels.Remove("CosmicRadio");
         if (TryComp<ActiveRadioComponent>(uid, out var radio))
-            radio.Channels.Remove("CosmicRadio");
+            radio.IntrinsicChannels.Remove("CosmicRadio");
         RemComp<CosmicCultLeadComponent>(uid);
         RemComp<InfluenceVitalityComponent>(uid);
         RemComp<InfluenceStrideComponent>(uid);


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
I've fixed issues with encryption keys overriding implanted radio channels in IPCs.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
IPCs no longer lose access to any implanted channels when switching out their encryption keys.

## Technical details
<!-- Summary of code changes for easier review. -->
I've added new "implicit" channels to ActiveRadioComponent and IntrinsicRadioTransmitterComponent, that will be untouched by the EncryptionKeyHolderComponent. This solves the issue of EncryptionKeyHolder wiping all channels and building it from scratch using only the keys it has inserted.
I've gone through and switched implants and cosmic cult to use the new intrinsic channels.
This also adds a couple helpers in the RadioSystem.cs, for easier readability and logic implementation.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: IPCs who gain channels in a manner other than an encryption key will no longer lose it when changing keys.
