### PR TITLE
Remove revolutionaries and survival from Secret

### DIFF
--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -39,9 +39,9 @@
   weights:
     Traitor: 0.27
     Changeling: 0.13 # Goobstation unique antag
-    Traitorling: 0.12 # 2 antags but less of each type applies for all hybrid modes, they all need 30 pop. Also makes lower pops roll more traitor games.
+    Traitorling: 0.20 # 2 antags but less of each type applies for all hybrid modes, they all need 30 pop. Also makes lower pops roll more traitor games.
     Nukeops: 0.15
-    Revolutionary: 0.10 # Maybe 0.08 after wiz/cult?
-    Survival: 0.08 # funky hi im putting something here because everything else has a comment
-    CosmicCult: 0.10
+    # Revolutionary: 0.10 # Maybe 0.08 after wiz/cult?
+    # Survival: 0.08 # funky hi im putting something here because everything else has a comment
+    CosmicCult: 0.20
     BlobTraitor: 0.05


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
Revolutionaries and survival are not up to the standards of other gamemodes in Secret rotation, and consistently create lower quality rounds than other gamemodes. Revs lend themselves heavily to roundstalling (the round that was the last straw for this almost necessitated a Death Squad), and survival leads to constant metagaming, where players cryo to take ghost roles as soon as they realize it's survival.

I've added the roll weights of these gamemodes to Cosmic Cult and Traitorling, respectively.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Revolutionaries and survival can no longer appear in Secret, replaced in weight by Cosmic Cult and Traitorling respectively.

