### PR TITLE
Gingerbreads don't take water damage

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/gingerbread.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/gingerbread.yml
@@ -60,7 +60,7 @@
         scaleByQuantity: true
         damage:
           types:
-            Genetic: 0.3
+            Cellular: 0.3
       - !type:PopupMessage
         type: Local
         visualType: Large


### PR DESCRIPTION
## About the PR
Fixes slimes being damaged by water.

## Why / Balance
It wasn't working previously.

## Technical details
I changed one word. Genetic to cellular, so that the damage actually applies. YAML is my passion.

## Media

https://github.com/user-attachments/assets/ce4133dd-27fa-4ed9-b225-ae02e6badbdf


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

- fix: Gingerbread now take damage when exposed to water, like slimes
