### PR TITLE
Revs: Doubletap to Confirm Open Revolt

### DIFF
--- a/Resources/Locale/en-US/_Goobstation/game-ticking/game-presets/presets-revolutionaries.ftl
+++ b/Resources/Locale/en-US/_Goobstation/game-ticking/game-presets/presets-revolutionaries.ftl
@@ -24,6 +24,7 @@ revolutionaries-win-announcement =
 revolutionaries-win-sender = Yucatan Communications
 revolutionaries-sender-cc = Central Command
 
+revolutionaries-open-revolt-confirmation = THIS ACTION WILL REVEAL ALL HEAD REVS! Use it again to confirm.
 revolutionaries-open-revolt-rev-popup = Open Revolt has been declared! Viva la revolución!
 revolutionaries-open-revolt-announcement =
     We have detected a psionic declaration of Open Revolt aboard the station by active revolutionary cells.

--- a/Resources/Prototypes/_Funkystation/Actions/revs.yml
+++ b/Resources/Prototypes/_Funkystation/Actions/revs.yml
@@ -8,6 +8,8 @@
   name: Declare Open Revolt
   description: Declares Open Revolt, allowing all Revolutionaries to see each other's Revolutionary status, at the cost of outing the name of all Head Revolutionaries.
   components:
+  - type: ConfirmableAction
+    popup: revolutionaries-open-revolt-confirmation
   - type: InstantAction
     itemIconStyle: NoItem
     checkCanInteract: false


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
No more oopsy doopsy slippy wippies

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<img width="632" height="156" alt="image" src="https://github.com/user-attachments/assets/6cea1f80-f38c-43b9-914e-b708e4da9ba4" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl:
- tweak: The Declare Open Revolt button for Head Revs now must be pressed twice on a delay for confirmation, preventing accidental activations. This functions in the exact same way as the Death Acidifier's confirmation sequence.
