### PR TITLE
Add TEGs to the request computer

### DIFF
--- a/Resources/Prototypes/_Funkystation/Catalog/Cargo/cargo_engineering.yml
+++ b/Resources/Prototypes/_Funkystation/Catalog/Cargo/cargo_engineering.yml
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2025 8tv <eightev@gmail.com>
 # SPDX-FileCopyrightText: 2025 AtlasHD <99688062+AtlasHDD@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 ThatOneMoon <91613003+ThatOneGuy227@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 ThatOneMoon <juozas.dringelis@gmail.com>

--- a/Resources/Prototypes/_Funkystation/Catalog/Fills/Crates/engineering.yml
+++ b/Resources/Prototypes/_Funkystation/Catalog/Fills/Crates/engineering.yml
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2025 8tv <eightev@gmail.com>
 # SPDX-FileCopyrightText: 2025 AtlasHD <99688062+AtlasHDD@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 ThatOneMoon <91613003+ThatOneGuy227@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 ThatOneMoon <juozas.dringelis@gmail.com>

--- a/Resources/Prototypes/_Funkystation/Entities/Objects/Devices/flatpack.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Objects/Devices/flatpack.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 8tv <eightev@gmail.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 - type: entity
   parent: BaseFlatpack
   id: TegCenterFlatpack


### PR DESCRIPTION
## About the PR
Adds entities for TEG flatpacks (teg center flatpack, teg circulator flatpack) and makes them purchasable in a crate from cargo for 20,000 spesos.

## Why / Balance
With the removal of thief objectives (Specifically the "steal the TEG part" objective, it is now more possible to freely circulate TEGs.

With that in mind, adding the TEG to the request computer should allow mappers to remove round-start TEGs, should they desire, thus placing a larger focus on more manual and involved modes of energy production for engineering.

## Technical details
yml

## Media
<img width="587" height="320" alt="image" src="https://github.com/user-attachments/assets/91e2d5fb-acd7-45e3-bc43-60ef041706e7" />
<img width="1450" height="957" alt="image" src="https://github.com/user-attachments/assets/5ca4ad97-77ca-40cd-a92a-544807151e6a" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- add: The TEG is now purchasable from the request computers for 20,000 spesos!