### PR TITLE
Balancing Nukie team size towards the current MaxPop balance

### DIFF
--- a/Resources/Prototypes/GameRules/roundstart.yml
+++ b/Resources/Prototypes/GameRules/roundstart.yml
@@ -31,6 +31,7 @@
 # SPDX-FileCopyrightText: 2024 deltanedas <39013340+deltanedas@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 username <113782077+whateverusername0@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Leonard Widham <rasmus@widham.se>
 # SPDX-FileCopyrightText: 2025 Middleson5 <Chance@thethiers.com>
 # SPDX-FileCopyrightText: 2025 Mish <bluscout78@yahoo.com>
 # SPDX-FileCopyrightText: 2025 Rainbow <ev0lvkitten@gmail.com>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
This simply reduces the NukeOp population ratio balance to 8% instead of 10%.

This is also my first PR and I hope it will serve to teach me how to effectively contribute. I have spent 10s of hours reading the codebase and writing design docs for my ideas and hope to be fully ready to contribute regularly after this.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Currently this is mainly based in math and my own experiences playing WarOps around the 40-50 player count.

The worst ratios happen at multiples of 10, with the worst one happening at 40 because it enables war ops.
For 40 pop (min for warops): 10% = 4 Nukies, leaving 36 crew. This means the crew to Nukie ratio is 1-9, at which point you can expect 1-2 sec per Nukie. (Or less in really bad cases)

Nukies then max out for 50. 50 has the same ratios as 40.

This means that by the time you hit 80 pop, Nukie ratio has dropped from 1/10 to 1/16, giving us a new ratio of 1-15, a more than 60% increase in the amount of crew to fight off the same threat. This is a massive difference that is very noticeable in gameplay.

At  8% maximum operatives should be reached at roughly 64 pop, with a nearly 1-12 ratio, leaving a 20% difference from max pop. Technically 7% gets the most even ratio at roughly 75 pops, giving a about a 1-14 ratio or around a 7% difference, but because of how the lobby generally works I do not think 7% is optimal.

Why I am lowering ratio instead of increasing operatives:
The mode is already one where SOP tends to fall apart immediately and large parts of the rounds have little to no RP. I do not believe this is the players fault, for not trying their hardest to win almost certainly means losing, which feels really bad when you are the 90% of players losing to the 10%. This is mainly a problem in WarOps of course. 

## Technical details
<!-- Summary of code changes for easier review. -->
It is one line currently. May need to change minPop for the mode to make this work.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ X ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Ralkern
- tweak: reduced NukeOp population ratio from 10% to 8%, to bridge some of the gap between max operatives and server max pop.

