### PR TITLE
Crew Kidnapping Buffs + Mind Control price decrease

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/handcuffs.yml
@@ -33,6 +33,7 @@
 # SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2024 Whisper <121047731+QuietlyWhisper@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 username <113782077+whateverusername0@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Rainbow <ev0lvkitten@gmail.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/stunprod.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/stunprod.yml
@@ -14,6 +14,7 @@
 # SPDX-FileCopyrightText: 2024 shamp <140359015+shampunj@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 username <113782077+whateverusername0@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Rainbow <ev0lvkitten@gmail.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT

--- a/Resources/Prototypes/Recipes/Crafting/Graphs/improvised/makeshifthandcuffs.yml
+++ b/Resources/Prototypes/Recipes/Crafting/Graphs/improvised/makeshifthandcuffs.yml
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2021 SETh lafuente <cetaciocascarudo@gmail.com>
 # SPDX-FileCopyrightText: 2021 SethLafuente <84478872+SethLafuente@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2021 metalgearsloth <comedian_vs_clown@hotmail.com>
+# SPDX-FileCopyrightText: 2025 Rainbow <ev0lvkitten@gmail.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 #
 # SPDX-License-Identifier: MIT

--- a/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
@@ -15,6 +15,7 @@
 # SPDX-FileCopyrightText: 2024 yglop <95057024+yglop@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Benjamin Velliquette <32338704+bVelliquette@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 McBosserson <148172569+McBosserson@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Rainbow <ev0lvkitten@gmail.com>
 # SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2025 UristMcWiki <endernate2015@gmail.com>
 # SPDX-FileCopyrightText: 2025 amatwiedle <amatwiedle@gmail.com>


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
Buffing up some less-used options relating to Kidnapping by general crew members, mainly targeted toward Syndies + Revs. Almost all of these options are either never seen (Stun Prod, Mind Control Implant), or rarely seen (Makeshift Cuffs).

## Why / Balance
Mind Control Implant: 50 TC -> 30 TC 

This puts the price on par with Reinforcement Radio. As you have to actually interact with a player to use this, and potentially get caught in doing so, whereas the Radio is completely free, literally noone uses this currently because of the prior reasonings + the cost. So the price decrease should encourage its use more.

======

Makeshift Cuffs: Self-breakout time: 3 sec -> 8 sec

Babysitting someone isn't fun for anyone, and 3 seconds is so low that if they're spamming it you legitimately just can not roleplay because every time you try to type or act, if you dont finish the message in 3 seconds theyre free and beating ya ass, 8 seconds is around half the proper cuffs breakout timer

======

Makeshift Cuffs: Cost: 15 LV -> 10 LV

Make 3 per LV cable set instead of 2, more accessible to Revs en masse!

======

Stunprod: Uses: 3 -> 5 swings

You physically can not stun anyone with a Sec Hardsuit anymore with this thing due to the Hardsuit Stun Resist, and it needs a TON of mechanical precision on anyone else, as if you hit the wrong target once you lose with only 3 swings (aka bad on Revs! And why it never gets used). This makes it more forgiving for general use while also making it capable of stunning Sec Offs again. Having it just under 6 swings means you can still only stun 1 person with it per charge.


## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl:
- tweak: Lowered the price of the Mind Control Implant to 30 TC. This is on par with the Reinforcement Radio in cost, and down from the prior 50 TC.
- tweak: It now takes 8 seconds to break yourself out of Makeshift Handcuffs, up from 3.
- tweak: Makeshift Handcuffs now cost 10 LV cables, instead of the prior 15 LV cables. This means you can make 3 sets of cuffs per Cable stack, instead of 2.
- tweak: The craftable Stun Prod now can be swung 5 times before it runs out of charge, down from 3. This allows it to be used to stun Hardsuit wearers again with enough swings, as well as requiring less precision to successfully stun someone in general.
