### PR TITLE
whoopsy daisy criminal records

### DIFF
--- a/Resources/Prototypes/_Funkystation/Security/criminal_statuses.yml
+++ b/Resources/Prototypes/_Funkystation/Security/criminal_statuses.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2025 Ilya Mikheev <me@ilyamikcoder.com>
+# SPDX-FileCopyrightText: 2025 ilyamikcoder <me@ilyamikcoder.com>
 #
 # SPDX-License-Identifier: MIT
 


### PR DESCRIPTION
LICENSE: MIT

## About the PR
Fix setting suspected status on criminal records consoles sending wanted radio messages.

## Why / Balance
screwup in my criminal records PR

## Technical details
webedit

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None

**Changelog**
:cl:
- fix: Setting suspect status on criminal record consoles no longer sends radio messages about marking people as wanted.
