### PR TITLE
Time display for Tape Recorder UI

### DIFF
--- a/Content.Client/_DV/TapeRecorder/UI/TapeRecorderWindow.xaml
+++ b/Content.Client/_DV/TapeRecorder/UI/TapeRecorderWindow.xaml
@@ -22,6 +22,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
             <BoxContainer Orientation="Vertical" HorizontalExpand="True">
                 <Label Text="{Loc 'tape-recorder-menu-controls-label'}" Align="Center" />
                 <BoxContainer Name="Buttons" Orientation="Horizontal" VerticalExpand="True" Align="Center"/> <!-- Populated in constructor -->
+                <Label Name="DurationLabel" Text="00:00" HorizontalAlignment="Right" HorizontalExpand="True"/>
             </BoxContainer>
         </BoxContainer>
         <BoxContainer Margin="0 2 0 0" Orientation="Horizontal">

--- a/Content.Client/_DV/TapeRecorder/UI/TapeRecorderWindow.xaml.cs
+++ b/Content.Client/_DV/TapeRecorder/UI/TapeRecorderWindow.xaml.cs
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2025 IronDragoon <8961391+IronDragoon@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 TakuTaco <gorill.ka.fmb@gmail.com>
 // SPDX-FileCopyrightText: 2025 deltanedas <39013340+deltanedas@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 //

--- a/Content.Client/_DV/TapeRecorder/UI/TapeRecorderWindow.xaml.cs
+++ b/Content.Client/_DV/TapeRecorder/UI/TapeRecorderWindow.xaml.cs
@@ -131,5 +131,6 @@ public sealed partial class TapeRecorderWindow : FancyWindow
             ? -comp.RewindSpeed
             : 1f;
         PlaybackSlider.Value += args.DeltaSeconds * speed;
+        DurationLabel.Text = $@"{TimeSpan.FromSeconds(PlaybackSlider.Value):mm\:ss}";
     }
 }


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
I added a time display in the corner of Tape Recorder's UI window.

## Why / Balance
Having used a tape recorder in-game for a bit, I noticed that it's not too convenient for replaying particular parts of the tape, as replay and rewind speeds are different, and on a 2-minute-long recording a slider is not a very precise way to gauge where you are in it. As recording transcripts already display the timestamp of every recorded message on the tape, I decided it would be convenient to include a way to tell exactly what second it is on at any given point.

## Technical details
I edied one .xaml and one .xaml.cs files connected to Tape Recorder UI. One change added a Duration Label to the UI window, the other one made it change depending on the playback slider position.

## Media

https://github.com/user-attachments/assets/7b49ba7c-7dd5-4a44-9e20-a7a5d1d9b4b6



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 TakuTaco
- add: Added time display to tape recorder UI. Now you can use your transcripts to more conveniently navigate the recording!