### PR TITLE
Adds a 5% sprint slow on satchels

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Back/satchel.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/satchel.yml
@@ -22,6 +22,7 @@
 # SPDX-FileCopyrightText: 2024 KingFroozy <froozy345@mail.ru>
 # SPDX-FileCopyrightText: 2024 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2025 8tv <eightev@gmail.com>
 # SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 #


### PR DESCRIPTION
## About the PR
Adds the ClothingSpeedModifier component to satchels with a sprintModifier of 0.95.

## Why / Balance
I've mastered the art of inventory jenga and now know that satchels are just backpacks but better. Items that don't fit into a 4x4 don't show up often enough to matter to satchel users, and backpacks thus end up often only used by bartenders (the devious 1x5 shotgun). 

If you want to go fast, you should sacrifice inventory space to do so. Backpacks are the solution.

## Technical details
yml

## Media
<img width="527" height="230" alt="image" src="https://github.com/user-attachments/assets/dc9de9f5-70d9-42e0-96d7-4d3d4a5794a6" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- tweak: Satchels now slow you down by 5%. Consider wearing a backpack instead.