### PR TITLE
SOS now properly pings the warden and paramedic

### DIFF
--- a/Content.Server/_Impstation/CartridgeLoader/Cartridges/SOSCartridgeComponent.cs
+++ b/Content.Server/_Impstation/CartridgeLoader/Cartridges/SOSCartridgeComponent.cs
@@ -34,11 +34,11 @@ public sealed partial class SOSCartridgeComponent : Component
 
     [DataField]
     //Channel to notify
-    public ProtoId<RadioChannelPrototype> HelpChannel = "Security";
+    public ProtoId<RadioChannelPrototype> HelpChannel = "Emergency";
 
     [DataField]
     //Timeout between calls
-    public const float TimeOut = 90;
+    public const float TimeOut = 180;
 
     [DataField]
     //Countdown until next call is allowed

--- a/Content.Server/_Impstation/CartridgeLoader/Cartridges/SOSCartridgeComponent.cs
+++ b/Content.Server/_Impstation/CartridgeLoader/Cartridges/SOSCartridgeComponent.cs
@@ -1,4 +1,6 @@
 // SPDX-FileCopyrightText: 2025 Josh Hilsberg <thejoulesberg@gmail.com>
+// SPDX-FileCopyrightText: 2025 JoulesBerg <104539820+JoulesBerg@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 PurpleTranStar <purpletranstars@gmail.com>
 // SPDX-FileCopyrightText: 2025 PurpleTranStar <tehevilduckiscoming@gmail.com>
 // SPDX-FileCopyrightText: 2025 mqole <113324899+mqole@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 rosieposie <52761126+rosieposieeee@users.noreply.github.com>


### PR DESCRIPTION
## Why / Balance
always was intended to, just forgot to make this change

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: PurpleTranStar
- fix: SOS now correctly pings the paramedic and warden.

