### PR TITLE
Reverted Magistrate Time Change

### DIFF
--- a/Resources/Prototypes/_Funkystation/Roles/Jobs/CentComm/magistrate.yml
+++ b/Resources/Prototypes/_Funkystation/Roles/Jobs/CentComm/magistrate.yml
@@ -1,7 +1,9 @@
+# SPDX-FileCopyrightText: 2025 88tv <131759102+88tv@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 8tv <eightev@gmail.com>
 # SPDX-FileCopyrightText: 2025 Josh Hilsberg <thejoulesberg@gmail.com>
 # SPDX-FileCopyrightText: 2025 JoulesBerg <104539820+JoulesBerg@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2025 ferynn <witchy.girl.me@gmail.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Reverted [PR 1552](https://github.com/funky-station/funky-station/pull/1552), which changed the Magistrate time requirements to 100 sec hours. This reverts it to 20 hours overall, 10 hours NTR, 10 hours Captain, and 10 hours Head of Security. This is what it was before.

The 20 hours overall is a bit redundant, but for this I am just reverting it.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

**Balance Effects:**
It would make magistrate more stringent in who has access to it. It could cause a decrease in magistrate players due to increased requirements.

**Reasoning:**
I think the current requirements poorly represent what a magistrate actually does, and it's role on the station. The magistrate has several roles. They are the final word on all space law on the station. They are the highest ranked Centcomm affiliated employee regularly on the station, and they supervise the NTR and IAAs. If there is no NTR, they take over their duties. They are also heavily involved in decisions regarding the disclosure of corporate secrets.

To unlock this job currently, a person can have worked only a generic security officer job for 100 hours. This requirement is certainly _lengthy_ yes, but it is not stringent and doesn't actually guarantee they know what they're doing. Currently there can be a magistrate that has never sentenced anyone, _ever_. One that has never played as an NTR, a role they are supposed to support and potentially cover for. One that has never even worked in command at all, and has no real understanding of the job and their requirements.

While the magistrate is not a super-captain, I think the varied requirements that the job had before were good for developing the skillsets needed to be an effective magistrate, and an effective Centcomm official on the station. Of the three, Captain is probably least directly applicable, but the NTR and HOS hours made sure that the Magistrate was actually competent in all spheres related to their job.

## Technical details
<!-- Summary of code changes for easier review. -->

Reverted PR. Only adjusted magistrate yml

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Reverted Magistrate requirements to 10 hours NTR, 10 hours HOS, 10 hours captain


