### PR TITLE
Hypernob recipe update

### DIFF
--- a/Content.Server/_EE/Supermatter/Systems/SupermatterSystem.Processing.cs
+++ b/Content.Server/_EE/Supermatter/Systems/SupermatterSystem.Processing.cs
@@ -192,7 +192,7 @@ public sealed partial class SupermatterSystem
         if (mix.GetMoles(Gas.AntiNoblium) > 0.01f && mix.GetMoles(Gas.Helium) > 0.01f)
         {
             // finds the minumum amount of either anti-noblium or helium
-            var consumedAN =  (Math.Min(gasReleased.GetMoles(Gas.Helium), gasReleased.GetMoles(Gas.AntiNoblium))* 0.5f);
+            var consumedAN =  Math.Min(gasReleased.GetMoles(Gas.Helium), gasReleased.GetMoles(Gas.AntiNoblium))* 0.5f;
             // finds zapPower by dividing the consumededAN and the total mols than multiplying it by 5 (capped between 1 and 3)
             // finds zapCount by dividing the consumedAN by 4
             var zapPower = (int) Math.Clamp((Math.Round(consumedAN / mix.TotalMoles) * 5), 1 ,3);


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
I cleaned up the code for the Hyper-Noblium recipe and made the lightning scale with how many mols of anti-noblium or helium there is. I also added a few notes to make what does what clearer

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I believe that this will encourage people to tinker with the sm a lot more and try harder to get the hfr (one of the few ways to get enough gas) 
it is also incredibly difficult to make this better than the tesla requiring risky set ups that need advanced gasses to maintain to get over 3 lightning strikes and more than low level lightning.
lightning power level is tied to how much of the gas is anti-noblium or helium (whichever is lowest) divided by total mols
lightning count is tied to how much anti-noblium or helium (whichever is lowest) divided by 4 and capped at 10 (which would require 100% of the gasses in the sm to be anti-noblium or helium which is nearly impossible)

## Technical details
<!-- Summary of code changes for easier review. -->
re-did the consumedAN code to just be whichever the lowest gas that is required for the recipe, previously it had code that was intended to reduce reaction rate but didn't work in practice and was generally unnecessary
(Dicerson helped me understand and update the code) It’s not identical in result but it’s incredibly close and reduces the math required by a ton. Its a lot less equations it needs to do to get the same result, with a minor change in accuracy that would have little to no difference in game.

if (mix.GetMoles(Gas.AntiNoblium) > 0.01f && mix.GetMoles(Gas.Helium) > 0.01f)
{
var ANPP = gasReleased.Pressure * ((mix.GetMoles(Gas.AntiNoblium) / mix.TotalMoles) * 100);
var ANRatio = Math.Clamp(0.5f * (ANPP - (101.325f * 0.01f)) / (ANPP + (101.325f * 0.25f)), 0, 1)
var consumedAN = gasReleased.GetMoles(Gas.AntiNoblium) * ANRatio;

consumedAN = Math.Min(consumedAN,Math.Min(gasReleased.GetMoles(Gas.Helium), gasReleased.GetMoles(Gas.AntiNoblium)));

This checks if anti noblium or helium is present and than does a few equations with it to find the consumedAN.

The first step is finding the ANPP by dividing the mols of Anti-Noblium with the total mols, than multiplying by 100. Than once again by the gasReleased.Pressure

The second step finds ANRatio by taking ANPP multiplying it by 1.01 kpa and than takes 50% of that. Thank it takes that and divides it by ANPP plus 25.33125. Than clamps it between 0 and 1.

The 3rd step is to find consumedAN by multiply the released Anti-Noblium by the ANRatio

The fourth step is to change the consumedAN’s value to the lowest of co2, o2, and consumedAN

So for example, if we had 25 mols of Anti-Noblium and 25 mols of helium at 1000kpa we would do
Step 1
1000 * ((25 / 50) * 100) = ANPP
1000 * ((0.5) * 100) = ANPP
1000 * 50 = ANPP
50 000  = ANPP

Step 2
Math.Clamp(0.5 * (50 000 - (101.325 * 0.01)) / (50 000 + (101.325 * 0.25)), 0, 1) = ANRatio
Math.Clamp(0.5 * (50 000 - 1.01325) / (50 000 + 25.33125), 0, 1) = ANRatio
Math.Clamp(0.5 * 49998.98675 / 50025.33125 ), 0, 1) = ANRatio
Math.Clamp(0.5 * 0.9994733768), 0, 1) = ANRatio
Math.Clamp(0.4997366884, 0, 1) = ANRatio
0.4997366884 = ANRatio

Step 3 
25 * 0.4997366884 = consumedAN
12.49341721 = consumedAN

Step 4
consumedAN = Math.Min(consumedAN,Math.Min(gasReleased.GetMoles(Gas.Helium), gasReleased.GetMoles(Gas.AntiNoblium)));
Math.Min(12.49341721,Math.Min(25, 25)) = consumedAN

This is what i updated it to, its a single step and it just finds if helium of Anti-Noblium is lower

var consumedAN =  Math.Min(gasReleased.GetMoles(Gas.Helium), gasReleased.GetMoles(Gas.AntiNoblium))* 0.5f;

Step 1
(Math.Min(25, 25) * 0.5) = consumedAN
(25 * 0.5) = consumedAN
12 = consumed AN

var zapPower = (int) Math.Clamp((Math.Round(consumedAN / mix.TotalMoles) * 5), 1 ,3);

This equation just takes the consumedAN divided by the total mols, multiplied it by 5 and clamps it between 1 and 3 after rounding it.

So if we have the same values as before it would be

Math.Clamp((Math.Round(12 / 50) * 5), 1, 3) = zapPower
Math.Clamp((Math.Round(0.24) * 5), 1, 3) = zapPower
Math.Clamp((Math.Round(1.2), 1 ,3)
1 = zapPower

var zapCount = (int) Math.Clamp(Math.Round(consumedAN/4), 1, 10);

This equation finds the zapCount by taking the consumedAN, dividing it by 4 and rounding it

Math.Clamp(Math.Round(12/4), 1, 10)
Math.Clamp(Math.Round(3), 1, 10
3 = zapCount

zapCount determines the amount of lightning bolts
zapPower determines the strength of the lightning

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Added scaling with how much Anti-Noblium and Helium there is for the hyper-Noblium recipe with the SM!
- tweak: the code for the SM

