### PR TITLE
first aid kit slot increase, combat medkit removed from medlathe

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Items/firstaidkits.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/firstaidkits.yml
@@ -21,6 +21,7 @@
 # SPDX-FileCopyrightText: 2024 Alzore <140123969+Blackern5000@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2024 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 DevilishMilk <michaellapjr@gmail.com>
 # SPDX-FileCopyrightText: 2025 Fenn <162015305+TooSillyFennec@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 corresp0nd <46357632+corresp0nd@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>

--- a/Resources/Prototypes/Catalog/Fills/Items/firstaidkits.yml
+++ b/Resources/Prototypes/Catalog/Fills/Items/firstaidkits.yml
@@ -40,6 +40,7 @@
       - id: Gauze
       - id: PillCanisterTricordrazine
       - id: PillCanisterGranibitulari # Funkychem
+      - id: HandheldHealthAnalyzer #funky
       # see https://github.com/tgstation/blob/master/code/game/objects/items/storage/firstaid.dm for example contents
 
 - type: entity
@@ -53,6 +54,7 @@
         amount: 2
       - id: PillCanisterAiuri # Funkychem
       - id: PillCanisterLenturi # funky
+      - id: HandheldHealthAnalyzer #funky
 
 - type: entity
   id: MedkitBruteFilled
@@ -67,6 +69,7 @@
         amount: 2
       - id: PillCanisterLibital # Funkychem
       - id: PillCanisterProbital # funky
+      - id: HandheldHealthAnalyzer #funky
 
 - type: entity
   id: MedkitToxinFilled
@@ -81,6 +84,7 @@
         amount: 2 # Funkychem
       - id: PillCanisterMultiver
       - id: PillCanisterCharcoal
+      - id: HandheldHealthAnalyzer #funky
 
 - type: entity
   id: MedkitOxygenFilled
@@ -97,6 +101,7 @@
       - id: SyringeConvermol # Funkychem - only kit to have 1 pill type, generally makes sense to have 2.
         amount: 2
       - id: PillCanisterDexalin
+      - id: HandheldHealthAnalyzer #funky
 
 - type: entity
   id: MedkitRadiationFilled
@@ -112,6 +117,7 @@
       - id: PillCanisterHyronalin
       - id: MedicalPatchPrefilledAntiRad # Funkychem
         amount: 2
+      - id: HandheldHealthAnalyzer #funky
 
 - type: entity
   id: MedkitAdvancedFilled
@@ -126,6 +132,7 @@
         amount: 1
       - id: SyringeSaline # Funky
         amount: 2
+      - id: HandheldHealthAnalyzer #funky
 
 - type: entity
   id: MedkitCombatFilled
@@ -141,6 +148,7 @@
       - id: SyringeSaline
       - id: BruteAutoInjector
       - id: BurnAutoInjector
+      - id: HandheldHealthAnalyzer #funky
 
 - type: entity
   id: StimkitFilled

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
@@ -30,7 +30,7 @@
   - type: Storage
     maxItemSize: Small
     grid:
-    - 0,0,3,1
+    - 0,0,4,1 #funky
   - type: Item
     size: Large
     sprite: Objects/Specific/Medical/firstaidkits.rsi

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/medkits.yml
@@ -14,6 +14,7 @@
 # SPDX-FileCopyrightText: 2024 Magnus Larsen <i.am.larsenml@gmail.com>
 # SPDX-FileCopyrightText: 2024 Piras314 <p1r4s@proton.me>
 # SPDX-FileCopyrightText: 2024 username <113782077+whateverusername0@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 DevilishMilk <michaellapjr@gmail.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -1183,7 +1183,7 @@
     - WeaponLaserCannon
     - WeaponLaserCarbine
     - WeaponXrayCannon
-    - WeaponLaserSvalinn # Funky Change 
+    - WeaponLaserSvalinn # Funky Change
     - SecurityCyberneticEyes # Shitmed Change
     - MedicalCyberneticEyes # Shitmed Change
     # Goobstation - Mechs
@@ -1324,7 +1324,7 @@
     - MedkitBrute
     - MedkitAdvanced
     - MedkitRadiation
-    - MedkitCombat
+#    - MedkitCombat #funky
     - Scalpel
     - Retractor
     - Cautery

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -147,6 +147,7 @@
 # SPDX-FileCopyrightText: 2024 to4no_fix <156101927+chavonadelal@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 yglop <95057024+yglop@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 DevilishMilk <michaellapjr@gmail.com>
 # SPDX-FileCopyrightText: 2025 Gansu <68031780+GansuLalan@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 IronDragoon <8961391+IronDragoon@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 IronDragoon <you@example.com>
@@ -159,6 +160,7 @@
 # SPDX-FileCopyrightText: 2025 Steve <marlumpy@gmail.com>
 # SPDX-FileCopyrightText: 2025 Tadeo <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2025 ThatOneMoon <91613003+ThatOneMoon@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 ThatOneMoon <juozas.dringelis@gmail.com>
 # SPDX-FileCopyrightText: 2025 TheSecondLord <88201625+TheSecondLord@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 V <97265903+formlessnameless@users.noreply.github.com>


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2021 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
SPDX-FileCopyrightText: 2021 Swept <sweptwastaken@protonmail.com>
SPDX-FileCopyrightText: 2021 mirrorcult <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2022 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
SPDX-FileCopyrightText: 2024 Vasilis <vasilis@pikachu.systems>
SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Aiden <28298836+Aidenkrz@users.noreply.github.com>
SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>

SPDX-License-Identifier: AGPL-3.0-or-later
-->
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 
Uncomment and modify the following line if you wish to change the license from the default of AGPL.-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Increased first aid kit slot capacity from 4x2 to 5x2.
It still remains a 4x2 item in bags, so now you have 2 extra slots.
All first aid kits now come with a health analyzer.
Combat medkit has been removed from the medlathe

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Incentivizes nicer and more sensible usage of storage containers, feels better than dumping everything in your bag being the optimal solution.
It's not TARDIS technology, it's just a visual representation of a better-organized box rather than having everything be loose.
Combat medkit has been killed from the medlathe as it's a 2x2 container with (now 5x2) units of space that cost the same amount of plastic as the base medkit.


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: Miiish
- remove: Combat medkits are no longer available in the medlathe.
- tweak: First aid kits now have 10 slots of capacity, up from 8.
- tweak: First aid kits now all come stocked with a health analyzer.