### PR TITLE
cc pen for ntr and magi

### DIFF
--- a/Resources/Prototypes/_Funkystation/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Objects/Devices/pda.yml
@@ -4,8 +4,11 @@
 # SPDX-FileCopyrightText: 2025 DevilishMilk <michaellapjr@gmail.com>
 # SPDX-FileCopyrightText: 2025 Mish <bluscout78@yahoo.com>
 # SPDX-FileCopyrightText: 2025 PurpleTranStar <purpletranstars@gmail.com>
+# SPDX-FileCopyrightText: 2025 PurpleTranStar <tehevilduckiscoming@gmail.com>
 # SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2025 ferynn <witchy.girl.me@gmail.com>
 # SPDX-FileCopyrightText: 2025 kbarkevich <24629810+kbarkevich@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 mqole <113324899+mqole@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 #


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Swapped Luxury Pens for CentComm pens in the magistrate and NTR PDAs

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The Centcomm Pen is notable for being a clone of the Cybersun pen, which allows for forgery. It also a somewhat decent weapon, but not better than the gavel.

The point of this PR isn't so much for the NTR or Magi to use these unique functions, but to make stealing their PDA and through that the pen a fun target target for antags. The NTR or Magi's ID is generally less useful than the Captain or HOP ID. This stronger pen makes it a  little fun thing for antags to try to grab, and open up various forgery related strategies.

It is possible that the NTR or Magi could use the forgery tool themselves. Ideally this would be rare, as the players in these roles are supposed to be trusted. I don't think this risk is an issue per se. Either they are using that ability in some way that elevates the round meaningfully, or it provides an easy way for admins to identify "bad" players of Centcomm roles. Either way, that's not a downside in the bigger picture, at least to me.

## Technical details
<!-- Summary of code changes for easier review. -->

Swapped pen ID in NTR and magi pda.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="478" height="449" alt="Screenshot 2025-11-15 232652" src="https://github.com/user-attachments/assets/f75f9864-4fbd-4236-a1ee-b0d7966ff243" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: The NTR and Magistrate PDA's now have the Centcomm pen inside.

