### PR TITLE
pAI shop add encryption

### DIFF
--- a/Content.Server/_EinsteinEngines/Radio/IntrinsicRadioKeySystem.cs
+++ b/Content.Server/_EinsteinEngines/Radio/IntrinsicRadioKeySystem.cs
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 
 using Content.Server.Radio.Components;
+using Content.Shared.PAI;
 using Content.Shared.Radio;
 using Content.Shared.Radio.Components;
 
@@ -22,7 +23,8 @@ public sealed class IntrinsicRadioKeySystem : EntitySystem
 
     private void OnTransmitterChannelsChanged(EntityUid uid, IntrinsicRadioTransmitterComponent component, EncryptionChannelsChangedEvent args)
     {
-        UpdateChannels(uid, args.Component, ref component.Channels);
+        if (!HasComp<PAIComponent>(uid)) //We don't want to update what channels a pAI can talk to
+            UpdateChannels(uid, args.Component, ref component.Channels);
     }
 
     private void OnReceiverChannelsChanged(EntityUid uid, ActiveRadioComponent component, EncryptionChannelsChangedEvent args)

--- a/Content.Server/_EinsteinEngines/Radio/IntrinsicRadioKeySystem.cs
+++ b/Content.Server/_EinsteinEngines/Radio/IntrinsicRadioKeySystem.cs
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2024 Fishbait <Fishbait@git.ml>
 // SPDX-FileCopyrightText: 2024 John Space <bigdumb421@gmail.com>
+// SPDX-FileCopyrightText: 2025 Currot <carpecarrot@gmail.com>
 // SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later AND MIT

--- a/Content.Shared/PAI/SharedPAISystem.cs
+++ b/Content.Shared/PAI/SharedPAISystem.cs
@@ -6,7 +6,10 @@
 // SPDX-FileCopyrightText: 2023 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 mr-bo-jangles <mr-bo-jangles@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 ArchRBX <5040911+ArchRBX@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 Currot <carpecarrot@gmail.com>
 // SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
+// SPDX-FileCopyrightText: 2025 archrbx <punk.gear5260@fastmail.com>
+// SPDX-FileCopyrightText: 2025 jackel234 <52829582+jackel234@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 //
 // SPDX-License-Identifier: MIT

--- a/Content.Shared/PAI/SharedPAISystem.cs
+++ b/Content.Shared/PAI/SharedPAISystem.cs
@@ -12,6 +12,7 @@
 // SPDX-License-Identifier: MIT
 
 using Content.Shared.Actions;
+using Content.Shared.Radio.Components;
 
 namespace Content.Shared.PAI;
 
@@ -34,6 +35,8 @@ public abstract class SharedPAISystem : EntitySystem
 
         SubscribeLocalEvent<PAIComponent, MapInitEvent>(OnMapInit);
         SubscribeLocalEvent<PAIComponent, ComponentShutdown>(OnShutdown);
+
+        SubscribeLocalEvent<PAIComponent, PAIEnableEncryptionEvent>(EnableEncryption);
     }
 
     private void OnMapInit(Entity<PAIComponent> ent, ref MapInitEvent args)
@@ -45,7 +48,16 @@ public abstract class SharedPAISystem : EntitySystem
     {
         _actions.RemoveAction(ent, ent.Comp.ShopAction);
     }
+
+    private void EnableEncryption(Entity<PAIComponent> ent, ref PAIEnableEncryptionEvent args)
+    {
+        EnsureComp<EncryptionKeyHolderComponent>(ent, out var holder);
+        holder.KeySlots = 4;
+    }
 }
 public sealed partial class PAIShopActionEvent : InstantActionEvent
 {
 }
+
+[DataDefinition]
+public sealed partial class PAIEnableEncryptionEvent : EntityEventArgs;

--- a/Resources/Locale/en-US/store/pai-catalog.ftl
+++ b/Resources/Locale/en-US/store/pai-catalog.ftl
@@ -6,3 +6,6 @@ pai-midi-player-desc = Enables you to play music to entertain your owner.
 
 pai-station-map-name = Station Map
 pai-station-map-desc = Enables you to view the station map to assist in navigation.
+
+pai-enable-encryption-name = Encryption Keys
+pai-enable-encryption-desc = Enables you to accept encryption keys to hear more radio channels.

--- a/Resources/Prototypes/Catalog/pai_catalog.yml
+++ b/Resources/Prototypes/Catalog/pai_catalog.yml
@@ -45,3 +45,18 @@
   conditions:
   - !type:ListingLimitedStockCondition
     stock: 1
+
+- type: listing
+  id: PAIEnableEncryption
+  name: pai-enable-encryption-name
+  description: pai-enable-encryption-desc
+  productEvent: !type:PAIEnableEncryptionEvent
+  raiseProductEventOnUser: true
+  icon: {sprite: Objects/Devices/encryption_keys.rsi, state: crypt_gray}
+  cost:
+    SiliconMemory: 10
+  categories:
+  - PAIAbilities
+  conditions:
+  - !type:ListingLimitedStockCondition
+    stock: 1

--- a/Resources/Prototypes/Catalog/pai_catalog.yml
+++ b/Resources/Prototypes/Catalog/pai_catalog.yml
@@ -1,4 +1,7 @@
 # SPDX-FileCopyrightText: 2025 ArchRBX <5040911+ArchRBX@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Currot <carpecarrot@gmail.com>
+# SPDX-FileCopyrightText: 2025 archrbx <punk.gear5260@fastmail.com>
+# SPDX-FileCopyrightText: 2025 jackel234 <52829582+jackel234@users.noreply.github.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/pai.yml
@@ -86,10 +86,10 @@
   - type: Examiner
   - type: IntrinsicRadioReceiver
   - type: IntrinsicRadioTransmitter
-    channels:
+    intrinsicChannels:
     - Binary
   - type: ActiveRadio
-    channels:
+    intrinsicChannels:
     - Binary
     - Common
   - type: DoAfter
@@ -151,10 +151,10 @@
     mindRoles:
     - MindRoleGhostRoleFamiliar
   - type: IntrinsicRadioTransmitter
-    channels:
+    intrinsicChannels:
     - Syndicate
   - type: ActiveRadio
-    channels:
+    intrinsicChannels:
     - Syndicate
   - type: Appearance
   - type: GenericVisualizer

--- a/Resources/Prototypes/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/pai.yml
@@ -24,7 +24,10 @@
 # SPDX-FileCopyrightText: 2024 mr-bo-jangles <mr-bo-jangles@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 nikthechampiongr <32041239+nikthechampiongr@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 ArchRBX <5040911+ArchRBX@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Currot <carpecarrot@gmail.com>
 # SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2025 archrbx <punk.gear5260@fastmail.com>
+# SPDX-FileCopyrightText: 2025 jackel234 <52829582+jackel234@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 #


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
I've added a new store listing to the pAI shop, that enabled pAIs to accept encryption keys to hear (but not speak to) more channels.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I feel this will help pAI's become more helpful to their owners, so they can be more in tune with what their owner's department is doing and offer advice if needed. pAI's can still speak over binary.

## Technical details
<!-- Summary of code changes for easier review. -->
Other than adding the store listing and event, I also modified how the EncryptionKeyHolderComponent works to check if the entity is a pAI, and if it does, it does not modify what the pAI can speak to.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="407" height="85" alt="image" src="https://github.com/user-attachments/assets/bd0b9b5a-0c53-466a-acd2-94c75aebc7ef" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- add: The pAI store now contains an upgrade to allow a pAI to hear (but not speak on) more radio channels.
