### PR TITLE
FIX late join antag selection, add character selection integration tests, add some more admin logging

### DIFF
--- a/Content.IntegrationTests/Pair/TestPair.Recycle.cs
+++ b/Content.IntegrationTests/Pair/TestPair.Recycle.cs
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: 2024 Aidenkrz <aiden@djkraz.com>
 // SPDX-FileCopyrightText: 2024 Leon Friedrich <60421075+ElectroJr@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
+// SPDX-FileCopyrightText: 2025 Jen Pollock <jen@jenpollock.ca>
 // SPDX-FileCopyrightText: 2025 Quantum-cross <7065792+Quantum-cross@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 //

--- a/Content.IntegrationTests/Pair/TestPair.Recycle.cs
+++ b/Content.IntegrationTests/Pair/TestPair.Recycle.cs
@@ -11,6 +11,7 @@
 #nullable enable
 using System.IO;
 using System.Linq;
+using Content.Client.Lobby;
 using Content.Server.GameTicking;
 using Content.Server.Preferences.Managers;
 using Content.Shared.CCVar;
@@ -100,26 +101,27 @@ public sealed partial class TestPair : IAsyncDisposable
     {
         if (Player == null)
             return;
-        await Server.WaitIdleAsync();
-        var prefMan = Server.ResolveDependency<IServerPreferencesManager>();
 
-        var prefs = prefMan.GetPreferences(Player.UserId);
+        await ReallyBeIdle();
 
-        foreach(var slot in prefs.Characters.Keys)
+        // reset through the client so that the client's cached preferences get updated
+        var prefMan = Client.ResolveDependency<IClientPreferencesManager>();
+        var prefs = prefMan.Preferences;
+
+        await Client.WaitAssertion(() =>
         {
-            if (slot == 0)
-                continue;
-            await Server.WaitPost(() =>
+            foreach (var slot in prefs!.Characters.Keys)
             {
-                prefMan.DeleteProfile(Player.UserId, slot).Wait();
-            });
-        }
+                if (slot == 0)
+                    continue;
+                prefMan.DeleteCharacter(slot);
+            }
 
-        await Server.WaitPost(() =>
-        {
-            prefMan.SetProfile(Player.UserId, 0, new HumanoidCharacterProfile().AsEnabled()).Wait();
-            prefMan.SetJobPriorities(Player.UserId, new () { { SharedGameTicker.FallbackOverflowJob, JobPriority.High } }).Wait();
+            prefMan.UpdateCharacter(new HumanoidCharacterProfile().AsEnabled(), 0);
+            prefMan.UpdateJobPriorities(new() { { SharedGameTicker.FallbackOverflowJob, JobPriority.High } });
         });
+
+        await ReallyBeIdle();
     }
 
     public async ValueTask CleanReturnAsync()

--- a/Content.IntegrationTests/Tests/Round/CharacterSelectionTest.cs
+++ b/Content.IntegrationTests/Tests/Round/CharacterSelectionTest.cs
@@ -179,6 +179,21 @@ public sealed class CharacterSelectionTest
                 new() { Jobs = [ Clown ], Traitor = true }
             ]
         },
+        // disabled characters should be ignored
+        new()
+        {
+            MediumPrioJobs = [Passenger, Mime],
+            Characters =
+            [
+                new() { Jobs = [ Mime ], ExpectToSpawn = true },
+                new() { Jobs = [ Passenger ], Enabled = false },
+                new() { Jobs = [ Mime ], Enabled = false },
+                new() { Jobs = [ Captain ], Enabled = false },
+                new() { Jobs = [ Passenger, Mime, Captain ], Enabled = false },
+                new() { Jobs = [ Passenger, Mime, Captain ], Enabled = false }
+            ],
+            ExpectedJob = Mime
+        },
         // adapted from https://github.com/space-wizards/space-station-14/pull/36493#issuecomment-2926983119
         new()
         {

--- a/Content.IntegrationTests/Tests/Round/CharacterSelectionTest.cs
+++ b/Content.IntegrationTests/Tests/Round/CharacterSelectionTest.cs
@@ -20,6 +20,8 @@ public sealed class CharacterSelectionTest
 {
 
     private static readonly string _map = "CharacterSelectionTestMap";
+
+    // this testing game mode attempts to make everyone a traitor
     private static readonly string _traitorsMode = "OopsAllTraitors";
 
     [TestPrototypes]
@@ -144,8 +146,31 @@ public sealed class CharacterSelectionTest
 
     public static readonly List<SelectionTestData> SelectionTestCaseData =
     [
-        new() // Case 1 from https://github.com/space-wizards/space-station-14/pull/36493#issuecomment-3014257219
+        // a player with one character & one job, traitor enabled, should spawn as that job and as a traitor
+        // (note that the game mode used for these tests attempts to make every player a traitor)
+        new()
         {
+            HighPrioJob = Passenger,
+            Characters =
+            [
+                new() { Jobs = [ Passenger ], Traitor = true, ExpectToSpawn = true}
+            ],
+            ExpectedJob = Passenger,
+            ExpectTraitor = true
+        },
+        // a player with only a job that doesn't appear on the station shouldn't spawn, even if they could be
+        // selected as a traitor
+        new()
+        {
+            HighPrioJob = Clown,
+            Characters =
+            [
+                new() { Jobs = [ Clown ], Traitor = true }
+            ]
+        },
+        // Case 1 from https://github.com/space-wizards/space-station-14/pull/36493#issuecomment-3014257219
+        // if a player has no antag-compatible jobs enabled they should not be selected as an antag
+        new() {
             HighPrioJob = Captain,
             Characters =
             [
@@ -154,7 +179,10 @@ public sealed class CharacterSelectionTest
             ExpectedJob = Captain,
             ExpectTraitor = false
         },
-        new() // Case 2 from https://github.com/space-wizards/space-station-14/pull/36493#issuecomment-3014257219
+        // Case 2 from https://github.com/space-wizards/space-station-14/pull/36493#issuecomment-3014257219
+        // a player that is selected as an antag should always roll a character & job compatible with that
+        // antag selection
+        new()
         {
             MediumPrioJobs = [ Mime, Passenger ],
             Characters =
@@ -169,24 +197,6 @@ public sealed class CharacterSelectionTest
             ],
             ExpectedJob = Mime,
             ExpectTraitor = true
-        },
-        new()
-        {
-            HighPrioJob = Passenger,
-            Characters =
-            [
-                new() { Jobs = [ Passenger ], Traitor = true, ExpectToSpawn = true}
-            ],
-            ExpectedJob = Passenger,
-            ExpectTraitor = true
-        },
-        new()
-        {
-            HighPrioJob = Clown,
-            Characters =
-            [
-                new() { Jobs = [ Clown ], Traitor = true }
-            ]
         }
     ];
 

--- a/Content.IntegrationTests/Tests/Round/CharacterSelectionTest.cs
+++ b/Content.IntegrationTests/Tests/Round/CharacterSelectionTest.cs
@@ -243,7 +243,7 @@ public sealed class CharacterSelectionTest
         // https://github.com/space-wizards/space-station-14/pull/36493#issuecomment-3014257219,
         // so this tests the updated behaviour
         // Since this player has no enabled characters that are eligible to be a traitor, their session will not be
-        // selector to be an antag, and thus the Captain character will be eligible to spawn, even if the Captain
+        // selected to be an antag, and thus the Captain character will be eligible to spawn, even if the Captain
         // character has traitor enabled.
         new()
         {

--- a/Content.IntegrationTests/Tests/Round/CharacterSelectionTest.cs
+++ b/Content.IntegrationTests/Tests/Round/CharacterSelectionTest.cs
@@ -1,0 +1,217 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Castle.Components.DictionaryAdapter.Xml;
+using Content.Client.Lobby;
+using Content.Server.Antag;
+using Content.Server.GameTicking;
+using Content.Server.Humanoid;
+using Content.Shared.CCVar;
+using Content.Shared.GameTicking;
+using Content.Shared.Preferences;
+using Content.Shared.Roles;
+using Robust.Shared.Prototypes;
+
+namespace Content.IntegrationTests.Tests.Round;
+
+[TestFixture]
+public sealed class CharacterSelectionTest
+{
+
+    private static readonly string _map = "CharacterSelectionTestMap";
+    private static readonly string _traitorsMode = "OopsAllTraitors";
+
+    [TestPrototypes]
+    private static readonly string Prototypes = $@"
+- type: entity
+  parent: BaseTraitorRule
+  id: {_traitorsMode}
+  components:
+  - type: GameRule
+    minPlayers: 0
+    delay:
+      min: 5
+      max: 10
+  - type: AntagSelection
+    selectionTime: IntraPlayerSpawn
+    definitions:
+    - prefRoles: [ Traitor ]
+      max: 99
+      playerRatio: 1
+      blacklist:
+        components:
+        - AntagImmune
+      lateJoinAdditional: true
+      mindRoles:
+      - MindRoleTraitor
+
+- type: gamePreset
+  id: {_traitorsMode}
+  name: traitor-title
+  description: traitor-description
+  showInVote: false
+  rules:
+  - {_traitorsMode}
+
+- type: gameMap
+  id: {_map}
+  mapName: {_map}
+  mapPath: /Maps/Test/empty.yml
+  minPlayers: 0
+  stations:
+    Empty:
+      mapNameTemplate: {_map}
+      stationProto: StandardNanotrasenStation
+      components:
+        - type: StationJobs
+          availableJobs:
+            Captain: [ 1, 1 ]
+            Passenger: [ -1, -1 ]
+";
+
+    // a few little helper structs for test case definition readability
+    public sealed class TestJobPriorities
+    {
+        public JobPriority Captain;
+        public JobPriority Passenger;
+
+        public Dictionary<ProtoId<JobPrototype>, JobPriority> ToDictForPreferences()
+        {
+            var dict = new Dictionary<ProtoId<JobPrototype>, JobPriority>();
+            if (Captain != JobPriority.Never)
+            {
+                dict.Add("Captain", Captain);
+            }
+            if (Passenger != JobPriority.Never)
+            {
+                dict.Add("Passenger", Passenger);
+            }
+            return dict;
+        }
+    }
+
+    public sealed class TestCharacter
+    {
+        public bool Captain;
+        public bool Passenger;
+        public bool Traitor;
+
+        public HumanoidCharacterProfile ToProfile()
+        {
+            var profile = HumanoidCharacterProfile.Random().AsEnabled();
+            if (Captain)
+            {
+                profile = profile.WithJob("Captain");
+            }
+            // default job set has passenger already
+            if (!Passenger)
+            {
+                profile = profile.WithoutJob("Passenger");
+            }
+            if (Traitor)
+            {
+                profile = profile.WithAntagPreference("Traitor", true);
+            }
+            return profile;
+        }
+    }
+
+    public sealed class SelectionTestData
+    {
+        public TestJobPriorities JobPriorities;
+        public TestCharacter ExpectedCharacter;    // null if player should not be spawned
+        public List<TestCharacter> OtherCharacters = [];
+        public string ExpectedJobName = "";
+        public bool ExpectTraitor;
+    }
+
+    // use a function for test data so we can use classes
+    public static IEnumerable<SelectionTestData> SelectionTestCases()
+    {
+        yield return new SelectionTestData()
+        {
+            JobPriorities = new TestJobPriorities(){Passenger = JobPriority.High},
+            ExpectedCharacter = new TestCharacter(){Passenger = true, Traitor = true},
+            ExpectedJobName = "Passenger",
+            ExpectTraitor = true
+        };
+    }
+
+    [Test]
+    [TestCaseSource(nameof(SelectionTestCases))]
+    public async Task SelectionTest(SelectionTestData data)
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings
+        {
+            DummyTicker = false,
+            Connected = true,
+            InLobby = true,
+        });
+        pair.Server.CfgMan.SetCVar(CCVars.GameMap, _map);
+
+        var ticker = pair.Server.System<GameTicker>();
+
+        ticker.SetGamePreset(_traitorsMode);
+
+        var cPref = pair.Client.ResolveDependency<IClientPreferencesManager>();
+
+        await pair.ReallyBeIdle();
+
+        HumanoidCharacterProfile expectedCharacterProfile = null;
+
+        await pair.Client.WaitAssertion(() =>
+        {
+            if (data.ExpectedCharacter != null)
+            {
+                expectedCharacterProfile = data.ExpectedCharacter.ToProfile();
+                cPref.CreateCharacter(expectedCharacterProfile);
+            }
+
+            foreach (var character in data.OtherCharacters)
+            {
+                cPref.CreateCharacter(character.ToProfile());
+            }
+
+            // delete initial default character now that there are other character(s) so it won't
+            // just be immediately re-created
+            cPref.DeleteCharacter(0);
+
+            cPref.UpdateJobPriorities(data.JobPriorities.ToDictForPreferences());
+        });
+
+        await pair.ReallyBeIdle();
+
+        Assert.That(ticker.PlayerGameStatuses[pair.Client.User!.Value], Is.EqualTo(PlayerGameStatus.NotReadyToPlay));
+        ticker.ToggleReadyAll(true);
+        Assert.That(ticker.PlayerGameStatuses[pair.Client.User!.Value], Is.EqualTo(PlayerGameStatus.ReadyToPlay));
+        await pair.Server.WaitPost(() => ticker.StartRound());
+        await pair.RunTicksSync(30);
+
+        if (expectedCharacterProfile == null)
+        {
+            Assert.That(ticker.PlayerGameStatuses[pair.Client.User!.Value], Is.EqualTo(PlayerGameStatus.NotReadyToPlay));
+        }
+        else
+        {
+            pair.AssertJob(data.ExpectedJobName, pair.Player!);
+            var humanoidAppearanceSystem = pair.Server.System<HumanoidAppearanceSystem>();
+            var antagSystem = pair.Server.System<AntagSelectionSystem>();
+            var antags = antagSystem.GetPreSelectedAntagDefinitions(pair.Player);
+            if (data.ExpectTraitor)
+            {
+                Assert.That(antags.Count, Is.EqualTo(1));
+                Assert.That(antags.First().MindRoles.Count, Is.EqualTo(1));
+                Assert.That(antags.First().MindRoles.First(), Is.EqualTo("MindRoleTraitor"));
+            }
+            else
+            {
+                Assert.That(antags.Count, Is.EqualTo(0));
+            }
+            // TODO: check correct profile spawned
+            // and maybe check status??
+        }
+
+        await pair.Server.WaitPost(() => ticker.RestartRound());
+        await pair.CleanReturnAsync();
+    }
+
+}

--- a/Content.IntegrationTests/Tests/Round/CharacterSelectionTest.cs
+++ b/Content.IntegrationTests/Tests/Round/CharacterSelectionTest.cs
@@ -1,7 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using NUnit.Framework;
-using Castle.Components.DictionaryAdapter.Xml;
 using Content.Client.Lobby;
 using Content.Server.Antag;
 using Content.Server.GameTicking;

--- a/Content.IntegrationTests/Tests/Round/CharacterSelectionTest.cs
+++ b/Content.IntegrationTests/Tests/Round/CharacterSelectionTest.cs
@@ -160,16 +160,6 @@ public sealed class CharacterSelectionTest
 
     public static readonly List<SelectionTestData> SelectionTestCaseData =
     [
-        new()
-        {
-            JobPriorities = new TestJobPriorities() { Passenger = JobPriority.High },
-            Characters =
-            [
-                new TestCharacter() { Passenger = true, Traitor = true, ExpectToSpawn = true}
-            ],
-            ExpectedJobName = "Passenger",
-            ExpectTraitor = true
-        },
         new() // Case 1 from https://github.com/space-wizards/space-station-14/pull/36493#issuecomment-3014257219
         {
             JobPriorities = new TestJobPriorities() { Captain = JobPriority.High },
@@ -194,6 +184,16 @@ public sealed class CharacterSelectionTest
                 new TestCharacter() { Captain = true }
             ],
             ExpectedJobName = "Mime",
+            ExpectTraitor = true
+        },
+        new()
+        {
+            JobPriorities = new TestJobPriorities() { Passenger = JobPriority.High },
+            Characters =
+            [
+                new TestCharacter() { Passenger = true, Traitor = true, ExpectToSpawn = true}
+            ],
+            ExpectedJobName = "Passenger",
             ExpectTraitor = true
         },
         new()
@@ -280,14 +280,11 @@ public sealed class CharacterSelectionTest
 
         await pair.ReallyBeIdle();
 
-    //    pair.Server.ResolveDependency<IRobustRandom>().SetSeed(6);
-    //    pair.Client.ResolveDependency<IRobustRandom>().SetSeed(6);
-
         Assert.That(ticker.PlayerGameStatuses[pair.Client.User!.Value], Is.EqualTo(PlayerGameStatus.NotReadyToPlay));
         ticker.ToggleReadyAll(true);
         Assert.That(ticker.PlayerGameStatuses[pair.Client.User!.Value], Is.EqualTo(PlayerGameStatus.ReadyToPlay));
         await pair.Server.WaitPost(() => ticker.StartRound());
-        await pair.RunTicksSync(50);
+        await pair.RunTicksSync(30);
 
         if (expectedCharacterProfile == null)
         {

--- a/Content.IntegrationTests/Tests/Round/CharacterSelectionTest.cs
+++ b/Content.IntegrationTests/Tests/Round/CharacterSelectionTest.cs
@@ -107,6 +107,7 @@ public sealed class CharacterSelectionTest
         public List<TestCharacter> Characters = [];
         public ProtoId<JobPrototype>? ExpectedJob;
         public bool ExpectTraitor;
+        public int? SetSeed;
 
         public SelectionTestData WithCharacters(IEnumerable<TestCharacter> newCharacters)
         {
@@ -118,7 +119,8 @@ public sealed class CharacterSelectionTest
                 LowPrioJobs = LowPrioJobs,
                 Characters = newCharacters.ToList(),
                 ExpectedJob = ExpectedJob,
-                ExpectTraitor = ExpectTraitor
+                ExpectTraitor = ExpectTraitor,
+                SetSeed = SetSeed,
             };
         }
 
@@ -340,7 +342,11 @@ public sealed class CharacterSelectionTest
         ticker.SetGamePreset(TraitorsMode);
 
         var cPref = pair.Client.ResolveDependency<IClientPreferencesManager>();
-        pair.Server.ResolveDependency<IRobustRandom>().SetSeed(0);
+
+        if(data.SetSeed is not null)
+        {
+            pair.Server.ResolveDependency<IRobustRandom>().SetSeed(data.SetSeed.Value);
+        }
 
         await pair.ReallyBeIdle();
 
@@ -404,6 +410,11 @@ public sealed class CharacterSelectionTest
 
     // Run multiple round starts with the same set of characters, all of which are valid to select,
     // and verify that which character is selected varies
+    // This uses a random seed and theoretically has a chance of randomly failing naturally.
+    // The probability of this test failing is (1 - 1/c)^n where c is the number of characters and n is the maximum
+    // number of rounds to run.
+    // Currently this test is set to 4 characters, with a max of 48 rounds, making the probability of
+    // failing one in a million. If you manage this, go buy a lottery ticket.
     [Test]
     public async Task VarietyTest()
     {
@@ -420,7 +431,6 @@ public sealed class CharacterSelectionTest
         ticker.SetGamePreset(TraitorsMode);
 
         var cPref = pair.Client.ResolveDependency<IClientPreferencesManager>();
-        pair.Server.ResolveDependency<IRobustRandom>().SetSeed(0);
 
         await pair.ReallyBeIdle();
 

--- a/Content.IntegrationTests/Tests/Round/CharacterSelectionTest.cs
+++ b/Content.IntegrationTests/Tests/Round/CharacterSelectionTest.cs
@@ -18,9 +18,10 @@ namespace Content.IntegrationTests.Tests.Round;
 [TestFixture]
 public sealed class CharacterSelectionTest
 {
-
+    // this map has slots for captain, mime, unlimited passengers, and no clowns
     private static readonly string _map = "CharacterSelectionTestMap";
 
+    // this game mode attempts to make everyone a traitor
     private static readonly string _traitorsMode = "OopsAllTraitors";
 
     [TestPrototypes]
@@ -153,6 +154,7 @@ public sealed class CharacterSelectionTest
         }
     }
 
+    // actual test case definitions for cases that should result in a specific character/job/traitor combination
     public static readonly List<SelectionTestData> SelectionTestCaseData =
     [
         // a player with one character & one job, traitor enabled, should spawn as that job and as a traitor
@@ -235,7 +237,7 @@ public sealed class CharacterSelectionTest
         }
     ];
 
-    // use a function for test data so we can use classes
+    // use a function for test data so we can use classes & also test different permutations of the same characters
     public static IEnumerable<SelectionTestData> SelectionTestCases()
     {
         foreach (var testCaseData in SelectionTestCaseData)

--- a/Content.IntegrationTests/Tests/Round/CharacterSelectionTest.cs
+++ b/Content.IntegrationTests/Tests/Round/CharacterSelectionTest.cs
@@ -222,6 +222,23 @@ public sealed class CharacterSelectionTest
             ],
             ExpectedJob = Mime
         },
+        // Medium priority job should be chosen over low priority job with same weight, then the character
+        // with that job should spawn; job with no slots on station should have no effect
+        new()
+        {
+            Description = "Many chars, one with expected medium prio job",
+            HighPrioJob = Clown,
+            MediumPrioJobs = [ Passenger ],
+            LowPrioJobs = [ Mime ],
+            Characters =
+            [
+                new() { Jobs = [ Passenger ], ExpectToSpawn = true },
+                new() { Jobs = [ Mime ] },
+                new() { Jobs = [ Captain ] },
+                new() { Jobs = [ Clown ] }
+            ],
+            ExpectedJob = Passenger
+        },
         // adapted from https://github.com/space-wizards/space-station-14/pull/36493#issuecomment-2926983119
         new()
         {

--- a/Content.IntegrationTests/Tests/Round/CharacterSelectionTest.cs
+++ b/Content.IntegrationTests/Tests/Round/CharacterSelectionTest.cs
@@ -273,7 +273,7 @@ public sealed class CharacterSelectionTest
         // antag selection
         // Put another way, a player should only be pre-selected to be an antag if they have characters to be eligible
         // to be an antag. Thus if a player is pre-selected to be an antag, they should then only be eligible for the
-        // set of antag-compatible jobs made from enabled characters.
+        // set of antag-compatible jobs made from enabled characters that have that antag enabled.
         new()
         {
             Description = "Many chars, one antag",

--- a/Content.IntegrationTests/Tests/Round/CharacterSelectionTest.cs
+++ b/Content.IntegrationTests/Tests/Round/CharacterSelectionTest.cs
@@ -270,28 +270,28 @@ public sealed class CharacterSelectionTest
     // use a function for test data so we can use classes & also test different permutations of the same characters
     public static IEnumerable<TestCaseData> SelectionTestCases()
     {
-        foreach (var testCaseData in SelectionTestCaseData)
+        foreach (var testCase in SelectionTestCaseData)
         {
-            yield return testCaseData.ToTestCaseData();
+            yield return testCase.ToTestCaseData();
 
             // test different orders of characters with the same rng seed to minimize effects of rng on tests
             // (the rng seed is set in SelectionTest())
-            if (testCaseData.Characters.Count > 1)
+            if (testCase.Characters.Count > 1)
             {
-                var reversedCharacters = testCaseData.Characters.ShallowClone();
+                var reversedCharacters = testCase.Characters.ShallowClone();
                 reversedCharacters.Reverse();
-                yield return testCaseData.WithCharacters(reversedCharacters).ToTestCaseData();
+                yield return testCase.WithCharacters(reversedCharacters).ToTestCaseData();
             }
 
-            if (testCaseData.Characters.Count > 2)
+            if (testCase.Characters.Count > 2)
             {
-                var rotatedCharacters = testCaseData.Characters.ShallowClone();
-                for (var i = 1; i < testCaseData.Characters.Count; i++)
+                var rotatedCharacters = testCase.Characters.ShallowClone();
+                for (var i = 1; i < testCase.Characters.Count; i++)
                 {
                     var movingCharacter = rotatedCharacters[0];
                     rotatedCharacters.RemoveAt(0);
                     rotatedCharacters.Add(movingCharacter);
-                    yield return testCaseData.WithCharacters(rotatedCharacters).ToTestCaseData();
+                    yield return testCase.WithCharacters(rotatedCharacters).ToTestCaseData();
                 }
             }
         }

--- a/Content.IntegrationTests/Tests/Round/CharacterSelectionTest.cs
+++ b/Content.IntegrationTests/Tests/Round/CharacterSelectionTest.cs
@@ -205,6 +205,23 @@ public sealed class CharacterSelectionTest
             ],
             ExpectedJob = Mime
         },
+        // High priority job should be chosen over medium priority job with same weight, then the character
+        // with that job should spawn
+        new()
+        {
+            Description = "Many chars, one with high prio job",
+            HighPrioJob = Mime,
+            MediumPrioJobs = [ Passenger ],
+            Characters =
+            [
+                new() { Jobs = [ Mime ], ExpectToSpawn = true },
+                new() { Jobs = [ Passenger ] },
+                new() { Jobs = [ Passenger ] },
+                new() { Jobs = [ Captain ] },
+                new() { Jobs = [ Clown ] }
+            ],
+            ExpectedJob = Mime
+        },
         // adapted from https://github.com/space-wizards/space-station-14/pull/36493#issuecomment-2926983119
         new()
         {

--- a/Content.IntegrationTests/Tests/Round/CharacterSelectionTest.cs
+++ b/Content.IntegrationTests/Tests/Round/CharacterSelectionTest.cs
@@ -1,4 +1,9 @@
-﻿using System.Collections.Generic;
+// SPDX-FileCopyrightText: 2025 Jen Pollock <jen@jenpollock.ca>
+// SPDX-FileCopyrightText: 2025 Quantum-cross <7065792+Quantum-cross@users.noreply.github.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+using System.Collections.Generic;
 using System.Linq;
 using Content.Client.Lobby;
 using Content.Server.Antag;

--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -375,26 +375,21 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
     {
         _adminLogger.Add(LogType.AntagSelection, $"Start trying to make {session} become the antagonist: {ToPrettyString(ent)}");
 
-        if (checkPref && !HasPrimaryAntagPreference(session, def, ent.Comp.SelectionTime))
-        {
-            _adminLogger.Add(LogType.AntagSelection, $"{session} didn't have antagonist preference for {ToPrettyString(ent)}");
-            return false;
-        }
-
         if (!IsSessionValid(ent, session, def))
         {
             _adminLogger.Add(LogType.AntagSelection, $"{session} didn't have valid session");
             return false;
         }
 
-        if (!IsEntityValid(session?.AttachedEntity, def))
-        {
-            _adminLogger.Add(LogType.AntagSelection, $"{session} didn't have valid attached entity");
-            return false;
-        }
-
         if (onlyPreSelect && session != null)
         {
+            // This is preselection, so check if the PLAYER AS A WHOLE is compatible with the antagonist
+            if (checkPref && !HasPrimaryAntagPreference(session, def, ent.Comp.SelectionTime))
+            {
+                _adminLogger.Add(LogType.AntagSelection, $"{session} didn't have antagonist preference for {ToPrettyString(ent)}");
+                return false;
+            }
+
             if (!ent.Comp.PreSelectedSessions.TryGetValue(def, out var set))
                 ent.Comp.PreSelectedSessions.Add(def, set = new HashSet<ICommonSession>());
             set.Add(session);
@@ -403,6 +398,14 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
         }
         else
         {
+            // This is not preselection, so check the player's actual entity to see if it's compatible with the antagonist.
+            // This function will also check the character profile's antagonist preferences.
+            if (!IsEntityValid(session?.AttachedEntity, def))
+            {
+                _adminLogger.Add(LogType.AntagSelection, $"{session} didn't have valid entity for {ToPrettyString(ent)}");
+                return false;
+            }
+
             MakeAntag(ent, session, def, ignoreSpawner);
         }
 

--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -21,6 +21,7 @@
 // SPDX-FileCopyrightText: 2024 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Mish <bluscout78@yahoo.com>
+// SPDX-FileCopyrightText: 2025 Quantum-cross <7065792+Quantum-cross@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 SlamBamActionman <83650252+SlamBamActionman@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
 // SPDX-FileCopyrightText: 2025 pa.pecherskij <pa.pecherskij@interfax.ru>

--- a/Content.Server/Antag/AntagSelectionSystem.cs
+++ b/Content.Server/Antag/AntagSelectionSystem.cs
@@ -376,10 +376,22 @@ public sealed partial class AntagSelectionSystem : GameRuleSystem<AntagSelection
         _adminLogger.Add(LogType.AntagSelection, $"Start trying to make {session} become the antagonist: {ToPrettyString(ent)}");
 
         if (checkPref && !HasPrimaryAntagPreference(session, def, ent.Comp.SelectionTime))
+        {
+            _adminLogger.Add(LogType.AntagSelection, $"{session} didn't have antagonist preference for {ToPrettyString(ent)}");
             return false;
+        }
 
-        if (!IsSessionValid(ent, session, def) || !IsEntityValid(session?.AttachedEntity, def))
+        if (!IsSessionValid(ent, session, def))
+        {
+            _adminLogger.Add(LogType.AntagSelection, $"{session} didn't have valid session");
             return false;
+        }
+
+        if (!IsEntityValid(session?.AttachedEntity, def))
+        {
+            _adminLogger.Add(LogType.AntagSelection, $"{session} didn't have valid attached entity");
+            return false;
+        }
 
         if (onlyPreSelect && session != null)
         {


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR

### FIX Late join antag selection

Thanks to @Terkala for helping me find this one.

Char 1: Alice
  - Enabled
  - No antag

Char 2: Bob
  - Disabled
  - Thief antag

If you late joined as Bob, and were selected to be a late join thief, it would fail as you have no enabled characters with thief selected.

Now late join antag selection will specifically look at the character profile that is joining.

### Add integration tests for character selection (Thanks @Absotively )

## Why / Balance

bug fix

## Technical details

The fix is well commented, the tests are kino.

## Media

nope

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- fix: Fix Late join antag selection if you have no "active" characters with a specific antagonist role.

