### PR TITLE
Court station additions and overhauls

### DIFF
--- a/Resources/Maps/_Funkystation/court.yml
+++ b/Resources/Maps/_Funkystation/court.yml
@@ -62,8 +62,8 @@ meta:
   engineVersion: 266.0.0
   forkId: ""
   forkVersion: ""
-  time: 11/06/2025 17:55:14
-  entityCount: 24864
+  time: 11/07/2025 15:02:32
+  entityCount: 24866
 maps:
 - 1
 grids:
@@ -10823,7 +10823,7 @@ entities:
       pos: 32.5,48.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -170988.6
+      secondsUntilStateChange: -171029.05
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11100,7 +11100,7 @@ entities:
       pos: -28.5,49.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -297215.53
+      secondsUntilStateChange: -297256
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11485,7 +11485,7 @@ entities:
       pos: -8.5,55.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -249385.2
+      secondsUntilStateChange: -249425.66
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -11716,7 +11716,7 @@ entities:
       pos: -30.5,31.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -286225.12
+      secondsUntilStateChange: -286265.6
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -45651,6 +45651,11 @@ entities:
     - type: Transform
       pos: -23.5,11.5
       parent: 2
+  - uid: 15790
+    components:
+    - type: Transform
+      pos: -21.5,11.5
+      parent: 2
   - uid: 15906
     components:
     - type: Transform
@@ -45765,6 +45770,11 @@ entities:
     components:
     - type: Transform
       pos: -23.5,14.5
+      parent: 2
+  - uid: 24866
+    components:
+    - type: Transform
+      pos: -22.5,11.5
       parent: 2
 - proto: CableHVStack
   entities:
@@ -64301,7 +64311,7 @@ entities:
       pos: 13.5,7.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -351753.34
+      secondsUntilStateChange: -351793.8
       state: Opening
   - uid: 1805
     components:
@@ -159327,7 +159337,7 @@ entities:
       pos: -4.5,1.5
       parent: 2
     - type: Door
-      secondsUntilStateChange: -373305.1
+      secondsUntilStateChange: -373345.56
       state: Opening
   - uid: 2193
     components:


### PR DESCRIPTION
LICENSE: MIT
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
all map changes: 
- moved vox box beacon two tiles up and the chem one a couple tiles down
- modified AI chamber slightly and added two turrets to make it more secure 
- added tropico to atmosia
- made sure dorms always has a clothes mate + winter drobe 
- gave law office some folders
- added a drip closet in IA office
- added some magi drip in the magi closet
- made librarian and reporter airlocks librarian and reporter access respectively
- added offset canes to clown, mime, captain, magi, HoP and RD lockers as well as some in medbay and dorms. 
- added three more pAIs to the map since they can now interact with PDAs
- added a note in the HoP office to encourage hiring a zookeeper 
- added a bookshelf containing the chempendium in chemistry 
- added a station lore book to the bridge
- made chem walls reinforced
- removed duplicate beacon in dorms
- added a second AI turret panel that is easier for people to access but is still in the core
- removed green room green slime
- rearranged clown room and gave clown, mime and musician extra clothes in their dressers
- dan's soaked smokes have boarded the station
- added ratvar
- added more firelocks in maints

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Updating court station to add new items from the recent update as well as overhauls to make the map more playable and fixing issues that became apparent in the second playtest on november 4th.
## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Current state of the map:

<img width="5408" height="4800" alt="Court-0" src="https://github.com/user-attachments/assets/282c7243-1c58-4f2e-831f-b54456fc0eed" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: updated Court station for the third playtest

