### PR TITLE
Changed legality on Magboots and Engineering Goggles

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/Entities/Clothing/Eyes/glasses.yml
@@ -39,6 +39,7 @@
 # SPDX-FileCopyrightText: 2024 themias <89101928+themias@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 88tv <131759102+88tv@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 8tv <eightev@gmail.com>
+# SPDX-FileCopyrightText: 2025 ALooseGoose <ALooseGoosey@gmail.com>
 # SPDX-FileCopyrightText: 2025 AtlasHD <99688062+AtlasHDD@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Dragon232347 <122056448+Dragon232347@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>

--- a/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/magboots.yml
@@ -26,6 +26,7 @@
 # SPDX-FileCopyrightText: 2024 Ty Ashley <42426760+TyAshley@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 deltanedas <39013340+deltanedas@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 ALooseGoose <ALooseGoosey@gmail.com>
 # SPDX-FileCopyrightText: 2025 Binbag <124107163+Binbagg@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2025 pa.pecherskij <pa.pecherskij@interfax.ru>

--- a/Resources/Prototypes/Entities/Objects/base_contraband.yml
+++ b/Resources/Prototypes/Entities/Objects/base_contraband.yml
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2024 Plykiya <58439124+Plykiya@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2024 Winkarst <74284083+Winkarst-cpu@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 ALooseGoose <ALooseGoosey@gmail.com>
 # SPDX-FileCopyrightText: 2025 Skye <57879983+Rainbeon@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2025 pa.pecherskij <pa.pecherskij@interfax.ru>

--- a/Resources/Prototypes/_Funkystation/Entities/Clothing/Eyes/glasses.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Clothing/Eyes/glasses.yml
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2025 ALooseGoose <ALooseGoosey@gmail.com>
 # SPDX-FileCopyrightText: 2025 AtlasHD <99688062+AtlasHDD@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Teasq <Xerithin@gmail.com>
 # SPDX-FileCopyrightText: 2025 mkanke-real <mikekanke@gmail.com>


### PR DESCRIPTION
## About the PR
Just as the title says. Magboots and Engineering Goggles have had their Legality for certain departments tweaked. Magboots, both Science and Engineering variants, are now legal for the Science and Engineering Department and for Salvs Specifically. Engineering goggles are now legal for Engineering department and Salvs as well.

## Why / Balance
I find it odd that, despite spawning in their locker, Engineering Goggles aren't legal for Salvs to use in technicality. I also found Magboots, while not something people usually ask for in science, are probably cooler if they were restricted to certain departments. I doubt sec will care, but it just makes sense in my opinion.

## Technical details
Added new Contra Levels (EngineeringScienceSalv and EngineeringSalv), and added it onto Science Magboots,, Engineering Magboots, Engineering Goggles, and Engineering Jamgoggles

## Media
[
<img width="552" height="147" alt="Magboots 1" src="https://github.com/user-attachments/assets/c7640462-782e-481d-9587-fbcc075b0b39" />
](url)
<img width="598" height="144" alt="Magboots 2" src="https://github.com/user-attachments/assets/d0482a5f-1fdf-49ee-aff8-6a6fca600a12" />
<img width="585" height="182" alt="Engi Goggles" src="https://github.com/user-attachments/assets/e6e4d914-6894-4500-a39f-b0a241b4d820" />
<img width="597" height="162" alt="Engi Jamgoggles" src="https://github.com/user-attachments/assets/1828eace-02d4-4ceb-a5a7-3deaa27eac07" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes

**Changelog**
:cl: ALooseGoose
- tweak: Changed the legality of Magboots (Restricted to Science, Engineering and Salvage) and Engineering goggles/jamgoggles (Engineering, Salvage).

