### PR TITLE
Hypodart Upgrade to 9u

### DIFF
--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -589,7 +589,7 @@ uplink-bribe-name = Lobbying Bundle
 uplink-bribe-desc = A heartfelt gift that can help you sway someone's opinion. Real or counterfeit? Yes.
 
 uplink-hypodart-name = Hypodart
-uplink-hypodart-desc = A seemingly unremarkable dart with an enlarged reservoir for chemicals. It can store up to 8u reagents in itself, and instantly inject when it hits the target. Starts empty.
+uplink-hypodart-desc = A seemingly unremarkable dart with an enlarged reservoir for chemicals. It can store up to 9u reagents in itself, and instantly inject when it hits the target. Starts empty.
 
 uplink-barber-scissors-name = Barber Scissors
 uplink-barber-scissors-desc = A good tool to give your fellow agent a nice haircut, unless you want to give it to yourself.

--- a/Resources/Locale/en-US/store/uplink-catalog.ftl
+++ b/Resources/Locale/en-US/store/uplink-catalog.ftl
@@ -589,7 +589,7 @@ uplink-bribe-name = Lobbying Bundle
 uplink-bribe-desc = A heartfelt gift that can help you sway someone's opinion. Real or counterfeit? Yes.
 
 uplink-hypodart-name = Hypodart
-uplink-hypodart-desc = A seemingly unremarkable dart with an enlarged reservoir for chemicals. It can store up to 7u reagents in itself, and instantly inject when it hits the target. Starts empty.
+uplink-hypodart-desc = A seemingly unremarkable dart with an enlarged reservoir for chemicals. It can store up to 8u reagents in itself, and instantly inject when it hits the target. Starts empty.
 
 uplink-barber-scissors-name = Barber Scissors
 uplink-barber-scissors-desc = A good tool to give your fellow agent a nice haircut, unless you want to give it to yourself.

--- a/Resources/Prototypes/Entities/Objects/Fun/darts.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/darts.yml
@@ -144,13 +144,13 @@
   - type: SolutionContainerManager
     solutions:
       melee:
-        maxVol: 8
+        maxVol: 9
   - type: SolutionInjectOnEmbed
-    transferAmount: 8
+    transferAmount: 9
     blockSlots: NONE
     solution: melee
   - type: SolutionTransfer
-    maxTransferAmount: 8
+    maxTransferAmount: 9
 
 - type: entity
   name: dartboard

--- a/Resources/Prototypes/Entities/Objects/Fun/darts.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/darts.yml
@@ -144,13 +144,13 @@
   - type: SolutionContainerManager
     solutions:
       melee:
-        maxVol: 7
+        maxVol: 8
   - type: SolutionInjectOnEmbed
-    transferAmount: 7
+    transferAmount: 8
     blockSlots: NONE
     solution: melee
   - type: SolutionTransfer
-    maxTransferAmount: 7
+    maxTransferAmount: 8
 
 - type: entity
   name: dartboard

--- a/Resources/Prototypes/Entities/Objects/Fun/darts.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/darts.yml
@@ -13,6 +13,7 @@
 # SPDX-FileCopyrightText: 2024 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 nikthechampiongr <32041239+nikthechampiongr@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Nictis <39938897+Nictis@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 TheSecondLord <88201625+TheSecondLord@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 #

--- a/Resources/Prototypes/_Funkystation/Entities/Objects/Weapons/Guns/dart_gun.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Objects/Weapons/Guns/dart_gun.yml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-# Just a weaker syringe gun with a purchaseable ammo type and syndie contra. Hypodarts can only hold 7u max.
+# Just a weaker syringe gun with a purchaseable ammo type and syndie contra. Hypodarts can only hold 8u max.
 - type: entity
   name: dart gun
   parent: [LauncherSyringe, BaseSyndicateContraband]

--- a/Resources/Prototypes/_Funkystation/Entities/Objects/Weapons/Guns/dart_gun.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Objects/Weapons/Guns/dart_gun.yml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-# Just a weaker syringe gun with a purchaseable ammo type and syndie contra. Hypodarts can only hold 8u max.
+# Just a weaker syringe gun with a purchaseable ammo type and syndie contra. Hypodarts can only hold 9u max.
 - type: entity
   name: dart gun
   parent: [LauncherSyringe, BaseSyndicateContraband]

--- a/Resources/Prototypes/_Funkystation/Entities/Objects/Weapons/Guns/dart_gun.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Objects/Weapons/Guns/dart_gun.yml
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2025 Nictis <39938897+Nictis@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 TheSecondLord <88201625+TheSecondLord@users.noreply.github.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
The Hypodart internal capacity has been adjusted to 9u.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This is primarily so that it can work as an alternative to the hypopen/nocturine combination. Nine units of Nocturine will cause whoever you inject to sleep for six seconds, 40% less than with the hypopen injections, while only requiring one hypo dart to inject instead of the two previously. This makes for a disposable kidnapping tool or way to escape pursuit and has the same functional amount of uses and cost as the hypopen if replaced on use.
## Technical details
<!-- Summary of code changes for easier review. -->
YML Updates to make the uplink purchase and dart gun state the correct capacity, and updated the internal capacity
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="440" height="699" alt="image" src="https://github.com/user-attachments/assets/3e317156-19b1-4b84-984f-871d7f24b505" />
<img width="706" height="882" alt="image" src="https://github.com/user-attachments/assets/91471f3b-e1fb-4ade-934c-8775d15120d4" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Adjusted the Hypodart internal reservoir to 9 units from 7.

