### PR TITLE
Cleanup cocoon system: replace HashSet and localization fix

### DIFF
--- a/Content.Shared/Species/Components/CocoonContainerComponent.cs
+++ b/Content.Shared/Species/Components/CocoonContainerComponent.cs
@@ -30,6 +30,13 @@ public sealed partial class CocoonContainerComponent : Component
     /// </summary>
     [DataField]
     public float AbsorbPercentage = 0.3f;
+
+    /// <summary>
+    /// Flag to prevent recursion when processing damage changes.
+    /// This is set to true while we're modifying damage to avoid infinite loops.
+    /// </summary>
+    [ViewVariables]
+    public bool ProcessingDamage = false;
 }
 
 /// <summary>

--- a/Resources/Locale/en-US/actions/actions/spider.ftl
+++ b/Resources/Locale/en-US/actions/actions/spider.ftl
@@ -22,6 +22,7 @@ arachnid-wrap-complete-user = You bind {$target} inside a cocoon of silk.
 arachnid-wrap-complete-target = Sticky silk envelops you, leaving you helpless!
 arachnid-unwrap-self = You're trussed up too tightly to free yourself!
 arachnid-unwrap-start-user = You begin unwrapping the cocoon restraining {$target}.
+arachnid-unwrap-start-user-empty = You begin unwrapping the cocoon.
 arachnid-unwrap-start-target = {$user} begins to unwrap you from the cocoon!
 arachnid-unwrap-user = You tear apart the cocoon restraining {$target}.
 arachnid-unwrap-target = {$user} frees you from the cocoon!


### PR DESCRIPTION
## About the PR
Cleanup code and fix some localization.

## Why / Balance
Because I like things when they are clean.

## Technical details
Added localization for when the target is invalid during unwrapping.
Replace hashset with component flag instead.

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Proper localization when the cocooned victim is invalid.
