### PR TITLE
Players can take actions while prone again. Percent chance to hit prone targets while standing.

### DIFF
--- a/Content.Shared/Cuffs/SharedCuffableSystem.cs
+++ b/Content.Shared/Cuffs/SharedCuffableSystem.cs
@@ -33,6 +33,7 @@
 // SPDX-FileCopyrightText: 2024 themias <89101928+themias@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 JoulesBerg <104539820+JoulesBerg@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
+// SPDX-FileCopyrightText: 2025 ferynn <witchy.girl.me@gmail.com>
 // SPDX-FileCopyrightText: 2025 pa.pecherskij <pa.pecherskij@interfax.ru>
 // SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 //

--- a/Content.Shared/Damage/Systems/RequireProjectileTargetSystem.cs
+++ b/Content.Shared/Damage/Systems/RequireProjectileTargetSystem.cs
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2024 Cojoke <83733158+Cojoke-dot@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 MilenVolf <63782763+MilenVolf@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
+// SPDX-FileCopyrightText: 2025 ferynn <witchy.girl.me@gmail.com>
 // SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 //
 // SPDX-License-Identifier: MIT


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->

Reverted PR 993, which removed the ability to take actions while prone. This was in response to views about the combat meta being too oriented towards being prone.

I do think it has negative impacts on the game though, as removing all prone actions hit a _lot_ more than just guns.

With that in mind, I readded the ability to take actions while prone. I added a percent chance for standing targets to hit prone targets with projectiles.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Let's people do things while prone again, and remove all the many annoyances that were caused by that.

Currently there is a 20 percent chance for projectiles fired by standing targets to hit prone targets in their line of fire. This means being prone isn't total immunity, especially against automatic weapons. Stealthed targets will eventually be revealed by their bleeding/damage reactions from sprayed bullets.

Also, as a reminder. If you are prone, you hit other prone people 100 percent of the time. This is not a new addition, but an existing mechanic. So if an enemy is prone, or perhaps prone and invisible, you can drop yourself and hit them.

## Technical details
<!-- Summary of code changes for easier review. -->

Added a initialization of the Random class in the class that determines projectile non-collision. When a projectile would potentially hit a prone target, it generates a new random number and compares it to a given threshold. Currently it is .2, and the rand value is from 0-1. 

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Players can once again take actions while prone
- add: Shooting projectiles over a prone target has a 20 percent chance of hitting them. (Firing while prone always hits prone targets)


