### PR TITLE
Minor additions to Security SOP and RoC

### DIFF
--- a/Resources/ServerInfo/Funkystation/Guidebook/Security/RulesOfConduct.xml
+++ b/Resources/ServerInfo/Funkystation/Guidebook/Security/RulesOfConduct.xml
@@ -32,7 +32,7 @@ SPDX-License-Identifier: MIT
 
   [bold]11.[/bold] Security Officers shall not be absent from duty assignment.
 
-  [bold]12.[/bold] Security Officers shall not be critical or talk negatively about other Nanotrasen security officers or any member of Command while on-duty.
+  [bold]12.[/bold] Security Officers shall not be critical or talk negatively about other Nanotrasen Security Officers or any member of Command while on-duty.
 
   [bold]13.[/bold] Security Officers shall not join a union or entertain the idea of a union.
 
@@ -41,6 +41,8 @@ SPDX-License-Identifier: MIT
   [bold]15.[/bold] Security Officers shall not associate or fraternize with any person to have been convicted of any crime, excluding violations that resulted in a warning.
 
   [bold]16.[/bold] Security Officers shall not give an opinion on any punishment to a crime, or whether the law should be enforced or not.
+
+  [bold]17.[/bold] Security Officers must wear a uniform that makes them identifiable as a member of the department.
 
   Failure to follow these Rules of Conduct may result in disciplinary action, or in termination, depending on the severity of the violation. All disciplinary actions or terminations may be made at the discretion of the Head of Security or the Captain.
 </Document>

--- a/Resources/ServerInfo/Funkystation/Guidebook/Security/SecurityOfficerSOP.xml
+++ b/Resources/ServerInfo/Funkystation/Guidebook/Security/SecurityOfficerSOP.xml
@@ -25,7 +25,9 @@ SPDX-License-Identifier: MIT
 
 [bold]7.[/bold] Security Officers are [bold]not[/bold] permitted to conduct searches, unless there is reasonable evidence/suspicion that the person in question has committed a crime. Any further searches require a warrant from the [color=#1b67a5]Head of Security[/color] or [color=#1b67a5]Captain[/color];
 
-[bold]8.[/bold] Security Officers are required to wear their uniform in accordance with the [textlink="Security Rules of Conduct" link="RulesOfConduct"].
+[bold]8.[/bold] Security Officers are required to wear their uniform in accordance with the [textlink="Security Rules of Conduct" link="RulesOfConduct"];
+
+[bold]9.[/bold] Security Officers are discouraged from entering maintenance without a valid reason. If they must enter maintenance for one reason or another, it is highly recommended that they do so with a partner.
 
 ## Code Blue
 


### PR DESCRIPTION
## About the PR
I added a line to the Security Officer SOP for Code Green, and a line to the RoC for Security.
These being:
[bold]17.[/bold] Security Officers must wear a uniform that makes them identifiable as a member of the department.
[bold]9.[/bold] Security Officers are discouraged from entering maintenance without a valid reason. If they must enter maintenance for one reason or another, it is highly recommended that they do so with a partner.

## Why / Balance
The SOP had mentioned that secoffs must wear a uniform in accordance with the RoC, but the RoC never really defined what said uniform could be. This addition, while vague, at least provides a solid guideline to work off of. Secondly, it was already treated as a phantom rule that security could not enter maints on green, yet nowhere in Space Law or the SOP was it actually mentioned, just suggested within the Security Officer section of the guidebook. Ultimately, it'd be best to codify this for future clarity.

## Technical details
I changed the xml files in vim to add the new lines :)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: amethystowo
- tweak: Added a new line to the Security Officer SOP, codifying that they should not be in maints on Green. Also added a line in their RoC that loosely defines what their uniform should be.

