### PR TITLE
Changed Magistrate time requirements again

### DIFF
--- a/Resources/Prototypes/_Funkystation/Roles/Jobs/CentComm/magistrate.yml
+++ b/Resources/Prototypes/_Funkystation/Roles/Jobs/CentComm/magistrate.yml
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2025 88tv <131759102+88tv@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 8tv <eightev@gmail.com>
 # SPDX-FileCopyrightText: 2025 Josh Hilsberg <thejoulesberg@gmail.com>
 # SPDX-FileCopyrightText: 2025 JoulesBerg <104539820+JoulesBerg@users.noreply.github.com>


### PR DESCRIPTION
## About the PR
Magistrate time requirements have been changed from 100 hours security to 15 hours HOS, 20 hours CC department, and 75 hours in Security.

## Why / Balance
Lengthy discussion in the discord led to the conclusion of numerous points, of which I will deliberate here:
* Magistrate needs a significant amount of experience in IAA or NT Rep
* Magistrate's current 100 hour security requirement cannot hold if we include a new requirement as a SOP knowledge check

To explain the exact numbers we came to, I present the following:
* Unlocking the Head of Security demands 35 hours in security (10 warden, 20 secoff, 5 cadet).
* As we cannot use the NT Rep to demand a SOP knowledge check due to the command hours required for said role to be unlocked, the CC department is our second best option, as it includes the IAA's playtime. 20 hours was relatively arbitrary, but determined to be a good measure for experience in SOP application.
* The 75 hour general security department time effectively increases the amount of time someone would have to play to unlock Magistrate by 25 hours _after_ they complete the 15 hour Head of Security requirement.
   * This means that someone will have to unlock the Head of Security, play it for about 7 or 8 shifts, and then play about 12 or 13 more shifts in security afterwards before they are able to unlock the Magistrate. This sums to 75 hours of security playtime, something we feel is reasonable considering the new 20 hour CC department requirement.

See https://github.com/funky-station/funky-station/pull/1661 and https://github.com/funky-station/funky-station/pull/1552 for relevant PRs to this issue.


## Technical details
Yaml.

## Media
<img width="1157" height="200" alt="image" src="https://github.com/user-attachments/assets/552d53ce-524d-4367-88cb-f827269052e8" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A

**Changelog**

:cl:
- tweak: Changed the playtime requirements for the Magistrate. You now need to have 15 hours as the Head of Security, 20 hours in the Central Command department, and 75 hours within the Security department total to unlock it.
