### PR TITLE
Lasers pass #3 - armor value changes

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -35,6 +35,7 @@
 # SPDX-FileCopyrightText: 2024 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 voidnull000 <18663194+voidnull000@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 Джексон Миссиссиппи <tripwiregamer@gmail.com>
+# SPDX-FileCopyrightText: 2025 DevilishMilk <michaellapjr@gmail.com>
 # SPDX-FileCopyrightText: 2025 QueerCats <jansencheng3@gmail.com>
 # SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2025 ferynn <117872973+ferynn@users.noreply.github.com>

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/armor.yml
@@ -156,11 +156,11 @@
         Blunt: 0.9
         Slash: 0.9
         Piercing: 0.9
-        Heat: 0.4 # this technically means it protects against fires pretty well? -heat is just for lasers and stuff, not atmos temperature
+        Heat: 0.5 # this technically means it protects against fires pretty well? -heat is just for lasers and stuff, not atmos temperature
   - type: StaminaResistance
     damageCoefficient: 0.85
   - type: Reflect
-    reflectProb: 1
+    reflectProb: 0.8
     reflects:
       - Energy
 

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -117,7 +117,7 @@
         Blunt: 0.9
         Slash: 0.9
         Piercing: 0.9
-        Heat: 0.8
+        Heat: 0.7
         Radiation: 0.5
   - type: ExplosionResistance
     damageCoefficient: 0.5
@@ -149,7 +149,8 @@
       coefficients:
         Blunt: 0.9
         Slash: 0.9
-        Piercing: 0.9
+        Piercing: 0.8
+        Heat: 0.8
         Shock: 0.5
         Caustic: 0.8
         Radiation: 0.2
@@ -317,15 +318,15 @@
         Blunt: 0.6
         Slash: 0.6
         Piercing: 0.6
-        Heat: 0.7 # Goobstation
+        Heat: 0.6
         Caustic: 0.7
   - type: ExplosionResistance
     damageCoefficient: 0.4
   - type: StaminaResistance
     damageCoefficient: 0.8
   - type: ClothingSpeedModifier
-    walkModifier: 0.75
-    sprintModifier: 0.75
+    walkModifier: 0.8
+    sprintModifier: 0.8
   - type: HeldSpeedModifier
   - type: ToggleableClothing
     clothingPrototype: ClothingHeadHelmetHardsuitSecurity
@@ -383,7 +384,7 @@
         Blunt: 0.5
         Slash: 0.6
         Piercing: 0.6
-        Heat: 0.7 # Goobstation
+        Heat: 0.6
         Caustic: 0.7
   - type: ExplosionResistance
     damageCoefficient: 0.4
@@ -566,7 +567,7 @@
         Piercing: 0.5
         Radiation: 0.5
         Caustic: 0.6
-        Heat: 0.6 # Goobstation
+        Heat: 0.5
   - type: ClothingSpeedModifier
     walkModifier: 0.8
     sprintModifier: 0.8
@@ -632,10 +633,10 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.5
-        Slash: 0.5
+        Blunt: 0.6
+        Slash: 0.6
         Piercing: 0.5
-        Heat: 0.5
+        Heat: 0.4
         Radiation: 0.5
         Caustic: 0.5
   - type: ClothingSpeedModifier
@@ -694,10 +695,10 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.6
-        Slash: 0.6
+        Blunt: 0.7
+        Slash: 0.7
         Piercing: 0.6
-        Heat: 0.2
+        Heat: 0.25
         Radiation: 0.01
         Caustic: 0.5
   - type: Item
@@ -730,10 +731,10 @@
   - type: Armor
     modifiers:
       coefficients:
-        Blunt: 0.4
-        Slash: 0.4
-        Piercing: 0.3
-        Heat: 0.5
+        Blunt: 0.5
+        Slash: 0.5
+        Piercing: 0.4
+        Heat: 0.4
         Radiation: 0.25
         Caustic: 0.4
   - type: ClothingSpeedModifier
@@ -767,7 +768,7 @@
         Blunt: 0.2
         Slash: 0.2
         Piercing: 0.2
-        Heat: 0.2
+        Heat: 0.25
         Radiation: 0.2
         Caustic: 0.2
   - type: ClothingSpeedModifier

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/hardsuits.yml
@@ -52,6 +52,7 @@
 # SPDX-FileCopyrightText: 2024 deltanedas <39013340+deltanedas@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 nikthechampiongr <32041239+nikthechampiongr@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 username <113782077+whateverusername0@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 DevilishMilk <michaellapjr@gmail.com>
 # SPDX-FileCopyrightText: 2025 QueerCats <jansencheng3@gmail.com>
 # SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2025 VMSolidus <evilexecutive@gmail.com>

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/vests.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/vests.yml
@@ -61,9 +61,9 @@
     modifiers:
       coefficients:
         Blunt: 0.7 #slightly better overall protection but slightly worse than bulletproof armor against bullets seems sensible
-        Slash: 0.7
+        Slash: 0.5
         Piercing: 0.5
-        Heat: 0.9
+        Heat: 0.8
   - type: ExplosionResistance
     damageCoefficient: 0.9
 
@@ -102,6 +102,10 @@
   - type: Tag
     tags:
     - HiViz
+  - type: Reflect
+    reflectProb: 0.1
+    reflects:
+    - Energy
 
 #(Bartender) vest -  #Funky - bartender changes
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/vests.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/vests.yml
@@ -13,6 +13,7 @@
 # SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2024 wafehling <wafehling@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 whateverusername0 <whateveremail>
+# SPDX-FileCopyrightText: 2025 DevilishMilk <michaellapjr@gmail.com>
 # SPDX-FileCopyrightText: 2025 McBosserson <148172569+McBosserson@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 QueerCats <jansencheng3@gmail.com>
 # SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Battery/battery_guns.yml
@@ -636,8 +636,8 @@
     soundGunshot:
       path: /Audio/Weapons/Guns/Gunshots/taser2.ogg
   - type: ProjectileBatteryAmmoProvider
-    proto: BulletDisablerSmg
-    fireCost: 25
+    proto: ProjectileEnergyGunDisablerSmall #funky
+    fireCost: 50 #funky
   - type: MagazineVisuals
     magState: mag
     steps: 5

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -147,6 +147,7 @@
 # SPDX-FileCopyrightText: 2024 to4no_fix <156101927+chavonadelal@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 yglop <95057024+yglop@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 DevilishMilk <michaellapjr@gmail.com>
 # SPDX-FileCopyrightText: 2025 Gansu <68031780+GansuLalan@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 IronDragoon <8961391+IronDragoon@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 IronDragoon <you@example.com>
@@ -159,6 +160,8 @@
 # SPDX-FileCopyrightText: 2025 Steve <marlumpy@gmail.com>
 # SPDX-FileCopyrightText: 2025 Tadeo <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2025 TheSecondLord <88201625+TheSecondLord@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 V <97265903+formlessnameless@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 aa5g21 <aa5g21@soton.ac.uk>
 # SPDX-FileCopyrightText: 2025 corresp0nd <46357632+corresp0nd@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 deltanedas <39013340+deltanedas@users.noreply.github.com>

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -1086,21 +1086,21 @@
     - MagazineBoxLightRifleSilver
     - MagazineBoxMagnum
     - MagazineBoxMagnumPractice
-    - MagazineBoxPistol
-    - MagazineBoxPistolPractice
-    - MagazineBoxRifle
-    - MagazineBoxRiflePractice
-    - MagazineLightRifle
-    - MagazineLightRifleSilver
-    - MagazineLightRifleEmpty
-    - MagazinePistol
-    - MagazinePistolEmpty
-    - MagazinePistolSubMachineGun
-    - MagazinePistolSubMachineGunEmpty
-    - MagazinePistolSubMachineGunTopMounted
-    - MagazinePistolSubMachineGunTopMountedEmpty
-    - MagazineRifle
-    - MagazineRifleEmpty
+#    - MagazineBoxPistol # funky start
+#    - MagazineBoxPistolPractice
+#    - MagazineBoxRifle
+#    - MagazineBoxRiflePractice
+#    - MagazineLightRifle
+#    - MagazineLightRifleSilver
+#    - MagazineLightRifleEmpty
+#    - MagazinePistol
+#    - MagazinePistolEmpty
+#    - MagazinePistolSubMachineGun
+#    - MagazinePistolSubMachineGunEmpty
+#    - MagazinePistolSubMachineGunTopMounted
+#    - MagazinePistolSubMachineGunTopMountedEmpty
+#    - MagazineRifle
+#    - MagazineRifleEmpty # funky end
     - MagazineShotgun
     - MagazineShotgunEmpty
     - MagazineShotgunSlug
@@ -1141,21 +1141,21 @@
     - MagazineBoxLightRifleUranium
     - MagazineBoxMagnumIncendiary
     - MagazineBoxMagnumUranium
-    - MagazineBoxPistolIncendiary
-    - MagazineBoxPistolUranium
-    - MagazineBoxRifleIncendiary
-    - MagazineBoxRifleUranium
+#    - MagazineBoxPistolIncendiary # funky
+#    - MagazineBoxPistolUranium
+#    - MagazineBoxRifleIncendiary
+#    - MagazineBoxRifleUranium
     - MagazineGrenadeEmpty
-    - MagazineLightRifleIncendiary
-    - MagazineLightRifleUranium
-    - MagazinePistolIncendiary
-    - MagazinePistolUranium
-    - MagazineRifleIncendiary
-    - MagazineRifleUranium
+#    - MagazineLightRifleIncendiary # funky
+#    - MagazineLightRifleUranium
+#    - MagazinePistolIncendiary
+#    - MagazinePistolUranium
+#    - MagazineRifleIncendiary
+#    - MagazineRifleUranium
     - MagazineShotgunBeanbag
     - MagazineShotgunIncendiary
-    - MagazinePistolSubMachineGunTopMountedIncendiary
-    - MagazinePistolSubMachineGunTopMountedUranium
+#    - MagazinePistolSubMachineGunTopMountedIncendiary # funky
+#    - MagazinePistolSubMachineGunTopMountedUranium
     - PortableRecharger
     - PowerCageHigh
     - PowerCageMedium

--- a/Resources/Prototypes/_Funkystation/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -105,3 +105,21 @@
   components:
   - type: StaminaDamageOnCollide
     damage: 0
+
+- type: entity
+  name : disabler bolt
+  id: ProjectileEnergyGunDisablerSmall
+  parent: ProjectileEnergyGunDisabler
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: StaminaDamageOnCollide
+    damage: 15
+  - type: Fixtures
+    fixtures:
+      projectile:
+        shape:
+          !type:PhysShapeAabb
+          bounds: "-0.15,-0.3,0.15,0.3"
+        hard: false
+        mask:
+        - Opaque


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: MIT -->
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Armor value pass, secfab change, disabler SMG projectile switchover
