### PR TITLE
Fix SMES wiring on Cluster Station.

### DIFF
--- a/Resources/Maps/_Funkystation/cluster.yml
+++ b/Resources/Maps/_Funkystation/cluster.yml
@@ -7198,7 +7198,7 @@ entities:
       pos: -28.5,22.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -57804.793
+      secondsUntilStateChange: -57242.12
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -7383,7 +7383,7 @@ entities:
       pos: 10.5,18.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -11831.951
+      secondsUntilStateChange: -11269.279
       state: Opening
     - type: DeviceLinkSource
       lastSignals:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
This fixes some weird mapping for the engineering SMES array on Cluster station. The SMESes had HV wires underneath them, but.

- They were duplicated.
- They did not connect to anything.

As a result, the SMESes would take in power from the grid, but not output it to anything. This change removes the duplicated wires, and shifts one of the wires over so that the SMESes are actually outputting to the grid as I assume was intended.

## Why / Balance
On Cluster, the SMES array in engineering basically acts as an input-only power sink unless manually rewired by engineering. This change makes it so that the SMES array actually outputs power to the grid.

## Technical details
Removes three duplicated wires under the SMES array in engineering. Shifts one piece of HV wire one tile to the left so that the grid is fed with SMES output.

## Media
BEFORE:
<img width="242" height="287" alt="Content Client_2025-09-29_17-01-35" src="https://github.com/user-attachments/assets/605ac3b7-4476-40ca-b9b9-364c1dcb0d96" />
AFTER:
<img width="238" height="285" alt="Content Client_2025-09-29_16-57-18" src="https://github.com/user-attachments/assets/7d4174fc-c50c-4c21-806e-e67fd590a7cf" />

(Airlock and reinforced wall removed for visibility.)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- fix: Fixed Cluster Station SMES array not being wired to output to the grid properly.
-->
