### PR TITLE
Makes cleanbots and medibots random sentience targets

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/silicon.yml
@@ -46,8 +46,10 @@
 # SPDX-FileCopyrightText: 2024 superjj18 <gagnonjake@gmail.com>
 # SPDX-FileCopyrightText: 2024 voidnull000 <18663194+voidnull000@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 88tv <131759102+88tv@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 8tv <eightev@gmail.com>
 # SPDX-FileCopyrightText: 2025 AsnDen <75905158+AsnDen@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Herostar898 <askherostar2@gmail.com>
+# SPDX-FileCopyrightText: 2025 Mish <bluscout78@yahoo.com>
 # SPDX-FileCopyrightText: 2025 Princess Cheeseballs <66055347+pronana@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2025 pa.pecherskij <pa.pecherskij@interfax.ru>


### PR DESCRIPTION
## About the PR
A direct revert of https://github.com/space-wizards/space-station-14/pull/32383. Cleanbot and medibot can be made sentient once more.

## Why / Balance
I miss roleplaying as a cleanbot.

## Technical details
yml knight

## Media
N/A

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A

**Changelog**
:cl:
- add: Medibots and Cleanbots can once more become sentient via the sentience event.
