### PR TITLE
Fix ready manifest

### DIFF
--- a/Content.Server/GameTicking/GameTicker.Lobby.cs
+++ b/Content.Server/GameTicking/GameTicker.Lobby.cs
@@ -211,9 +211,15 @@ namespace Content.Server.GameTicking
             // Ensure that the player has a character enabled with a compatible job that can even join.
             var readyPossible = (_prefsManager.GetPreferencesOrNull(player.UserId)?.JobPrioritiesFiltered().Count ?? 0) != 0;
 
-            _playerGameStatuses[player.UserId] = ready && readyPossible
+            var newStatus = ready && readyPossible
                 ? PlayerGameStatus.ReadyToPlay
                 : PlayerGameStatus.NotReadyToPlay;
+
+            if (newStatus == _playerGameStatuses[player.UserId])
+                return;
+
+            _playerGameStatuses[player.UserId] = newStatus;
+
             RaiseNetworkEvent(GetStatusMsg(player), player.Channel);
             RaiseLocalEvent(new PlayerToggleReadyEvent(player));
             // update server info to reflect new ready count

--- a/Content.Server/GameTicking/GameTicker.Lobby.cs
+++ b/Content.Server/GameTicking/GameTicker.Lobby.cs
@@ -28,6 +28,7 @@
 // SPDX-FileCopyrightText: 2024 Mervill <mervills.email@gmail.com>
 // SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
 // SPDX-FileCopyrightText: 2024 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 Quantum-cross <7065792+Quantum-cross@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 //
 // SPDX-License-Identifier: MIT

--- a/Content.Server/Preferences/Managers/IServerPreferencesManager.cs
+++ b/Content.Server/Preferences/Managers/IServerPreferencesManager.cs
@@ -49,4 +49,20 @@ namespace Content.Server.Preferences.Managers
         /// </summary>
         Task DeleteProfile(NetUserId userId, int slot);
     }
+
+    public sealed class PlayerJobPriorityChangedEvent : EntityEventArgs
+    {
+        public readonly ICommonSession Session;
+        public readonly Dictionary<ProtoId<JobPrototype>, JobPriority> OldPriorities;
+        public readonly Dictionary<ProtoId<JobPrototype>, JobPriority> NewPriorities;
+
+        public PlayerJobPriorityChangedEvent(ICommonSession session,
+        Dictionary<ProtoId<JobPrototype>, JobPriority> oldPriorities,
+        Dictionary<ProtoId<JobPrototype>, JobPriority> newPriorities)
+        {
+            Session = session;
+            OldPriorities = oldPriorities;
+            NewPriorities = newPriorities;
+        }
+    }
 }

--- a/Content.Server/Preferences/Managers/IServerPreferencesManager.cs
+++ b/Content.Server/Preferences/Managers/IServerPreferencesManager.cs
@@ -9,6 +9,7 @@
 // SPDX-FileCopyrightText: 2024 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
 // SPDX-FileCopyrightText: 2024 deltanedas <39013340+deltanedas@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 Quantum-cross <7065792+Quantum-cross@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 //
 // SPDX-License-Identifier: MIT

--- a/Content.Server/Preferences/Managers/ServerPreferencesManager.cs
+++ b/Content.Server/Preferences/Managers/ServerPreferencesManager.cs
@@ -56,6 +56,7 @@ namespace Content.Server.Preferences.Managers
         [Dependency] private readonly IDependencyCollection _dependencies = default!;
         [Dependency] private readonly ILogManager _log = default!;
         [Dependency] private readonly UserDbDataManager _userDb = default!;
+        [Dependency] private readonly IEntityManager _entityManager = default!;
 
         // Cache player prefs on the server so we don't need as much async hell related to them.
         private readonly Dictionary<NetUserId, PlayerPrefData> _cachedPlayerPrefs =
@@ -131,6 +132,9 @@ namespace Content.Server.Preferences.Managers
 
             if (ShouldStorePrefs(session.Channel.AuthType))
                 await _db.SaveJobPrioritiesAsync(userId, jobPriorities);
+
+            var evt = new PlayerJobPriorityChangedEvent(session, curPrefs.JobPriorities, jobPriorities);
+            _entityManager.EventBus.QueueEvent(EventSource.Local, evt);
         }
 
         private async void HandleDeleteCharacterMessage(MsgDeleteCharacter message)

--- a/Content.Server/Preferences/Managers/ServerPreferencesManager.cs
+++ b/Content.Server/Preferences/Managers/ServerPreferencesManager.cs
@@ -20,6 +20,7 @@
 // SPDX-FileCopyrightText: 2024 deltanedas <39013340+deltanedas@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 nikthechampiongr <32041239+nikthechampiongr@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 Quantum-cross <7065792+Quantum-cross@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 //
 // SPDX-License-Identifier: MIT

--- a/Content.Server/ReadyManifest/ReadyManifestSystem.cs
+++ b/Content.Server/ReadyManifest/ReadyManifestSystem.cs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
+// SPDX-FileCopyrightText: 2025 Quantum-cross <7065792+Quantum-cross@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 //
 // SPDX-License-Identifier: MIT

--- a/Content.Server/ReadyManifest/ReadyManifestSystem.cs
+++ b/Content.Server/ReadyManifest/ReadyManifestSystem.cs
@@ -40,7 +40,10 @@ public sealed class ReadyManifestSystem : EntitySystem
 
     private void OnPlayerJobPriorityChanged(PlayerJobPriorityChangedEvent ev)
     {
-        if (_gameTicker.PlayerGameStatuses[ev.Session.UserId] != PlayerGameStatus.ReadyToPlay)
+        if (!_gameTicker.PlayerGameStatuses.TryGetValue(ev.Session.UserId, out var status))
+            return;
+
+        if (status != PlayerGameStatus.ReadyToPlay)
             return;
 
         var allJobs = ev.OldPriorities.Keys.Union(ev.NewPriorities.Keys);


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR

Fixed the ready manifest.

## Why / Balance

bug fix

## Technical details

Previously, if you ran `toggleready true/false`, it would increment or decrement job counters regardless of if your ready state is actually changing. This resulted in negative numbers on the manifest, as entering the character customization screen would force unready (even if you weren't ready).

Additionally, my multi-char changes adds the ability to change your job priorities (via drag and drop) while readied, so a new event and some logic is added to handle these cases.

## Media

### BEFORE:

https://github.com/user-attachments/assets/ded08390-190e-4977-bfd8-1578290cbcee

### AFTER:

https://github.com/user-attachments/assets/497749b6-ce3a-42ce-bba3-6ad63e5c952d


https://github.com/user-attachments/assets/8768e1da-1691-4454-a112-1b5ca66bd524


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

none

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Quantumcross
- fix: Fixed the ready manifest.

