### PR TITLE
Argocyte Spawners

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Mobs/argocyte.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Mobs/argocyte.yml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2025 8tv <eightev@gmail.com>
 # SPDX-FileCopyrightText: 2025 Errant <35878406+Errant-4@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Southbridge <7013162+southbridge-fur@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 salpphie <alyssa.thomas51@gmail.com>
 #
 # SPDX-License-Identifier: MIT
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
Added spawners for each Argocyte, allowing them to be mapped and used in future projects.

## Why / Balance
No direct gameplay effect. Argocytes were already in the game, just did not have a spawner.

## Technical details
Added:
* Resources/Prototypes/Entities/Markers/Spawners/Mobs/argocyte.yml

## Media
<img width="368" height="834" alt="image" src="https://github.com/user-attachments/assets/c3cb6bc2-42d1-48e6-aa55-45114be428d4" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: salpphie
- add: Added Argocyte spawners
