### PR TITLE
Eden (Ready for Omega Replacement)

### DIFF
--- a/Resources/Maps/_Funkystation/eden.yml
+++ b/Resources/Maps/_Funkystation/eden.yml
@@ -122617,13 +122617,6 @@ entities:
     - type: Transform
       pos: -18.5,-18.5
       parent: 2
-- proto: SpawnMobPossumPoppy
-  entities:
-  - uid: 24212
-    components:
-    - type: Transform
-      pos: -41.5,-6.5
-      parent: 2
 - proto: SpawnMobRaccoonMorticia
   entities:
   - uid: 4661

--- a/Resources/Prototypes/Maps/eden.yml
+++ b/Resources/Prototypes/Maps/eden.yml
@@ -29,7 +29,7 @@
 
 - type: gameMap
   id: Eden
-  mapName: 'Eden Station'
+  mapName: 'Eden'
   mapPath: /Maps/_Funkystation/eden.yml
   minPlayers: 7
   maxPlayers: 45


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
Eden is finally ready for live! After three weeks of amazing playtesting and feedback, it will now be replacing Omega in rotation!

Eden is a 7 to 45 player map, and is the spiritual successor to Omega. It was made with Omega as a canvas but has enough to give it its own identity. Eden is meant to fix the issues of the little-to-no maints in Omega, giving it plenty of room for expansion in the future, an additional means of energy production with the Tesla and optional Singulo, as well as including the Zookeeper role and Celedon (the zookeeper pet and ghost role). 

The most recent and final touches to Eden included, but are not limited to: 
- A working mail unit between Chem and Bot for easy transportation of plants.
- Minor details and additions with adjusting catwalks, decals, and more.

## Why / Balance
To make Eden an enjoyable and playable map.

## Media
<img width="6464" height="4448" alt="Eden-0" src="https://github.com/user-attachments/assets/e48741ee-f5cd-4ab9-be34-f7718f433386" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR, or it does not require an in-game showcase.
<!-- You should understand that not following the above may get your PR closed at the maintainer’s discretion -->

**Changelog**
:cl: salpphie
- add: Added Eden Station as the replacement for Omega Station