### PR TITLE
Ports unimplemnted VSCode QOL improvements from Wizden

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,11 @@
 {
     "recommendations": [
         "ms-dotnettools.csharp",
-        "editorconfig.editorconfig"
+        "editorconfig.editorconfig",
+        "ertanic.robust-lsp",
+        "GitHub.vscode-pull-request-github",
+        "eamodio.gitlens",
+        "macabeus.vscode-fluent",
+        "redhat.vscode-yaml"
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,17 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "YAML Linter",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build-yaml-linter",
+            "program": "${workspaceFolder}/bin/Content.YAMLLinter/Content.YAMLLinter.dll",
+            "cwd": "${workspaceFolder}/Content.YAMLLinter",
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        // Client configurations
+        {
             "name": "Client",
             "type": "coreclr",
             "request": "launch",
@@ -14,7 +25,28 @@
             "stopAtEntry": false
         },
         {
-            "name": "Client (Compatibility renderer)",
+            "name": "Client - Tools",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build - Tools",
+            "program": "${workspaceFolder}/bin/Content.Client/Content.Client.dll",
+            "args": [],
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": "Client - Release",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build - Release",
+            "program": "${workspaceFolder}/bin/Content.Client/Content.Client.dll",
+            "args": [],
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        // Compatibility renderer client configurations
+        {
+            "name": "Client - (Compatibility renderer)",
             "type": "coreclr",
             "request": "launch",
             "program": "${workspaceFolder}/bin/Content.Client/Content.Client.dll",
@@ -22,6 +54,27 @@
             "console": "internalConsole",
             "stopAtEntry": false
         },
+        {
+            "name": "Client - Tools - (Compatibility renderer)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build - Tools",
+            "program": "${workspaceFolder}/bin/Content.Client/Content.Client.dll",
+            "args": ["--cvar display.compat=true"],
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        {
+            "name": "Client - Release - (Compatibility renderer)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build - Release",
+            "program": "${workspaceFolder}/bin/Content.Client/Content.Client.dll",
+            "args": ["--cvar display.compat=true"],
+            "console": "internalConsole",
+            "stopAtEntry": false
+        },
+        // Server configurations
         {
             "name": "Server",
             "type": "coreclr",
@@ -32,15 +85,25 @@
             "stopAtEntry": false
         },
         {
-            "name": "YAML Linter",
+            "name": "Server - Tools",
             "type": "coreclr",
             "request": "launch",
-            "preLaunchTask": "build-yaml-linter",
-            "program": "${workspaceFolder}/bin/Content.YAMLLinter/Content.YAMLLinter.dll",
-            "cwd": "${workspaceFolder}/Content.YAMLLinter",
-            "console": "internalConsole",
+            "preLaunchTask": "build - Tools",
+            "program": "${workspaceFolder}/bin/Content.Server/Content.Server.dll",
+            "args": [""],
+            "console": "integratedTerminal",
             "stopAtEntry": false
-        }
+        },
+        {
+            "name": "Server - Release",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build - Release",
+            "program": "${workspaceFolder}/bin/Content.Server/Content.Server.dll",
+            "args": [""],
+            "console": "integratedTerminal",
+            "stopAtEntry": false
+        },
     ],
     "compounds": [
         {
@@ -50,6 +113,22 @@
                 "Client"
             ],
             "preLaunchTask": "build"
+        },
+        {
+            "name": "Server/Client - Tools",
+            "configurations": [
+                "Server - Tools",
+                "Client - Tools"
+            ],
+            "preLaunchTask": "build - Tools"
+        },
+        {
+            "name": "Server/Client - Release",
+            "configurations": [
+                "Server - Release",
+                "Client - Release"
+            ],
+            "preLaunchTask": "build - Release"
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -22,6 +22,46 @@
             "problemMatcher": "$msCompile"
         },
         {
+            "label": "build - Tools",
+            "command": "dotnet",
+            "type": "shell",
+            "args": [
+                "build",
+                "--configuration",
+                "Tools",
+                "/property:GenerateFullPaths=true", // Ask dotnet build to generate full paths for file names.
+                "/consoleloggerparameters:'ForceNoAlign;NoSummary'", // Do not generate summary otherwise it leads to duplicate errors in Problems panel
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            },
+            "presentation": {
+                "reveal": "silent"
+            },
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "build - Release",
+            "command": "dotnet",
+            "type": "shell",
+            "args": [
+                "build",
+                "--configuration",
+                "Release",
+                "/property:GenerateFullPaths=true", // Ask dotnet build to generate full paths for file names.
+                "/consoleloggerparameters:'ForceNoAlign;NoSummary'", // Do not generate summary otherwise it leads to duplicate errors in Problems panel
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            },
+            "presentation": {
+                "reveal": "silent"
+            },
+            "problemMatcher": "$msCompile"
+        },
+        {
             "label": "build-yaml-linter",
             "command": "dotnet",
             "type": "process",


### PR DESCRIPTION
<!--- LICENSE: MIT -->
## About the PR
Ports https://github.com/space-wizards/space-station-14/pull/33891, an unimplemented PR for vscode QOL improvements.

## Why / Balance
I think I might be the only vscode user. While this is undoubtedly hell, this port should make me feel a little better about it.

## Technical details
Uhhh... Yeah, I have no clue what's going on in there. For what it's worth, Delta-V ported this a couple months ago, and they're doing just fine.

## Media
I mostly brought this over for the release build options.

BEFORE:
<img width="586" height="390" alt="image" src="https://github.com/user-attachments/assets/f8e4a87d-a94a-4179-a158-22b2a5bc0482" />

AFTER:
<img width="642" height="582" alt="image" src="https://github.com/user-attachments/assets/f83abd6f-0249-4d08-812e-e0a55d6a8b01" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A

**Changelog**
<!--- No changelog, this isn't user-facing -->