### PR TITLE
Magistrate playtime requirement is now 100 sec hours

### DIFF
--- a/Resources/Prototypes/_Funkystation/Roles/Jobs/CentComm/magistrate.yml
+++ b/Resources/Prototypes/_Funkystation/Roles/Jobs/CentComm/magistrate.yml
@@ -1,4 +1,6 @@
+# SPDX-FileCopyrightText: 2025 8tv <eightev@gmail.com>
 # SPDX-FileCopyrightText: 2025 Josh Hilsberg <thejoulesberg@gmail.com>
+# SPDX-FileCopyrightText: 2025 JoulesBerg <104539820+JoulesBerg@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 #

--- a/Resources/Prototypes/_Funkystation/Roles/Jobs/CentComm/magistrate.yml
+++ b/Resources/Prototypes/_Funkystation/Roles/Jobs/CentComm/magistrate.yml
@@ -9,18 +9,10 @@
   name: Magistrate
   description: "Serve directly under CentComm. As the stations central legal authority, you authorize executions, extended detentions, warrants, etc."
   playTimeTracker: JobMagistrate
-  requirements:
-  - !type:OverallPlaytimeRequirement
-    time: 72000 #20 hrs
-  - !type:RoleTimeRequirement
-    role: JobNanotrasenRepresentative
-    time: 36000 #10 hrs
-  - !type:RoleTimeRequirement
-    role: JobCaptain
-    time: 36000 #10 hrs
-  - !type:RoleTimeRequirement
-    role: JobHeadOfSecurity
-    time: 36000 #10 hrs
+  requirement:
+  - !type:DepartmentTimeRequirement
+    department: Security
+    time: 360000 #100 hrs
   weight: 20
   startingGear: MagistrateGear
   icon: "JobIconMagistrate"

--- a/Resources/Prototypes/_Funkystation/Roles/Jobs/CentComm/magistrate.yml
+++ b/Resources/Prototypes/_Funkystation/Roles/Jobs/CentComm/magistrate.yml
@@ -9,7 +9,7 @@
   name: Magistrate
   description: "Serve directly under CentComm. As the stations central legal authority, you authorize executions, extended detentions, warrants, etc."
   playTimeTracker: JobMagistrate
-  requirement:
+  requirements:
   - !type:DepartmentTimeRequirement
     department: Security
     time: 360000 #100 hrs


### PR DESCRIPTION
<!--- LICENSE: AGPL -->
## About the PR
Changed the magistrate playtime requirements to be 100 hours in the security department.

## Why / Balance
In initial discord discussions regarding porting the Magistrate to Funky, the goal was to demand 100 security hours to play the role. In doing so, we both match the playtime requirement from [Paradise Station](https://www.paradisestation.org/wiki/index.php?title=Magistrate) and require a deep understanding of Space Law from any potential Magistrate players.

Initially added to Funky on [July 7, 2025](https://github.com/funky-station/funky-station/pull/793), under playtime requirements of 20 overall hours and 5 Nanotrasen Representative hours, the playtime requirements were changed on [July 25, 2025](https://github.com/funky-station/funky-station/pull/1217) to be 10 hours in Head of Security, 10 hours in Captain, and 10 hours in Nanotrasen Representative.

By moving the playtime requirements from 10 HOS, 10 Cap, and 10 NTR to 100 Security, we solely demand experience understanding and enforcing Space Law while moving away from requiring experience in leading the station and enforcing SOP, items which arguably have no strong correlation with what the Magistrate should be doing.

The other side of the coin is that we may still wish for people to have extended access to Magistrate for means of easier telling what the role is like in-game. It's been over 2 months since the role was added, though, which makes me feel like we've had enough time sitting with it to understand what it's like. 

## Technical details
yml

## Media
<img width="1182" height="272" alt="image" src="https://github.com/user-attachments/assets/f930bf2d-0166-4ffd-bd13-3f55fd054b19" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A

**Changelog**
:cl:
- tweak: Magistrate's playtime requirements were changed to 100 Security hours.
