### PR TITLE
Magi sop numbering fix

### DIFF
--- a/Resources/ServerInfo/Funkystation/Guidebook/Command/CommandStandardOperatingProcedure.xml
+++ b/Resources/ServerInfo/Funkystation/Guidebook/Command/CommandStandardOperatingProcedure.xml
@@ -157,7 +157,7 @@ SPDX-License-Identifier: MIT
 
   [bold]7.[/bold] The Magistrate may administer class 1, 2, and 3 penalties for misconduct concerning the misinterpretation of space law. They should consult with the NanoTrasen Representative before administering penalties for misconduct concerning standard operating procedure, but have authority to administer up to class 3 penalties for those breaches as well.
 
-  [bold]7.[/bold] The Magistrate is permitted to carry their flash;
+  [bold]8.[/bold] The Magistrate is permitted to carry their flash;
 
   ## Magistrate OOC Rules
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Changes an errant second 7 in magistrate's sop to an 8
## Why / Balance
Resolves #1666 also I'm bored as hell right now and wanted to solve some pointless bullshit



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


No changelog who gives a shit

Also why the hell do you need sop to say you can have a flash, what? 