### PR TITLE
Cyborgs slow down when sufficiently damaged

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -33,6 +33,7 @@
 # SPDX-FileCopyrightText: 2024 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 plykiya <plykiya@protonmail.com>
 # SPDX-FileCopyrightText: 2024 themias <89101928+themias@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 8tv <eightev@gmail.com>
 # SPDX-FileCopyrightText: 2025 Ilya Mikheev <me@ilyamikcoder.com>
 # SPDX-FileCopyrightText: 2025 Kittygyat <202250949+Kittygyat@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 PurpleTranStar <purpletranstars@gmail.com>
@@ -45,6 +46,7 @@
 # SPDX-FileCopyrightText: 2025 V <97265903+formlessnameless@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 archrbx <punk.gear5260@fastmail.com>
 # SPDX-FileCopyrightText: 2025 corresp0nd <46357632+corresp0nd@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 ilyamikcoder <me@ilyamikcoder.com>
 # SPDX-FileCopyrightText: 2025 jackel234 <52829582+jackel234@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 pa.pecherskij <pa.pecherskij@interfax.ru>
 # SPDX-FileCopyrightText: 2025 slarticodefast <161409025+slarticodefast@users.noreply.github.com>


### PR DESCRIPTION
## About the PR
Added the SlowOnDamage component to the BaseBorgChassis using the default values applied to the BaseMob entity. Cyborgs slow down by 20% once they reach 60 total damage and they slow down by 40% once they reach 80 total damage. To the best of my knowledge, these numbers are standard across most entities.

## Why / Balance
This is a means to make traitor-cyborg combos less powerful, but it in effect makes ALL cyborgs significantly worse at combat - now they're on a somewhat more level playing field with the humanoids, save for the inherent inability to slip.

There is a worry of this messing with syndicate assault cyborg balance and the malf AI game mode. I think the change is warranted regardless. 

## Technical details
Copied the SlowOnDamage component straight off of BaseMob.

## Media
N/A

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A

**Changelog**
:cl:
- tweak: Cyborgs now slow down when sufficiently damaged.
