### PR TITLE
Fix Quartermaster Stalling Rounds During Revs

### DIFF
--- a/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
+++ b/Content.Server/GameTicking/Rules/RevolutionaryRuleSystem.cs
@@ -570,7 +570,7 @@ public sealed class RevolutionaryRuleSystem : GameRuleSystem<RevolutionaryRuleCo
                     {
                         gone++;
                     }
-                    else if (checkOffStation && _stationSystem.GetOwningStation(entity) == null && !_emergencyShuttle.EmergencyShuttleArrived)
+                    else if (checkOffStation && _stationSystem.IsEntityOnStationGrid(entity) && !_emergencyShuttle.EmergencyShuttleArrived)
                     {
                         gone++;
                     }

--- a/Content.Server/Station/Systems/StationSystem.cs
+++ b/Content.Server/Station/Systems/StationSystem.cs
@@ -571,6 +571,24 @@ public sealed class StationSystem : EntitySystem
 
         return null;
     }
+    
+    // funkystation
+    /// <summary>
+    /// Returns true if the entity is on a station proper, not just on a StationMember
+    /// otherwise just returns false if not on a station or whatever 
+    /// </summary>
+    public bool IsEntityOnStationGrid(EntityUid entity)
+    {
+        var res = GetOwningStation(entity);
+        
+        if (res == null)
+            return false;
+
+        if (!TryComp<StationMemberComponent>(res, out var comp))
+            return false;
+        
+        return Transform(entity).GridUid == Transform(comp.Station).GridUid;
+    }
 }
 
 /// <summary>


### PR DESCRIPTION
fix

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed shuttles and the ATS counting as the station for Revolutionaries off-station checks. If the last Head Rev or Command member is not directly on-station for long enough, the game should now correctly end.