### PR TITLE
Remove SM Hallucinations

### DIFF
--- a/Content.Server/_EE/Supermatter/Systems/SupermatterSystem.Processing.cs
+++ b/Content.Server/_EE/Supermatter/Systems/SupermatterSystem.Processing.cs
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2025 BrightNibbleston <218794821+BrightNibbleston@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 BrightNibbleston <brightnibbleston@gmail.com>
 // SPDX-FileCopyrightText: 2025 Do You Like Beans <bowenjonathan407@gmail.com>
 // SPDX-FileCopyrightText: 2025 Steve <marlumpy@gmail.com>
@@ -7,6 +8,7 @@
 // SPDX-FileCopyrightText: 2025 marc-pelletier <113944176+marc-pelletier@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+// SPDX-FileCopyrightText: 2025 viktoriiapell <viktoriiapell@gmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 


### PR DESCRIPTION
## About the PR
<!-- What did you change? -->
The SM no longer makes people hallucinate.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I personally suffer from paracusia and it bothers me that having the SM on my screen for one or more frames makes it worse.

## Technical details
<!-- Summary of code changes for easier review. -->
I commented out the lines referring to paracusia in the SM code.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: removed the supermatter's hallucination feature.
