### PR TITLE
Rework fire stacks spreading logic

### DIFF
--- a/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
+++ b/Content.Server/Atmos/EntitySystems/FlammableSystem.cs
@@ -36,6 +36,7 @@
 // SPDX-FileCopyrightText: 2024 Whisper <121047731+QuietlyWhisper@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 deltanedas <39013340+deltanedas@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 deltanedas <@deltanedas:kde.org>
+// SPDX-FileCopyrightText: 2025 Drywink <hugogrethen@gmail.com>
 // SPDX-FileCopyrightText: 2025 Ilya246 <ilyukarno@gmail.com>
 // SPDX-FileCopyrightText: 2025 QueerCats <jansencheng3@gmail.com>
 // SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>


### PR DESCRIPTION
## About the PR
Rewrite how fire stacks spread upon collision with entities.

## Why / Balance
The old logic didn't made any senses, i'm suprised it survived this long. Now fire will properly spread between entities depending on their mass.

## Technical details
Before, the logic made absolutely no senses. If an entity got 10 fire stacks, it could be able to transfer all 10 stacks to someone else, extinguishing himself in the process... or do absolutely nothing, depending on the order... I can't really expand on what it was supposed to do honestly.

Now it properly distribute the total heat depending on the mass of the entities.

Example A :
EntityA.mass = 10
EntityA.fireStacks = 10
EntityB.mass = 100
EntityB.fireStacks = 0

Result =
EntityA.fireStacks = 0.91
EntityB.fireStacks = 0.91

Example B :
EntityA.mass = 100
EntityA.fireStacks = 10
EntityB.mass = 10
EntityB.fireStacks = 0

Result =
EntityA.fireStacks = 9.1
EntityB.fireStacks = 9.1

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Fire spreading when entities are colliding now works properly.