### PR TITLE
Fix IPC cosmic cultists not being deconvertable

### DIFF
--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
@@ -5,7 +5,6 @@
 # SPDX-FileCopyrightText: 2025 Lyndomen <49795619+lyndomen@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Mish <bluscout78@yahoo.com>
 # SPDX-FileCopyrightText: 2025 No Elka <no.elka.the.god@gmail.com>
-# SPDX-FileCopyrightText: 2025 NoElkaTheGod <no.elka.the.god@gmail.com>
 # SPDX-FileCopyrightText: 2025 Skye <57879983+Rainbeon@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2025 corresp0nd <46357632+corresp0nd@users.noreply.github.com>


### PR DESCRIPTION
## About the PR
IPC cosmic cultists can now be deconverted like everyone else.

## Why / Balance
Being able to deconvert cultists is kinda important.

## Technical details
One line PR ops.

## Media
Not needed.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: IPC cosmic cultists can be properly deconverted now.
