### PR TITLE
Shotgun Deckard 

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -103,7 +103,7 @@
   name: Deckard
   parent: [BaseWeaponRevolver, BaseSecurityCommandContraband]
   id: WeaponRevolverDeckard
-  description: A beautifully machined, custom-built revolver. Used when there is no time for the Voight-Kampff test. Loads 5 rounds of .45 magnum.
+  description: A beautifully machined, custom-built revolver. Used when there is no time for the Voight-Kampff test. Loads 5 rounds of .50 shotgun shells.
   components:
   - type: Sprite
     sprite: Objects/Weapons/Guns/Revolvers/deckard.rsi
@@ -119,6 +119,10 @@
     capacity: 5
     chambers: [ True, True, True, True, True ]
     ammoSlots: [ null, null, null, null, null ]
+    proto: ShellShotgun # Funky Station
+    whitelist:
+      tags:
+        - ShellShotgun
   - type: MagazineVisuals
     magState: mag
     steps: 4

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Revolvers/revolvers.yml
@@ -39,6 +39,7 @@
 # SPDX-FileCopyrightText: 2024 username <113782077+whateverusername0@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 QueerCats <jansencheng3@gmail.com>
 # SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2025 ThatOneMoon <juozas.dringelis@gmail.com>
 # SPDX-FileCopyrightText: 2025 pa.pecherskij <pa.pecherskij@interfax.ru>
 # SPDX-FileCopyrightText: 2025 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>


### PR DESCRIPTION
## About the PR
Changes the Deckards caliber from .45 magnum into .50 shotgun shells 

## Why / Balance
The Deckard has always been a somewhat forgotten weapon, supposedly intended as a emergency weapon to use for command, it being only 5 shots of .45 meant it rarely makes a differance 

With the laser arsenal slowly on its way and most balistics exept for shotguns being phased out, seems like a oportunity to give it some much needed attention.

With 5 shotgun shots that can be fired in pretty rapidly it would now be a supprisingly effective weapon for emergencies 

And it would make it stand out as a properly unique weapon rather than just a borderline sidegrade to the inspector.

Due to not being able to use a speed loader on it, instead needing to load 1 shell at a time, helps reinforce it as more of a emergency weapon for command.

Also
Shotgun. Revolver. 
## Technical details
just simple yml. 

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: ThatOneMoon
- tweak: The Deckard has been rechambered to from .45 magnum into .50 shotgun shells 

