### PR TITLE
MAYBE fixes rare biome/planetmap gen hangup related to goliath vs landmine

### DIFF
--- a/Content.Server/Explosion/EntitySystems/ExplosionSystem.GridMap.cs
+++ b/Content.Server/Explosion/EntitySystems/ExplosionSystem.GridMap.cs
@@ -15,6 +15,7 @@
 // SPDX-FileCopyrightText: 2024 beck-thompson <107373427+beck-thompson@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 deltanedas <39013340+deltanedas@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 eoineoineoin <github@eoinrul.es>
+// SPDX-FileCopyrightText: 2025 GreyMaria <mariomister541@gmail.com>
 // SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
 // SPDX-FileCopyrightText: 2025 Tayrtahn <tayrtahn@gmail.com>
 // SPDX-FileCopyrightText: 2025 marc-pelletier <113944176+marc-pelletier@users.noreply.github.com>


### PR DESCRIPTION
## About the PR
Copied over some Wizden code in the hopes that it might resolve a rare issue that causes chunkload systems to fail and logspam, with VERY noticeable issues in arrivals/expeditions. Seems to have resolved that issue by my testing. Scream at me if it happens again, but that probably won't help.

## Why / Balance
nobody likes gigabyte logfiles

## Technical details
Literally just handpicked some functions in `Content.Server/Explosion/EntitySystems/ExplosionSystem.GridMap.cs` to be parity with [current Wizden version of the code](https://github.com/space-wizards/space-station-14/blob/915d8152542f45bd197965147fff65807393e7f7/Content.Server/Explosion/EntitySystems/ExplosionSystem.GridMap.cs)

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
no cl no fun
