### PR TITLE
Entities with AdvertiseComponent no longer advertise while posessed by a player

### DIFF
--- a/Content.Server/Advertise/EntitySystems/AdvertiseSystem.cs
+++ b/Content.Server/Advertise/EntitySystems/AdvertiseSystem.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2024 Aidenkrz <aiden@djkraz.com>
 // SPDX-FileCopyrightText: 2024 Tayrtahn <tayrtahn@gmail.com>
 // SPDX-FileCopyrightText: 2024 Wrexbe (Josh) <81056464+wrexbe@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2025 Ilya Mikheev <me@ilyamikcoder.com>
 // SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 //
 // SPDX-License-Identifier: MIT


### PR DESCRIPTION
LICENSE: MIT

## About the PR
Extremely simple one file change. Entities with AdvertiseComponent (medibots, vending machines etc.) will no longer say random things at times when they are possessed by a player.

## Why / Balance
I was playing a Medibot, and it yelled AM Hate copypasta, breaking my character. I didn't like it. Consider this a mald PR.

## Technical details
This adds like 6 lines of code save for comments.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl:
- tweak: Entities that "advertise" (say random things at intervals - medibots, vending machines etc.) will no longer do so while possessed by a player.
