### PR TITLE
Purchaseable HEV Suit Crate and Ashing Immunity Tooltip

### DIFF
--- a/Content.Shared/Armor/SharedArmorSystem.cs
+++ b/Content.Shared/Armor/SharedArmorSystem.cs
@@ -5,6 +5,7 @@
 // SPDX-FileCopyrightText: 2025 pa.pecherskij <pa.pecherskij@interfax.ru>
 // SPDX-FileCopyrightText: 2025 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+// SPDX-FileCopyrightText: 2025 unknown <alexander.kuepper1234@gmail.com>
 //
 // SPDX-License-Identifier: MIT
 

--- a/Content.Shared/Armor/SharedArmorSystem.cs
+++ b/Content.Shared/Armor/SharedArmorSystem.cs
@@ -13,6 +13,7 @@ using Content.Shared.Examine;
 using Content.Shared.Inventory;
 using Content.Shared.Silicons.Borgs;
 using Content.Shared.Verbs;
+using Content.Shared._EE.Supermatter.Components;
 using Robust.Shared.Utility;
 
 namespace Content.Shared.Armor;
@@ -64,7 +65,7 @@ public abstract class SharedArmorSystem : EntitySystem
         if (!args.CanInteract || !args.CanAccess || !component.ShowArmorOnExamine)
             return;
 
-        var examineMarkup = GetArmorExamine(component.Modifiers);
+        var examineMarkup = GetArmorExamine(component.Modifiers, uid);
 
         var ev = new ArmorExamineEvent(examineMarkup);
         RaiseLocalEvent(uid, ref ev);
@@ -74,7 +75,7 @@ public abstract class SharedArmorSystem : EntitySystem
             Loc.GetString("armor-examinable-verb-message"));
     }
 
-    private FormattedMessage GetArmorExamine(DamageModifierSet armorModifiers)
+    private FormattedMessage GetArmorExamine(DamageModifierSet armorModifiers, EntityUid? uid = null)
     {
         var msg = new FormattedMessage();
         msg.AddMarkupOrThrow(Loc.GetString("armor-examine"));
@@ -107,6 +108,12 @@ public abstract class SharedArmorSystem : EntitySystem
                 ("type", armorType),
                 ("value", flatArmor.Value)
             ));
+        }
+
+        if (uid != null && HasComp<SupermatterImmuneComponent>(uid.Value))
+        {
+            msg.PushNewline();
+            msg.AddMarkupOrThrow(Loc.GetString("armor-supermatter-immune"));
         }
 
         return msg;

--- a/Resources/Locale/en-US/armor/armor-examine.ftl
+++ b/Resources/Locale/en-US/armor/armor-examine.ftl
@@ -27,3 +27,4 @@ armor-damage-type-poison = Poison
 armor-damage-type-shock = Shock
 armor-damage-type-structural = Structural
 armor-damage-type-holy = Holy
+armor-supermatter-immune = - [color=orange]Supermatter[/color] ashing [color=lightblue]immunity[/color].

--- a/Resources/Prototypes/_Funkystation/Catalog/Cargo/cargo_engineering.yml
+++ b/Resources/Prototypes/_Funkystation/Catalog/Cargo/cargo_engineering.yml
@@ -1,4 +1,7 @@
+# SPDX-FileCopyrightText: 2025 AtlasHD <99688062+AtlasHDD@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 ThatOneMoon <91613003+ThatOneGuy227@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 ThatOneMoon <juozas.dringelis@gmail.com>
+# SPDX-FileCopyrightText: 2025 unknown <alexander.kuepper1234@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/_Funkystation/Catalog/Cargo/cargo_engineering.yml
+++ b/Resources/Prototypes/_Funkystation/Catalog/Cargo/cargo_engineering.yml
@@ -20,7 +20,7 @@
   product: CrateEngineeringAtmosEquipment
   cost: 9000
   category: cargoproduct-category-name-engineering
-  group: market
+  group: market  
 
 - type: cargoProduct
   id: BasicHardsuit

--- a/Resources/Prototypes/_Funkystation/Catalog/Cargo/cargo_engineering.yml
+++ b/Resources/Prototypes/_Funkystation/Catalog/Cargo/cargo_engineering.yml
@@ -20,7 +20,7 @@
   product: CrateEngineeringAtmosEquipment
   cost: 9000
   category: cargoproduct-category-name-engineering
-  group: market  
+  group: market
 
 - type: cargoProduct
   id: BasicHardsuit
@@ -30,4 +30,14 @@
   product: CrateBasicHardsuit
   cost: 4500
   category: cargoproduct-category-name-engineering
-  group: market  
+  group: market
+
+- type: cargoProduct
+  id: EngineeringHEVCrate
+  icon:
+    sprite: _Goobstation/Clothing/OuterClothing/Suits/hev.rsi
+    state: icon
+  product: CrateEngineeringHEV
+  cost: 5000
+  category: cargoproduct-category-name-engineering
+  group: market

--- a/Resources/Prototypes/_Funkystation/Catalog/Fills/Crates/engineering.yml
+++ b/Resources/Prototypes/_Funkystation/Catalog/Fills/Crates/engineering.yml
@@ -39,7 +39,7 @@
      - id: NitrogenTankFilled
      - id: OxygenTankFilled
      - id: RCD
-     - id: RCDAmmo     
+     - id: RCDAmmo
      - id: HolofanProjector
 
 - type: entity
@@ -51,5 +51,18 @@
   - type: StorageFill
     contents:
       - id: ClothingOuterHardsuitBasic
-      - id: NitrogenTankFilled 
-      - id: OxygenTankFilled    
+      - id: NitrogenTankFilled
+      - id: OxygenTankFilled
+
+- type: entity
+  id: CrateEngineeringHEV
+  parent: CrateEngineeringSecure
+  name: HEV equipment crate
+  description: Contains a full HEV suit and a crowbar for handling hazardous materials safely.
+  components:
+  - type: StorageFill
+    contents:
+     - id: ClothingOuterSuitHEV
+     - id: CrowbarYellow
+     - id: NitrogenTankFilled
+     - id: OxygenTankFilled

--- a/Resources/Prototypes/_Funkystation/Catalog/Fills/Crates/engineering.yml
+++ b/Resources/Prototypes/_Funkystation/Catalog/Fills/Crates/engineering.yml
@@ -1,4 +1,7 @@
+# SPDX-FileCopyrightText: 2025 AtlasHD <99688062+AtlasHDD@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 ThatOneMoon <91613003+ThatOneGuy227@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 ThatOneMoon <juozas.dringelis@gmail.com>
+# SPDX-FileCopyrightText: 2025 unknown <alexander.kuepper1234@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/Resources/Prototypes/_Funkystation/Catalog/Fills/Crates/engineering.yml
+++ b/Resources/Prototypes/_Funkystation/Catalog/Fills/Crates/engineering.yml
@@ -39,7 +39,7 @@
      - id: NitrogenTankFilled
      - id: OxygenTankFilled
      - id: RCD
-     - id: RCDAmmo
+     - id: RCDAmmo     
      - id: HolofanProjector
 
 - type: entity

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Head/helmets.yml
@@ -8,7 +8,7 @@
 - type: entity
   parent: ClothingHeadHelmetHardsuitBasic
   id: ClothingHeadHelmetHEV
-  name: H.E.V helmet
+  name: HEV helmet
   description: Not included in a set with crowbar, long jump module and gravity manipulation device.
   components:
   - type: Sprite

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/Head/helmets.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/Head/helmets.yml
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2025 QueerCats <jansencheng3@gmail.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2025 unknown <alexander.kuepper1234@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 - type: entity

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/specific.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/specific.yml
@@ -4,6 +4,7 @@
 # SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2025 McBosserson <148172569+McBosserson@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2025 unknown <alexander.kuepper1234@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 

--- a/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/specific.yml
+++ b/Resources/Prototypes/_Goobstation/Entities/Clothing/OuterClothing/specific.yml
@@ -10,8 +10,8 @@
 - type: entity
   parent: ClothingOuterHardsuitBase
   id: ClothingOuterSuitHEV
-  name: H.E.V suit
-  description: Full-body hazardous suit designed to protect wearer from radiation, energy discarges, blunt-force trauma during the handling of hazardous material.
+  name: HEV suit
+  description: A full-body hazardous environment suit designed to protect its wearer from radiation, energy discharges, blunt-force trauma, and disintegration during the handling of hazardous materials.
   components:
   - type: Sprite
     sprite: _Goobstation/Clothing/OuterClothing/Suits/hev.rsi
@@ -32,6 +32,7 @@
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHEV
+  - type: SupermatterImmune
   - type: ClothingGrantComponent
     component:
       - type: SupermatterImmune


### PR DESCRIPTION
## About the PR
I added an purchaseable HEV equipment crate for 5000 spesos that includes a HEV suit, crowbar, and nitrogen/oxygen tanks. Adjusted HEV suit & helmet descriptions and changed naming from H.E.V to HEV. 
All suits that don’t ash in contact with the SM now display this in their armor examine text.

## Why / Balance
The HEV suit is currently only rarely available, either by being mapped in or through low-chance radiation locker spawns. Aside from the CE hardsuit, it's the only hardsuit that resists contact with the SM. The HEV suit is also useful for other departments like Science, who often need proper hardsuits instead of relying on EVA suits. The new crate increases availability while the 5000 spesos price tag keeps it a significant investment and can be adjusted for balance if needed.

## Technical details
- Added SupermatterImmune type to ClothingOuterSuitHEV 
- Extended SharedArmorSystem.cs to show an examine tooltip for SupermatterImmune suits (HEV and CE)
- Added new crate to _Funkystation Catalog (cargo_engineering.yml + engineering.yml).

## Media
<img width="350" height="250" alt="hev_description" src="https://github.com/user-attachments/assets/ae01c497-b190-4ebd-a40a-e7e3b052d8d3" />
<img width="350" height="250" alt="hev_armor_inspect" src="https://github.com/user-attachments/assets/69372a42-01d9-4a57-8241-8d9eabb29311" />
<img width="718" height="350" alt="hev_ordering" src="https://github.com/user-attachments/assets/7f179e1b-6942-4a25-8b6d-e609514c629a" />

## Requirements
- [X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X ] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A

**Changelog**

🆑
- add: Added purchaseable HEV equipment crate. Added armor examine message to HEV and CE hardsuits showing they are immune to supermatter ashing.
- tweak: Standardized HEV suit and helmet names/descriptions and fixed typos.

