### PR TITLE
Fixed gingerbread water damage

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/gingerbread.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/gingerbread.yml
@@ -8,6 +8,8 @@
 # SPDX-FileCopyrightText: 2024 whateverusername0 <whateveremail>
 # SPDX-FileCopyrightText: 2025 88tv <131759102+88tv@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 YoungThug <ramialanbagy@gmail.com>
+# SPDX-FileCopyrightText: 2025 lzk <124214523+lzk228@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 otokonoko-dev <248204705+otokonoko-dev@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT


### PR DESCRIPTION
## About the PR
Fixes slimes being damaged by water.

## Why / Balance
It wasn't working previously.

## Technical details
I changed one word. Genetic to cellular, so that the damage actually applies. YAML is my passion.

## Media

https://github.com/user-attachments/assets/ce4133dd-27fa-4ed9-b225-ae02e6badbdf


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

- fix: Gingerbread now take damage when exposed to water, like slimes
