### PR TITLE
mindshields can't hurt thieves anymore

### DIFF
--- a/Content.Shared/Revolutionary/SharedRevolutionarySystem.cs
+++ b/Content.Shared/Revolutionary/SharedRevolutionarySystem.cs
@@ -62,11 +62,6 @@ public abstract class SharedRevolutionarySystem : EntitySystem
             return;
         }
 
-        //if (HasComp<ThievingComponent>(uid)) // funkystation - We're doing it here because this FUCKING SUCKS
-        //{
-        //    RemComp<ThievingComponent>(uid);
-        //} funkystation again - NEVERMORE SHALL THIEF FEEL THE WRATH OF THE MINDSHIELD!!
-
         if (HasComp<RevolutionaryComponent>(uid))
         {
             var stunTime = TimeSpan.FromSeconds(4);

--- a/Content.Shared/Strip/ThievingSystem.cs
+++ b/Content.Shared/Strip/ThievingSystem.cs
@@ -8,7 +8,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-using Content.Shared.Alert; // Funkystation - Removed unnecessary references
+using Content.Shared.Alert;
 using Content.Shared.Inventory;
 using Content.Shared.Strip.Components;
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Commented out the part of the C# that removed a thief's thieving component when mindshielded.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
It fucking sucks to be mindshielded as a thief. What part of a mindshield locks away (presumably years of) muscle memory related to taking someone's PDA or pocketbook? Mindshields could use another lore pass in general, but nothing it currently says would take away the ability to steal good.
## Technical details
<!-- Summary of code changes for easier review. -->
Deleted the part of SharedRevolutionarySystems.cs which says to nuke the thieving component when one gets mindshielded, and removed unnecessary references in ThievingSystem.cs
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="723" height="375" alt="pure, unadulterated test environment with thievery and a mindshield at once." src="https://github.com/user-attachments/assets/a6374015-39b6-4423-9652-cde3f07fdc82" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: zergologist, directed by mish and with moral support from Cuwaga
- tweak: Mindshields no longer nuke thief's passive thieving ability. Fanciful fingerwork finds a way.