### PR TITLE
Enabling powered prying for the fireaxe

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/fireaxe.yml
@@ -30,6 +30,9 @@
 # SPDX-FileCopyrightText: 2024 Winkarst <74284083+Winkarst-cpu@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 nikthechampiongr <32041239+nikthechampiongr@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 QueerCats <jansencheng3@gmail.com>
+# SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2025 W.xyz() <tptechteam@gmail.com>
 # SPDX-FileCopyrightText: 2025 marc-pelletier <113944176+marc-pelletier@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 #


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
LICENSE: AGPL AND MIT
## About the PR
<!-- What did you change? -->
The fireaxe (as well as the fire axe* and the metal hydrogen axe) can now pry open powered doors.

\* "Fireaxe" refers to the Nanotrasen axe found in atmospherics and the bridge. "Fire axe" refers to the Syndicate axe that can be purchased through the uplink.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The reason Atmospherics has a fireaxe in the first place is part of their job identity. They're firefighters in addition to managing distro and the TEG, so they should be well-equipped to rescue people from fires.

The problem with the current fireaxe is, it's not very good at that. If someone is trapped in an department with a fire or other atmospheric hazard, the existing fireaxe is not going to help with that unless atmos goes and manually depowers all the doors just to get someone out. And at that point, why not just use a crowbar?

As for balance, this shouldn't be too much of a problem, especially when you compare it to the jaws of life. It's not as good at prying non-powered objects as the jaws of life, and lacks the jaws' wirecutter function. It can pry hull plating, but overall it's still a downgrade. Therefore, it feels more than fair for atmos to share this when the CE gets a strictly better version for themselves in their locker.

## Technical details
<!-- Summary of code changes for easier review. -->
The fireaxe now has `pryPowered` set to `true`. Since the fire axe and the hydrogen metal axe inherit from the fireaxe, this change also affects them (which is intended).

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
N/A.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: The fireaxe, fire axe, and metal hydrogen axe can now all pry open powered doors.