### PR TITLE
Smoke Implant CD nerf

### DIFF
--- a/Resources/Prototypes/_Goobstation/Actions/types.yml
+++ b/Resources/Prototypes/_Goobstation/Actions/types.yml
@@ -26,10 +26,10 @@
 - type: entity
   id: ActivateSmokeImplant
   name: Release a cloud of smoke
-  description: Releases a cloud of smoke around you.
+  description: Releases a large cloud of smoke around you that lasts 15 seconds.
   components:
   - type: InstantAction
-    useDelay: 20
+    useDelay: 35
     itemIconStyle: BigAction
     priority: -20
     icon:


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Nerfs the Smoke Implanter's Cooldown from 20 seconds (Effective: 5) to 35 seconds (Effective: 20).

## Why / Balance
The Smoke Implanter is mostly fine, but stood out as a problem in one large way: The ability to entirely lock down vision from a spot with extremely short windows of opportunity. Previously this window of opportunity where you can actually see was 5 seconds, this has been increased to 20 seconds to increase counterplay.

The Smoke Implant with this CD change is still EXCELLENT value, costing only 10 TC overall for the equivalent of infinite Smoke Grenades and no inventory slots taken, but with a real time-gate, while a single-use Smoke Grenade costs 4 TC (40% the cost) and does use inventory space. It still functions well as an escape tool, but should be less oppressive in prolonged combat situations.

The result of Smoke lockdown is still possible to achieve in conjunction with Smoke Grenades with this, but this takes up additional TC and/or bag space as a cost (to pre-prepare) and the timers are not as clean, still leaving some windows to perform actions.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl:
- tweak: Smoke Implanter's cooldown has been changed from 20 seconds to 35 seconds. This leaves a gap where no smoke may exist from the Implant for 20 seconds total, up from the previous 5 seconds.

