### PR TITLE
CPR Fixes

### DIFF
--- a/Resources/Locale/en-US/cpr/cpr.ftl
+++ b/Resources/Locale/en-US/cpr/cpr.ftl
@@ -2,6 +2,7 @@ cpr-verb-text = CPR
 cpr-verb-text-disabled = Do CPR at close range!
 cpr-start = {CAPITALIZE(THE($person))} starts resuscitating {THE($target)}.
 cpr-start-you = You started resuscitating {THE($target)}.
+cpr-already-in-progress = Someone is already performing CPR!
 
 cpr-too-slow = CPR too slow! Apply pressure every {$seconds} seconds.
 cpr-too-fast = CPR too quick! Apply pressure every {$seconds} seconds.


### PR DESCRIPTION
LICENSE: MIT

## About the PR
Fixes a few CPR bugs as pointed out by players. Also makes CPR work a bit more consistently making it easier to expand later (hopefully).

CPR is now no longer able to be initialised if the recipient is already receiving CPR. Additionally CPR is stopped if the recipient is dragged out of the givers range. 

## Why / Balance
I fix issues

## Technical details
Ultimately, syncing with Dirty is what needed to be done. CPR is a shared system and the prediction was hanging behind server, allowing multiple people to do CPR. My changes simply make the check actually work, and adds a popup message.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

https://github.com/user-attachments/assets/fdec8f57-cd52-49b9-88ae-a5d482029793



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Ven
- tweak: CPR can now only be initialised by one person.
- fix: Dragging a CPR recipient away from the giver now correctly stops CPR.
