### PR TITLE
Made moths less vulnerable to flames

### DIFF
--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -41,6 +41,7 @@
 # SPDX-FileCopyrightText: 2024 deltanedas <39013340+deltanedas@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 deltanedas <@deltanedas:kde.org>
 # SPDX-FileCopyrightText: 2024 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 2DSiggy <siggymaxwell@gmail.com>
 # SPDX-FileCopyrightText: 2025 Mish <bluscout78@yahoo.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 #

--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -20,6 +20,7 @@
 # SPDX-FileCopyrightText: 2024 Ubaser <134914314+UbaserB@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 username <113782077+whateverusername0@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 whateverusername0 <whateveremail>
+# SPDX-FileCopyrightText: 2025 2DSiggy <siggymaxwell@gmail.com>
 # SPDX-FileCopyrightText: 2025 Skye <57879983+Rainbeon@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2025 jackel234 <52829582+jackel234@users.noreply.github.com>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
LICENSE: MIT
## About the PR
<!-- What did you change? -->
Port of [39672](https://github.com/space-wizards/space-station-14/pull/39672) from wizden. The description used will be from the port.

I made moths take less extra damage from being on-fire (not to be confused with their base heat weakness) to give them time to react, and to make it more fair for them compared to everyone else.
This should give moths roughly twice the time to react upon being set on fire.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This has been changed due to moths having an extremely easily abused weakness to flames; any raider or traitor could pick bartender, grab a bottle or two of alcohol, and set fire to every moth they see, killing them within 5s, with little they could do about it once they realised what was happening.

This also posed an unfair disadvantage to combat roles, as even a moth HoS or Captain could be very easily killed with just 20u of napalm, made with easily acquired materials at no cost.

## Technical details
<!-- Summary of code changes for easier review. -->
I just changed;

-  type: Flammable
    damage:
    types:
    Heat: 4.5 # moths burn more easily

to;

-   type: Flammable
    damage:
    types:
    Heat: 2 # moths burn more easily

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Unchanged, upstream example;

https://github.com/user-attachments/assets/4938aafc-00d3-443a-99e7-0ff0160d235e

New, PR example; (please note I accidentally gave the human urist an extra spray)

https://github.com/user-attachments/assets/00a91e07-d12e-446b-b216-1c8b71b997bf

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Made moths less susceptible to flames and heat. (4x Fire Damage -> 2x Fire damage) (1.3x heat -> 1.2x heat).

