### PR TITLE
(Bugfix) Fix RPD mirrored prototypes

### DIFF
--- a/Content.Shared/RCD/Systems/RCDSystem.cs
+++ b/Content.Shared/RCD/Systems/RCDSystem.cs
@@ -648,30 +648,21 @@ public class RCDSystem : EntitySystem
                 break;
 
             case RcdMode.ConstructObject:
-                // Funky - Determine the correct prototype based on selected layer for RPD
-                // var proto = (component.UseMirrorPrototype && !string.IsNullOrEmpty(component.CachedPrototype.MirrorPrototype))
-                //     ? component.CachedPrototype.MirrorPrototype
-                //     : component.CachedPrototype.Prototype;
+                var proto = (component.UseMirrorPrototype && !string.IsNullOrEmpty(component.CachedPrototype.MirrorPrototype))
+                    ? component.CachedPrototype.MirrorPrototype
+                    : component.CachedPrototype.Prototype;
 
-                string proto;
+                // Funky - Determine the correct prototype based on selected layer for RPD
                 if (component.IsRpd && !component.CachedPrototype.NoLayers)
                 {
-                    if (_protoManager.TryIndex<EntityPrototype>(component.CachedPrototype.Prototype, out var entityProto) &&
+                    if (_protoManager.TryIndex<EntityPrototype>(proto, out var entityProto) &&
                         entityProto.TryGetComponent<AtmosPipeLayersComponent>(out var atmosPipeLayers, _entityManager.ComponentFactory) &&
                         _pipeLayersSystem.TryGetAlternativePrototype(atmosPipeLayers, _currentLayer, out var newProtoId))
                     {
-                        proto = newProtoId;
+                        proto = (component.UseMirrorPrototype && !string.IsNullOrEmpty(component.CachedPrototype.MirrorPrototype))
+                              ? component.CachedPrototype.MirrorPrototype
+                              : newProtoId;
                     }
-                    else
-                    {
-                        proto = component.CachedPrototype.Prototype;
-                    }
-                }
-                else
-                {
-                    proto = (component.UseMirrorPrototype && !string.IsNullOrEmpty(component.CachedPrototype.MirrorPrototype))
-                        ? component.CachedPrototype.MirrorPrototype
-                        : component.CachedPrototype.Prototype;
                 }
                 // Funky - end of changes
 


### PR DESCRIPTION
## About the PR
Allows the RPD to build flipped filters and mixers. 

## Why / Balance
Someone broke filters and mixers.

## Technical details
RCDSystem now applies the mirrored prototype before checking for and switching to an alternate pipe layer. 

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None

**Changelog**
:cl:
- fix: The RPD is now able to print flipped filters and mixers again.
