### PR TITLE
Rolling and slicing artifact triggers

### DIFF
--- a/Resources/Locale/en-US/xenoarchaeology/artifact-hints.ftl
+++ b/Resources/Locale/en-US/xenoarchaeology/artifact-hints.ftl
@@ -9,6 +9,7 @@
 # SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2025 pa.pecherskij <pa.pecherskij@interfax.ru>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2025 TheHolyAegis <Sanderkamphuis719@gmail.com>
 #
 # SPDX-License-Identifier: MIT
 
@@ -74,6 +75,8 @@ xenoarch-trigger-tip-wrenching = Tightening
 xenoarch-trigger-tip-prying = Prying
 xenoarch-trigger-tip-screwing = Screwing
 xenoarch-trigger-tip-pulsing = Pulsing
+xenoarch-trigger-tip-rolling = Rolling
+xenoarch-trigger-tip-slicing = Slicing
 xenoarch-trigger-tip-pressure-low = Low pressure
 xenoarch-trigger-tip-pressure-high = High pressure
 xenoarch-trigger-tip-examine = Close inspection
@@ -88,6 +91,8 @@ xenoarch-trigger-examine-wrenching = There's a loose bit spinning around.
 xenoarch-trigger-examine-prying = There's a panel coming up from the surface.
 xenoarch-trigger-examine-screwing = There's a raised section with a small inset on it.
 xenoarch-trigger-examine-pulsing = An exposed diode pokes out of the artifact's surface.
+xenoarch-trigger-examine-rolling = Make it a pizza.
+xenoarch-trigger-examine-slicing = Cut it into bits.
 xenoarch-trigger-examine-timer = Carvings and scratches cover the surface... You can just barely make out a number: [italic]{$time}[/italic]
 
 ### Effects hints

--- a/Resources/Prototypes/XenoArch/artifact_triggers.yml
+++ b/Resources/Prototypes/XenoArch/artifact_triggers.yml
@@ -11,6 +11,7 @@
 # SPDX-FileCopyrightText: 2025 corresp0nd <46357632+corresp0nd@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 pa.pecherskij <pa.pecherskij@interfax.ru>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2025 TheHolyAegis <Sanderkamphuis719@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 
@@ -38,6 +39,8 @@
     TriggerPrying: 0.5
     TriggerScrewing: 0.5
     TriggerPulsing: 0.5
+    TriggerRolling: 5
+    TriggerSlicing: 5
     TriggerTimer: 0.25
     TriggerBlood: 1
     TriggerThrow: 1
@@ -236,6 +239,24 @@
     requiredTool: Pulsing
   - type: XATExaminableText
     examineText: xenoarch-trigger-examine-pulsing
+
+- type: xenoArchTrigger
+  id: TriggerRolling
+  tip: xenoarch-trigger-tip-rolling
+  components:
+  - type: XATToolUse
+    requiredTool: Rolling
+  - type: XATExaminableText
+    examineText: xenoarch-trigger-examine-rolling
+
+- type: xenoArchTrigger
+  id: TriggerSlicing
+  tip: xenoarch-trigger-tip-slicing
+  components:
+  - type: XATToolUse
+    requiredTool: Slicing
+  - type: XATExaminableText
+    examineText: xenoarch-trigger-examine-slicing
 
 - type: xenoArchTrigger
   id: TriggerTimer

--- a/Resources/Prototypes/XenoArch/artifact_triggers.yml
+++ b/Resources/Prototypes/XenoArch/artifact_triggers.yml
@@ -39,8 +39,8 @@
     TriggerPrying: 0.5
     TriggerScrewing: 0.5
     TriggerPulsing: 0.5
-    TriggerRolling: 5
-    TriggerSlicing: 5
+    TriggerRolling: 0.5
+    TriggerSlicing: 0.5
     TriggerTimer: 0.25
     TriggerBlood: 1
     TriggerThrow: 1

--- a/Resources/Prototypes/XenoArch/artifact_triggers.yml
+++ b/Resources/Prototypes/XenoArch/artifact_triggers.yml
@@ -7,11 +7,12 @@
 # SPDX-FileCopyrightText: 2024 wafehling <wafehling@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 ATDoop <bug@bug.bug>
 # SPDX-FileCopyrightText: 2025 Fenn <162015305+TooSillyFennec@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Sanderk35 <sanderkamphuis719@gmail.com>
 # SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2025 TheHolyAegis <Sanderkamphuis719@gmail.com>
 # SPDX-FileCopyrightText: 2025 corresp0nd <46357632+corresp0nd@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 pa.pecherskij <pa.pecherskij@interfax.ru>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
-# SPDX-FileCopyrightText: 2025 TheHolyAegis <Sanderkamphuis719@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 


### PR DESCRIPTION

## About the PR
Added the rolling and slicing artifact triggers.

## Why / Balance
So science has some interaction with the kitchen, if they require an kitchen knife or rolling pin. And also a way for antags to get a weapon secretly.

## Technical details
Added lines in "Resources/Prototypes/XenoArch/artifact_triggers.yml" and "Resources/Locale/en-US/xenoarchaeology/artifact-hints.ftl" (see changelist of this pull request)

## Media
<img width="176" height="93" alt="image" src="https://github.com/user-attachments/assets/767299f8-77d8-4141-a369-f6b8e2de56fe" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None

**Changelog**

:cl:
- add: Added rolling artifact trigger
- add: Added slicing artifact trigger
