### PR TITLE
Longer time gates on antags

### DIFF
--- a/Resources/Prototypes/Roles/Antags/nukeops.yml
+++ b/Resources/Prototypes/Roles/Antags/nukeops.yml
@@ -30,7 +30,7 @@
   objective: roles-antag-nuclear-operative-objective
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 18000 # 5h
+    time: 36000 # 10h
   guides: [ NuclearOperatives ]
   previewStartingGear: SyndicateOperativeGearFull
 
@@ -42,10 +42,10 @@
   objective: roles-antag-nuclear-operative-agent-objective
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 18000 # 5h
+    time: 36000 # 10h
   - !type:RoleTimeRequirement
     role: JobChemist
-    time: 10800 # 3h
+    time: 18000 # 5h
   guides: [ NuclearOperatives ]
   previewStartingGear: SyndicateOperativeMedicFull
 
@@ -57,7 +57,7 @@
   objective: roles-antag-nuclear-operative-commander-objective
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 18000 # 5h
+    time: 180000 # 50h
   - !type:DepartmentTimeRequirement
     department: Security
     time: 18000 # 5h

--- a/Resources/Prototypes/Roles/Antags/revolutionary.yml
+++ b/Resources/Prototypes/Roles/Antags/revolutionary.yml
@@ -20,7 +20,7 @@
   guides: [ Revolutionaries ]
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 3600 # 1h
+    time: 36000 # 10hours
 
 - type: antag
   id: Rev

--- a/Resources/Prototypes/_DV/CosmicCult/cosmiccultist.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/cosmiccultist.yml
@@ -12,5 +12,5 @@
   objective: roles-antag-cosmiccult-description
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 43200 # 12h
+    time: 86400 # 24h
   guides: [ CosmicCult ]

--- a/Resources/Prototypes/_Funkystation/Roles/Antags/bloodcult.yml
+++ b/Resources/Prototypes/_Funkystation/Roles/Antags/bloodcult.yml
@@ -19,6 +19,9 @@
   setPreference: true
   objective: roles-antag-cult-objective
   guides: [ BloodCult ]
+  requirements:
+  - !type:OverallPlaytimeRequirement
+    time: 36000 # 10h
 
 - type: startingGear
   id: BloodCultistGear

--- a/Resources/Prototypes/_Goobstation/Changeling/Roles/Antags/changeling.yml
+++ b/Resources/Prototypes/_Goobstation/Changeling/Roles/Antags/changeling.yml
@@ -21,3 +21,6 @@
     species:
     - IPC
   guides: [ Changelings ]
+  requirements:
+  - !type:OverallPlaytimeRequirement
+    time: 18000 # 5h

--- a/Resources/Prototypes/_Goobstation/Roles/Antags/blob.yml
+++ b/Resources/Prototypes/_Goobstation/Roles/Antags/blob.yml
@@ -13,4 +13,4 @@
   guides: [ Blob ]
   requirements:
   - !type:OverallPlaytimeRequirement
-    time: 18000 # 5h # Goobstation-RoleTime
+    time: 54000 # 15h


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
SPDX-FileCopyrightText: 2025 Terkala <5533221177+Terkala@users.noreply.github.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Lengthened timegates for a lot of antags, and added some timegates for antags that had none.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I've been seeing a lot of people enable all antags without really thinking about it, since most antags can be enabled with just a tiny bit of job time. In order to hopefully stop that I have increased the time gates. It won't matter for most people, as over 80% of the server has more time than all of these gates.

## Technical details
<!-- Summary of code changes for easier review. -->
Adding timegates to the yes/no in the lobby.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- tweak: Longer timegates for most antagonists
-->
