### PR TITLE
Map rotation updates for the week of Dec. 1st

### DIFF
--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -52,8 +52,8 @@
   - Bagel
   - roid_outpost
   - Amber
-  - Elkridge
   - Core
   - Fland
+  - Olympus
 
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->

This PR will finally formally remove Elkridge from regular map rotation. I'm also adding Olympus to rotation for a 1-2 week trial period, after which it will either be formally retired and only used for events, or given a more concrete spot in rotation.

:cl:
- tweak: Map rotation updates: Add Olympus (on a trial period), remove Elkridge

