### PR TITLE
Fix the SM to no longer eat gas.

### DIFF
--- a/Content.Server/_EE/Supermatter/Systems/SupermatterSystem.Processing.cs
+++ b/Content.Server/_EE/Supermatter/Systems/SupermatterSystem.Processing.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 BrightNibbleston <218794821+BrightNibbleston@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 BrightNibbleston <brightnibbleston@gmail.com>
 // SPDX-FileCopyrightText: 2025 Do You Like Beans <bowenjonathan407@gmail.com>
+// SPDX-FileCopyrightText: 2025 Homingpenguins <asadellace4@gmail.com>
 // SPDX-FileCopyrightText: 2025 Steve <marlumpy@gmail.com>
 // SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
 // SPDX-FileCopyrightText: 2025 Terkala <appleorange64@gmail.com>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
We have known about this for too long, and haven't fixed it. So i typed out the lines from the pictures, and here it is.
This forces the SM to spit out the gas it was eating to make damage calculations.

I would recommend mappers have 2 canisters of nitrogen in their SM rooms, assuming engineers do not have access to those canisters without maints hunting or going into atmos.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
This allows SMs to run without miners as intended. This will likely make SMs more stable in general, and probably less finicky.
It will also allow engineers to run basic SMs without the need to even walk into atmospherics. [Assuming canisters are handy]
We can also run more exotic SMs without a constant supply of said exotic gas.

## Technical details
<!-- Summary of code changes for easier review. -->
Added 2 lines of code and 2 comments.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="739" height="397" alt="Thumbs up" src="https://github.com/user-attachments/assets/e114bf7e-74b6-44ac-b7bb-0ef9777c427d" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
-->
🆑 fix: SM no longer eats gasses during its damage calculations.