### PR TITLE
fix guidebook printing edge essentia proc chance multiple times

### DIFF
--- a/Resources/Locale/en-US/_Funkystation/reagents/bloodcult.ftl
+++ b/Resources/Locale/en-US/_Funkystation/reagents/bloodcult.ftl
@@ -6,10 +6,7 @@ reagent-name-edge-essentia = edge essentia
 reagent-desc-edge-essentia = A dark, cursed substance that corrupts the blood of wounded victims, turning their bleeding wounds into sources of sanguine perniculate.
 
 reagent-effect-guidebook-bleed-sanguine-perniculate =
-    { $chance ->
-        [1] Converts
-       *[other] Has a {NATURALPERCENT($chance, 2)} chance to convert
-    } bleeding blood into sanguine perniculate
+    convert bleeding blood into sanguine perniculate
 
 reagent-effect-condition-guidebook-is-blood-cultist = { $invert ->
     [true] the target is not a blood cultist


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
removed a few lines that would print information in the guidebook more than once regarding the Edge Essentia reagent for blood cultists

## Why / Balance
so the guidebook has one less issue with it

## Technical details
the tag:
      - !type:BleedSanguinePerniculate
        probability: 0.5
was printing "Has a 50% chance to" prior to any text in the effect description of the reagent in the guidebook already, so it was printing "Has a 50% chance to Has a 50% chance to" due to the existence of "Has a {NATURALPERCENT($chance, 2)} chance to" in reagent-effect-guidebook-bleed-sanguine-perniculate

## Media
Small fixes/refactors are exempt.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: loams
- fix: Fixed an issue where the guidebook was printing proc chances for Edge Essentia multiple times