### PR TITLE
Adds a 0.1% chance for MobCorgiMouse to show up as HoP's pet

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Mobs/pets.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Mobs/pets.yml
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2025 88tv <131759102+88tv@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 8tv <eightev@gmail.com>
+# SPDX-FileCopyrightText: 2025 Amethyst <52829582+jackel234@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Crude Oil <124208219+CroilBird@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Errant <35878406+Errant-4@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Southbridge <7013162+southbridge-fur@users.noreply.github.com>


### PR DESCRIPTION
## About the PR
Instead of Ian, puppy ian, old ian, or lisa, there's a very, very small chance for HoP's pet spawner to create MobCorgiMouse.

## Why / Balance
<img width="195" height="162" alt="image" src="https://github.com/user-attachments/assets/eb132f1e-3dda-4458-8366-11f926d5fc23" />

## Technical details
Replaced the ConditionalSpawner component on the HoP's pet spawner with RandomSpawner, giving a 99.9% chance to spawn the typical corgis and a 0.1% chance to spawn the mouse corgi.

## Media
<img width="1573" height="1157" alt="image" src="https://github.com/user-attachments/assets/8b26a73a-762f-4c19-bdea-a350fe10eeef" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
N/A

**Changelog**
:cl:
- add: Added a very low chance for HoP's corgi to spawn as a very real, very hungry mouse.
