### PR TITLE
Spring Eden Fixes

### DIFF
--- a/Resources/Changelog/Funkylog.yml
+++ b/Resources/Changelog/Funkylog.yml
@@ -6964,3 +6964,9 @@ Entries:
       message: NanoTrasen got a killer deal on new designer satchel bags!
   id: 810
   time: '2025-12-30T10:46:33.0000000+00:00'
+- author: KittyCat432
+  changes:
+    - type: Fix
+      message: Fixed Box's evac not docking.
+  id: 811
+  time: '2026-01-01T23:13:20.0000000+00:00'

--- a/Resources/Maps/_Funkystation/box.yml
+++ b/Resources/Maps/_Funkystation/box.yml
@@ -72,7 +72,7 @@ meta:
   engineVersion: 268.0.0
   forkId: ""
   forkVersion: ""
-  time: 12/27/2025 17:54:43
+  time: 12/29/2025 17:33:16
   entityCount: 29836
 maps:
 - 11906
@@ -11922,22 +11922,26 @@ entities:
   - uid: 548
     components:
     - type: Transform
-      pos: 95.5,-23.5
+      rot: 1.5707963267948966 rad
+      pos: 95.5,-21.5
       parent: 8364
   - uid: 19287
     components:
     - type: Transform
-      pos: 95.5,-31.5
+      rot: 1.5707963267948966 rad
+      pos: 95.5,-29.5
       parent: 8364
   - uid: 19979
     components:
     - type: Transform
-      pos: 95.5,-29.5
+      rot: 1.5707963267948966 rad
+      pos: 95.5,-31.5
       parent: 8364
   - uid: 20042
     components:
     - type: Transform
-      pos: 95.5,-21.5
+      rot: 1.5707963267948966 rad
+      pos: 95.5,-23.5
       parent: 8364
 - proto: AirlockExternalGlassShuttleEscape
   entities:
@@ -12250,7 +12254,7 @@ entities:
       pos: 24.5,16.5
       parent: 8364
     - type: Door
-      secondsUntilStateChange: -129607.945
+      secondsUntilStateChange: -129658.28
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -12415,7 +12419,7 @@ entities:
       pos: 74.5,-14.5
       parent: 8364
     - type: Door
-      secondsUntilStateChange: -30270.877
+      secondsUntilStateChange: -30321.21
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -91545,7 +91549,7 @@ entities:
       pos: 27.5,-15.5
       parent: 8364
     - type: Door
-      secondsUntilStateChange: -20248.475
+      secondsUntilStateChange: -20298.809
       state: Closing
   - uid: 14342
     components:
@@ -91583,7 +91587,7 @@ entities:
       pos: -34.5,-14.5
       parent: 8364
     - type: Door
-      secondsUntilStateChange: -123796.484
+      secondsUntilStateChange: -123846.82
       state: Closing
   - uid: 15010
     components:
@@ -92108,7 +92112,7 @@ entities:
       pos: -4.5,-71.5
       parent: 8364
     - type: Door
-      secondsUntilStateChange: -115544.22
+      secondsUntilStateChange: -115594.555
       state: Closing
   - uid: 27600
     components:
@@ -184538,7 +184542,7 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -2859.5857
+      secondsUntilStateChange: -2909.9192
       state: Opening
     - type: Airlock
       autoClose: False


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
Eden is no longer Christmas'd and has been revitalized for spring in... several months. Minor adjustments to medical layout to give it the new personal rooms, and connected it to virology. + some other minor changes and adjustments.

## Why / Balance
Neccessary improvements for the map and gameplay.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: salpphie
- add: Added shooting range in Eden's security
- remove: Removed brigmed/medical at security in Eden station.
- tweak: Changed Eden's medical layout to accommodate the new medical beds
