### PR TITLE
Alert level Cyan added to the guidebook

### DIFF
--- a/Resources/Locale/en-US/_Funkystation/guidebook.ftl
+++ b/Resources/Locale/en-US/_Funkystation/guidebook.ftl
@@ -4,6 +4,7 @@
 # SPDX-FileCopyrightText: 2025 Skye <57879983+Rainbeon@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 kbarkevich <24629810+kbarkevich@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2025 TheHolyAegis <sanderkamphuis719@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 
@@ -23,6 +24,7 @@ guide-entry-alertlevel-yellow = Yellow Alert
 guide-entry-alertlevel-blue = Blue Alert
 guide-entry-alertlevel-red = Red Alert
 guide-entry-alertlevel-violet = Violet Alert
+guide-entry-alertlevel-cyan = Cyan Alert
 guide-entry-alertlevel-gamma = Gamma Alert
 guide-entry-alertlevel-delta = Delta Alert
 

--- a/Resources/Prototypes/_Funkystation/Guidebook/sop.yml
+++ b/Resources/Prototypes/_Funkystation/Guidebook/sop.yml
@@ -4,6 +4,7 @@
 # SPDX-FileCopyrightText: 2025 corresp0nd <46357632+corresp0nd@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 kbarkevich <24629810+kbarkevich@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2025 TheHolyAegis <sanderkamphuis719@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 
@@ -39,6 +40,7 @@
   - BlueAlertSOP
   - RedAlertSOP
   - VioletAlertSOP
+  - CyanAlertSOP
   - DeltaAlertSOP
   - GammaAlertSOP
   - OctarineAlertSOP
@@ -111,20 +113,26 @@
   text: "/ServerInfo/Funkystation/Guidebook/AlertLevel/VioletAlert.xml"
 
 - type: guideEntry
+  id: CyanAlertSOP
+  name: guide-entry-alertlevel-cyan
+  priority: 60
+  text: "/ServerInfo/Funkystation/Guidebook/AlertLevel/CyanAlert.xml"
+
+- type: guideEntry
   id: GammaAlertSOP
   name: guide-entry-alertlevel-gamma
-  priority: 60
+  priority: 70
   text: "/ServerInfo/Funkystation/Guidebook/AlertLevel/GammaAlert.xml"
 
 - type: guideEntry
   id: DeltaAlertSOP
   name: guide-entry-alertlevel-delta
-  priority: 70
+  priority: 80
   text: "/ServerInfo/Funkystation/Guidebook/AlertLevel/DeltaAlert.xml"
 
 # impstation cosmic cult
 - type: guideEntry
   id: OctarineAlertSOP
   name: alert-level-octarine
-  priority: 70
+  priority: 90
   text: "/ServerInfo/Funkystation/Guidebook/AlertLevel/OctarineAlert.xml"

--- a/Resources/ServerInfo/Funkystation/Guidebook/AlertLevel/CyanAlert.xml
+++ b/Resources/ServerInfo/Funkystation/Guidebook/AlertLevel/CyanAlert.xml
@@ -1,0 +1,43 @@
+<!--
+SPDX-FileCopyrightText: 2025 TheHolyAegis <sanderkamphuis719@gmail.com>
+
+SPDX-License-Identifier: MIT
+-->
+
+<Document>
+  # Station Alert - Cyan
+
+  <Box>
+    [italic]Called by: Anyone with Command-Level Access at a working Communications Console.[/italic]
+  </Box>
+
+  [bold]Conditions:[/bold]
+
+  A large number of borgs have been emagged, or the AI is malfunctioning. Either way there are dangerous silicons aboard the station.
+
+  [bold]Security:[/bold]
+
+  Security is required to be armed and ready to deal with any silicons;
+
+  Disable borgs with lethal force if necessary;
+
+  Only destroy borgs if they are too dangerous.
+
+  [bold]Science:[/bold]
+
+  Roboticists are required to turn borgs back to better laws;
+  
+  The Research Director or roboticist should disable all borgs with their console if it isn't stolen yet;
+
+  If the AI is malfunctioning, the Research Director should try to download the AI's consciousness onto their Intellicard.
+
+  [bold]Secure Areas:[/bold]
+
+  EVA Storage, Tech Storage, Gravity Generator, Engineering Secure Storage, AI Upload, Vault, Gateway, anywhere else requiring command level access that does not get regularly used.
+
+  It's recommended to bolt any door leading to an important area, so borgs can't enter that room.
+
+  [bold]General Crew:[/bold]
+
+  All personel are to remain in their department, for Visitors (anyone with Civilian-level access) it's inside the Bar, Library or Dormitories.
+</Document>

--- a/Resources/ServerInfo/Funkystation/Guidebook/Command/AlertLevels.xml
+++ b/Resources/ServerInfo/Funkystation/Guidebook/Command/AlertLevels.xml
@@ -3,6 +3,7 @@ SPDX-FileCopyrightText: 2024 DevilishMilk <bluscout78@yahoo.com>
 SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
 SPDX-FileCopyrightText: 2025 corresp0nd <46357632+corresp0nd@users.noreply.github.com>
 SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+SPDX-FileCopyrightText: 2025 TheHolyAegis <sanderkamphuis719@gmail.com>
 
 SPDX-License-Identifier: MIT
 -->
@@ -25,6 +26,7 @@ SPDX-License-Identifier: MIT
   - [textlink="Blue Alert" link="BlueAlertSOP"]
   - [textlink="Red Alert" link="RedAlertSOP"]
   - [textlink="Violet Alert" link="VioletAlertSOP"]
+  - [textlink="Cyan Alert" link="CyanAlertSOP"]
   - [textlink="Gamma Alert" link="GammaAlertSOP"]
   - [textlink="Delta Alert" link="DeltaAlertSOP"]
   - [textlink="Octarine Alert" link="OctarineAlertSOP"]


### PR DESCRIPTION

## About the PR
I added the new alert level to the guidebook for a SoP procedure during the alert.

## Why / Balance
Since it's an alert level that can be set with the communications console, it felt necessary.

## Technical details
No code changes, just additions to yaml files.

## Media
<img width="1695" height="742" alt="image" src="https://github.com/user-attachments/assets/6bc47b10-3bd4-4281-af87-34ca8c22c65e" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Added alert level cyan to the guidebook.
