### PR TITLE
Removes MedTek cartridge from crew PDAs, boosts health analyzer usage a bit

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/belt.yml
@@ -34,6 +34,7 @@
 # SPDX-FileCopyrightText: 2024 Ubaser <134914314+UbaserB@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 jellygato <aly.jellygato@gmail.com>
 # SPDX-FileCopyrightText: 2024 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 DevilishMilk <michaellapjr@gmail.com>
 # SPDX-FileCopyrightText: 2025 IronDragoon <8961391+IronDragoon@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 IronDragoon <you@example.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>

--- a/Resources/Prototypes/Catalog/Fills/Items/belt.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/belt.yml
@@ -145,6 +145,7 @@
         amount: 1
       - id: Gauze
       - id: EmergencyMedipen #You never know what people are going to latejoin into
+      - id: HandheldHealthAnalyzer #funky
 
 - type: entity
   id: ClothingBeltMedicalEMTFilled
@@ -159,6 +160,7 @@
       - id: Gauze
       - id: EmergencyMedipen
       - id: ParamedHypo
+      - id: HandheldHealthAnalyzer #funky
 
 - type: entity
   id: ClothingBeltPlantFilled

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -323,7 +323,7 @@
     - id: MedicalScannerMachineCircuitboard
     #- id: CloningConsoleComputerCircuitboard
     - id: BiomassReclaimerMachineCircuitboard
-    - id: MedTekCartridge
+    #- id: MedTekCartridge #funky - medtek removal
     # Shitmed
     - id: MedicalBiofabMachineBoard
     - id: AutoclaveFlatpack # DV

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
@@ -14,6 +14,7 @@
 # SPDX-FileCopyrightText: 2024 Hanz <41141796+Hanzdegloker@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2024 fishbait <gnesse@gmail.com>
+# SPDX-FileCopyrightText: 2025 DevilishMilk <michaellapjr@gmail.com>
 # SPDX-FileCopyrightText: 2025 Fenn <162015305+TooSillyFennec@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 IronDragoon <8961391+IronDragoon@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 IronDragoon <you@example.com>

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/medical.yml
@@ -27,7 +27,7 @@
 - type: vendingMachineInventory
   id: NanoMedPlusInventory
   startingInventory:
-    HandheldHealthAnalyzer: 3
+    HandheldHealthAnalyzer: 5 #funky
     Brutepack: 5
     Ointment: 5
     Bloodpack: 5

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -264,7 +264,7 @@
       - NotekeeperCartridge
       - NanoTaskCartridge
       - NewsReaderCartridge
-      - MedTekCartridge
+      #- MedTekCartridge #funky - medtek removal
       - NanoChatCartridge # DeltaV
 
 - type: entity
@@ -1441,7 +1441,7 @@
     - NanoTaskCartridge
     - NewsReaderCartridge
     - WantedListCartridge
-    - MedTekCartridge
+    #- MedTekCartridge #funky - medtek removal
     - NanoChatCartridge # DeltaV
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/healthanalyzer.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/healthanalyzer.yml
@@ -74,7 +74,7 @@
   suffix: Powered
   components:
   - type: PowerCellDraw
-    drawRate: 1.2 #Calculated for 5 minutes on a small cell
+    drawRate: 1.8 #7.5 minutes on a small cell - funky change boosted by 50%
   - type: ToggleCellDraw
   - type: ActivatableUIRequiresPowerCell
 

--- a/Resources/Prototypes/_Funkystation/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Objects/Devices/pda.yml
@@ -123,7 +123,7 @@
       - NotekeeperCartridge
       - NanoTaskCartridge
       - NewsReaderCartridge
-      - MedTekCartridge
+      #- MedTekCartridge #funky - medtek removal
       - WantedListCartridge
       - LogProbeCartridge
       - AstroNavCartridge

--- a/Resources/Prototypes/_Funkystation/Entities/Objects/Misc/PDA_cartridge_case.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Objects/Misc/PDA_cartridge_case.yml
@@ -24,14 +24,14 @@
     size: Normal
   - type: Storage
     grid:
-    - 0,0,6,1
+    - 0,0,5,1
     whitelist:
       tags:
       - PDACart
   - type: StorageFill
     contents:
     - id: AstroNavCartridge
-    - id: MedTekCartridge
+    #- id: MedTekCartridge #funky - medtek removal
     - id: WantedListCartridge
     - id: LogProbeCartridge
     - id: NetProbeCartridge


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Removed the MedTek from Medical crew and the BSO.
Boosted health analyzer charge by 50%, so it should now hold about 7.5 minutes of constant use.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The MedTek seems a bit odd and out-of-place, and makes the health analyzer completely redundant. Why bother using this cool specialized tool if I have a constantly-charged better one constantly on me?

## Technical details
<!-- Summary of code changes for easier review. -->
yml edits galore

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Miiish
- remove: Removed the MedTek cartridge from crew PDAs.
- add: Doctors and Paramedics now start with health analyzers.
- tweak: Boosted health analyzer charge capacity by 50%
