### PR TITLE
Nerfing Greencomms

### DIFF
--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -20,7 +20,9 @@
 // SPDX-FileCopyrightText: 2024 Tayrtahn <tayrtahn@gmail.com>
 // SPDX-FileCopyrightText: 2024 beck-thompson <107373427+beck-thompson@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 Carrot <carpecarrot@gmail.com>
 // SPDX-FileCopyrightText: 2025 Currot <carpecarrot@gmail.com>
+// SPDX-FileCopyrightText: 2025 Ecramox <65426878+Ecramox@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 //
 // SPDX-License-Identifier: MIT

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -173,6 +173,10 @@ public sealed class RadioSystem : EntitySystem
             if (attemptEv.Cancelled)
                 continue;
 
+            // Imp original
+            if (channel.IntercomOnly && HasComp<HeadsetComponent>(radioSource))
+                continue;
+
             // send the message
             RaiseLocalEvent(receiver, ref ev);
         }

--- a/Content.Shared/Radio/RadioChannelPrototype.cs
+++ b/Content.Shared/Radio/RadioChannelPrototype.cs
@@ -4,6 +4,7 @@
 // SPDX-FileCopyrightText: 2023 Slava0135 <40753025+Slava0135@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2023 Visne <39844191+Visne@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 chavonadelal <156101927+chavonadelal@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 Ecramox <65426878+Ecramox@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
 // SPDX-FileCopyrightText: 2025 pa.pecherskij <pa.pecherskij@interfax.ru>
 // SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>

--- a/Content.Shared/Radio/RadioChannelPrototype.cs
+++ b/Content.Shared/Radio/RadioChannelPrototype.cs
@@ -47,4 +47,11 @@ public sealed partial class RadioChannelPrototype : IPrototype
     /// </summary>
     [DataField("longRange"), ViewVariables]
     public bool LongRange = false;
+
+    /// <summary>
+    /// ImpStation original. If a channel is readOnly, then headsets cannot send messages through it.
+    /// Intercomms still can.
+    /// </summary>
+    [DataField("intercomOnly")]
+    public bool IntercomOnly = false;
 }

--- a/Resources/Prototypes/radio_channels.yml
+++ b/Resources/Prototypes/radio_channels.yml
@@ -10,6 +10,7 @@
 # SPDX-FileCopyrightText: 2024 Piras314 <p1r4s@proton.me>
 # SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2024 Winkarst <74284083+Winkarst-cpu@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Ecramox <65426878+Ecramox@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT

--- a/Resources/Prototypes/radio_channels.yml
+++ b/Resources/Prototypes/radio_channels.yml
@@ -20,6 +20,7 @@
   keycode: ";"
   frequency: 1459
   color: "#2cdb2c"
+  intercomOnly: true # Imp Original
 
 - type: radioChannel
   id: CentCom


### PR DESCRIPTION
## About the PR
This PR removes the ability to speak on the common channel through your headset. You need to use the intercom to scream for help.

## Why / Balance
The removal of greencomms changes a lot.
### Encourages in-person roleplay.
No more screaming for help at security because you broke into science and made yourself a PKA. Now, you have to actually incite a riot naturally.
### Antagonists more accessible.
Antagonists get more leeway. No longer will your sneaky stealth roleplay be shut down instantly because of a tider. You have room for error and you can more easily hide your acts. Gives more room to do stealth. Be one with the shadows.
### Reporter has a purpose.
The reporter is the main source of information. This should encourage more actual reporter roleplay and not just being a glorified tider with an announcement board. (This may require a sop rewrite..)
### We love service workers.
Service should see more usage because the bar is generally where you go to talk to people. Also a good place to go pick up a fight.
### Maints are scary.
Maints are actually scary now. Amazing, right. Be careful maints diving.
### Encourages use of alternative communications.
Faxing, holopads, and nanochat see very little useage due to greencomms just being there. Now, you have an actual reason to use them. It's your only way of communication now.

## Technical details
https://github.com/impstation/imp-station-14/commit/364aeaa798d2b060d9fbc118462462928bd71093
see here

**Changelog**
:cl:
- tweak: Common channel is now read only. You need to use an intercom to speak on it.

