### PR TITLE
Map rotation update for the week of Dec. 15

### DIFF
--- a/Resources/Prototypes/Maps/Pools/default.yml
+++ b/Resources/Prototypes/Maps/Pools/default.yml
@@ -46,13 +46,19 @@
 - type: gameMapPool
   id: DefaultMapPool
   maps: #funkystation
+  # low pop
   - Cluster
   - Eden
-  - Bagel
-  - roid_outpost
   - Amber
+  - roid_outpost
+# - open slot
+  # high pop
+  - Bagel
   - Core
   - Fland
-  - Olympus
-
+# - open slot
+# - open slot
+  # backup maps
+  # comment and uncomment as needed
+  - Court
 


### PR DESCRIPTION

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->

Removing Olympus from rotation now that its test period is up, and temporarily adding Court to stop every round from being Bagel, Core, and Fland.

I also took the liberty of reformatting default.yml, so the state of the map rotation is clearer at a glance.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- tweak: Map rotation update: -Olympus +Court

