### PR TITLE
Fixed erroneous label on the supermatter console

### DIFF
--- a/Content.Client/_EE/Supermatter/Consoles/SupermatterEntryContainer.xaml
+++ b/Content.Client/_EE/Supermatter/Consoles/SupermatterEntryContainer.xaml
@@ -239,7 +239,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
                         HorizontalAlignment="Left"
                         HorizontalExpand="True"
                         Name="MolesLabel"
-                        Text="{Loc 'supermatter-console-window-label-power'}" />
+                        Text="{Loc 'supermatter-console-window-label-moles'}" />
                     <BoxContainer
                         Orientation="Horizontal"
                         SetHeight="24"


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
SM console no longer says "Internal Energy" twice, and instead correctly reads "Absorbed Moles".
<img width="685" height="340" alt="image" src="https://github.com/user-attachments/assets/b48c09f2-3e7b-40fa-9ada-d7ded023960f" />


## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It was there, in my quest to document the effects of the supermatter where a most heinous oversight laid itself bare. Alas, a second Internal Energy metre? I was vexed. I inquired with my associates Dicer and Nibbleston to realize the end of this quandary. 

One of my compatriots answered, "do you not see," in obvious surprise. "'Tis the current amount of internal energy being processed". This conclusion did not satisfy, nor settle the questioning air. I had dared to inquire Dicer, whose knowledge of the Super Matter had been shown to be most fair. 
"It is nebulous," he gave to me. "I cannot tell you, how this may be or what it might mean."
With such a mystery, I had settled to do what little other shitter dare to do. I peered at the machinations within the game's code.
While the code contained within supermatter-console.ftl presented itself as clean, it did not answer this query that I have come to hold dear, in the past twenty minutes that afternoon. I peered closer, scouring gigabytes of information for where this answer may lie. Lo and behold, the culprit presented itself. 

Upon closer inspection, SupermatterEntryContainer.xaml revealed a small misprint upon its beautiful tapestry. A mislabelled label, how queer! I dared to change this line of code back to its true meaning, hoping that no other atmos tech may be caught in the folly of the informational penumbra that is Space Station.


## Technical details
<!-- Summary of code changes for easier review. -->
One line C# change that is currently untested.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed erroneous label on the supermatter console
