### PR TITLE
Felinid downside reduction.

### DIFF
--- a/Resources/Prototypes/Nyanotrasen/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Nyanotrasen/Damage/modifier_sets.yml
@@ -6,6 +6,6 @@
 - type: damageModifierSet
   id: Felinid
   coefficients:
-    Blunt: 1.15
-    Slash: 1.15
-    Piercing: 1.15
+    Blunt: 1.05
+    Slash: 1.00
+    Piercing: 1.00

--- a/Resources/ServerInfo/Guidebook/Mobs/Felinid.xml
+++ b/Resources/ServerInfo/Guidebook/Mobs/Felinid.xml
@@ -32,7 +32,6 @@ SPDX-License-Identifier: MIT
 
   ## Damage
 
-  Felinids take 15% more [color=orange]Blunt[/color], [color=orange]Slashing[/color] and [color=orange]Piercing[/color] damage,
-  and take 30% more [color=cornflowerblue]Cold[/color] damage than other species.
+  Felinids take 5% more [color=orange]Blunt[/color] damage than other species.
 
 </Document>


### PR DESCRIPTION


Oh and regarding the whole "Its just an rp game why do the stats matter" Look at the whole ipc debate. Balancing the stats to make the other, non-rp parts of the game fun helps.

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
-Removed and reduced the damage vulnerabilities Felinids have to only a 5% blunt reduction and keeping the 30% cold weakness; as well as removing the stamcap decrease
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Basically i feel like Felinids just are way, WAY too handicapped for no real reason The two "Upsides" are so, SO niche they will only occur once in  a blue moon, and the downsides are too crippling to balance it out.

For comparison:
Lizards have the tail drag. Dragging a janitorial trolley, body, crate, etc, hands free is a nice convenience. Slashing instead of blunt unarmed is okay. For this trade off they get a mild weakness against cold. Fair enough.

Slimes, have their core thing and internal storage, along with blunt and poison resist. In exchange, they get absolutely SHREDDED by piercing and slash damage. again. fair.

Harpies have their wings, the music thing, and the talon and breath gimmick. Their damage vulnerability is explained in game by the wings and hollow bones.

And then you have the cats who's two upsides are both terrible one only come in handy once in a blue moon and is more of a bandaid on a decapitation. I dont even know what CAUSES fall damage, and the only high speed collision i can think of off the top is shuttle crashing which if that happens in the first place you probably have bigger problems, such as the eviscerated shuttle, the rest of the crew, and that I'm pretty sure you'd still be in crit or dying... not to mention you could just yknow... *not crash in the first place? the other is good on paper but in practice is also useless. If i need to sneak around, im certainly not going to remember to go barefoot (if that even actually DOES silence it) and if i do... then what? i get a few shots off and die anyways? I get seen cause the lights are on and people are actually watching their flank?)

Does this make them stronger? Yes. _**by making them far closer to the human mutation that they are meant to be.**_
 For instance, Echofur is a security character; Sure, I can RP her like a bit of a cat or a "human+" but then when it comes time  to fight nukies or do my job in anyway shape or form i have to have a crippling disadvantage in both nonlethal and lethal combat for no discernible reason. Another gripe is that unlike with harpies, felinids aren't even given a lore reason; just "oh yeah they take more physical damage btw lol get fucked"  Harpys  have big wings and legs that are the hollow bones of the mutation, so that makes sense. but do you mean to tell me that having cat ears on my *head* makes getting shot in the *foot* that much worse?


## Technical details
<!-- Summary of code changes for easier review. -->
-Blunt: 1.15>1.05
-Slash and Pierce: 1.15>1.00
-Stamcrit: 75>100

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="2560" height="1392" alt="{2603F0F3-B756-4422-B19E-AD20A0F8F982}" src="https://github.com/user-attachments/assets/7ec140ed-04a1-4c1e-ae4b-7dbf4b0b885a" />
(I have no idea what variable to look at in-game to prove that i changed the damage vulnerabilites


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- remove: Removed felinids pierce and slash vulnerabilities
- tweak: Made Felinids have a default 100 stamina crit (was only 75) and 5% blunt weakness (From 15%)

-->
