### PR TITLE
IntercomOnlyBypass

### DIFF
--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -23,6 +23,7 @@
 // SPDX-FileCopyrightText: 2025 Carrot <carpecarrot@gmail.com>
 // SPDX-FileCopyrightText: 2025 Currot <carpecarrot@gmail.com>
 // SPDX-FileCopyrightText: 2025 Ecramox <65426878+Ecramox@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 PurpleTranStar <purpletranstars@gmail.com>
 // SPDX-FileCopyrightText: 2025 PurpleTranStar <tehevilduckiscoming@gmail.com>
 // SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 //

--- a/Content.Server/Radio/EntitySystems/RadioSystem.cs
+++ b/Content.Server/Radio/EntitySystems/RadioSystem.cs
@@ -178,7 +178,7 @@ public sealed class RadioSystem : EntitySystem
                 continue;
 
             // Imp original - edited to correct behavior for IPCs and Silicons
-            if (channel.IntercomOnly && !(HasComp<IntercomComponent>(radioSource) || HasComp<SiliconLawBoundComponent>(radioSource)))
+            if (channel.IntercomOnly && !(HasComp<IntercomComponent>(radioSource) || HasComp<IntercomOnlyBypassComponent>(radioSource)))
                 continue;
 
             // send the message

--- a/Content.Shared/Radio/Components/IntercomOnlyBypassComponent.cs
+++ b/Content.Shared/Radio/Components/IntercomOnlyBypassComponent.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2025 PurpleTranStar <purpletranstars@gmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 namespace Content.Shared.Radio.Components;
 
 /// <summary>

--- a/Content.Shared/Radio/Components/IntercomOnlyBypassComponent.cs
+++ b/Content.Shared/Radio/Components/IntercomOnlyBypassComponent.cs
@@ -1,0 +1,10 @@
+namespace Content.Shared.Radio.Components;
+
+/// <summary>
+/// Dummy component to bypass common only radio
+/// </summary>
+[RegisterComponent]
+public sealed partial class IntercomOnlyBypassComponent : Component
+{
+
+}

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -34,13 +34,16 @@
 # SPDX-FileCopyrightText: 2024 plykiya <plykiya@protonmail.com>
 # SPDX-FileCopyrightText: 2024 themias <89101928+themias@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Kittygyat <202250949+Kittygyat@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 PurpleTranStar <purpletranstars@gmail.com>
 # SPDX-FileCopyrightText: 2025 Quantum-cross <7065792+Quantum-cross@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Tadeo <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2025 TheSecondLord <88201625+TheSecondLord@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Tyranex <bobthezombie4@gmail.com>
 # SPDX-FileCopyrightText: 2025 V <97265903+formlessnameless@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 archrbx <punk.gear5260@fastmail.com>
 # SPDX-FileCopyrightText: 2025 corresp0nd <46357632+corresp0nd@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 jackel234 <52829582+jackel234@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 pa.pecherskij <pa.pecherskij@interfax.ru>
 # SPDX-FileCopyrightText: 2025 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>

--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -300,6 +300,7 @@
     damageProtection:
       flatReductions:
         Heat: 10 # capable of touching light bulbs and stoves without feeling pain!
+  - type: IntercomOnlyBypass
 
 - type: entity
   abstract: true

--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -966,4 +966,5 @@
       gender: male
   - type: Loadout
     prototypes: [ MobPollyGear ]
+  - type: IntercomOnlyBypass
 

--- a/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/pets.yml
@@ -67,8 +67,11 @@
 # SPDX-FileCopyrightText: 2024 nao fujiwara <awkwarddryad@gmail.com>
 # SPDX-FileCopyrightText: 2024 reverie collection <revsys413@gmail.com>
 # SPDX-FileCopyrightText: 2024 themias <89101928+themias@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 88tv <131759102+88tv@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Crude Oil <124208219+CroilBird@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Ekpy <33184056+Ekpy@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Errant <35878406+Errant-4@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 PurpleTranStar <purpletranstars@gmail.com>
 # SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2025 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -32,9 +32,11 @@
 # SPDX-FileCopyrightText: 2024 Piras314 <p1r4s@proton.me>
 # SPDX-FileCopyrightText: 2024 ScarKy0 <106310278+ScarKy0@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Ekpy <33184056+Ekpy@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Ekpy <xekpyx@gmail.com>
 # SPDX-FileCopyrightText: 2025 McBosserson <148172569+McBosserson@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 PurpleTranStar <purpletranstars@gmail.com>
 # SPDX-FileCopyrightText: 2025 Tadeo <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2025 Winkarst-cpu <74284083+Winkarst-cpu@users.noreply.github.com>

--- a/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/silicon.yml
@@ -491,6 +491,7 @@
     layerData:
     - sprite: Mobs/Silicon/holograms.rsi
       state: default
+  - type: IntercomOnlyBypass
 
 # Hologram projection that the AI's eye tracks.
 - type: entity

--- a/Resources/Prototypes/_DV/Entities/Structures/Power/Generation/Supermatter/supermatter.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Power/Generation/Supermatter/supermatter.yml
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2025 PurpleTranStar <purpletranstars@gmail.com>
 # SPDX-FileCopyrightText: 2025 VMSolidus <evilexecutive@gmail.com>
 # SPDX-FileCopyrightText: 2025 corresp0nd <46357632+corresp0nd@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>

--- a/Resources/Prototypes/_DV/Entities/Structures/Power/Generation/Supermatter/supermatter.yml
+++ b/Resources/Prototypes/_DV/Entities/Structures/Power/Generation/Supermatter/supermatter.yml
@@ -68,6 +68,7 @@
   - type: Clickable
   - type: InteractionOutline
   - type: Physics
+  - type: IntercomOnlyBypass
 
 - type: entity
   parent: BaseSupermatter


### PR DESCRIPTION
## About the PR
Adds the IntercomOnlyBypass Component. A blank component that allows headsets and some specific characters to talk in common as if they were an intercom.

## Why / Balance
This allows specific objects that speak on common (SM) to actually be able to type in common. Also allows the ability to create headsets that can type in common. 

## Technical details
Just a blank component called IntercomOnlybypass. It checks for that in the code. Previously, only the Intercom component and Silicon Law Bounds were checked.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: PurpleTranStar
- fix: The Supermatter will now speak in Common

