### PR TITLE
Box hotfix

### DIFF
--- a/Resources/Maps/_Funkystation/box.yml
+++ b/Resources/Maps/_Funkystation/box.yml
@@ -4,7 +4,7 @@ meta:
   engineVersion: 268.0.0
   forkId: ""
   forkVersion: ""
-  time: 12/27/2025 17:54:43
+  time: 12/29/2025 17:20:08
   entityCount: 29836
 maps:
 - 11906
@@ -11854,22 +11854,26 @@ entities:
   - uid: 548
     components:
     - type: Transform
-      pos: 95.5,-23.5
+      rot: 1.5707963267948966 rad
+      pos: 95.5,-21.5
       parent: 8364
   - uid: 19287
     components:
     - type: Transform
-      pos: 95.5,-31.5
+      rot: 1.5707963267948966 rad
+      pos: 95.5,-29.5
       parent: 8364
   - uid: 19979
     components:
     - type: Transform
-      pos: 95.5,-29.5
+      rot: 1.5707963267948966 rad
+      pos: 95.5,-31.5
       parent: 8364
   - uid: 20042
     components:
     - type: Transform
-      pos: 95.5,-21.5
+      rot: 1.5707963267948966 rad
+      pos: 95.5,-23.5
       parent: 8364
 - proto: AirlockExternalGlassShuttleEscape
   entities:
@@ -12182,7 +12186,7 @@ entities:
       pos: 24.5,16.5
       parent: 8364
     - type: Door
-      secondsUntilStateChange: -129607.945
+      secondsUntilStateChange: -129648.67
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -12347,7 +12351,7 @@ entities:
       pos: 74.5,-14.5
       parent: 8364
     - type: Door
-      secondsUntilStateChange: -30270.877
+      secondsUntilStateChange: -30311.602
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -91477,7 +91481,7 @@ entities:
       pos: 27.5,-15.5
       parent: 8364
     - type: Door
-      secondsUntilStateChange: -20248.475
+      secondsUntilStateChange: -20289.2
       state: Closing
   - uid: 14342
     components:
@@ -91515,7 +91519,7 @@ entities:
       pos: -34.5,-14.5
       parent: 8364
     - type: Door
-      secondsUntilStateChange: -123796.484
+      secondsUntilStateChange: -123837.21
       state: Closing
   - uid: 15010
     components:
@@ -92040,7 +92044,7 @@ entities:
       pos: -4.5,-71.5
       parent: 8364
     - type: Door
-      secondsUntilStateChange: -115544.22
+      secondsUntilStateChange: -115584.945
       state: Closing
   - uid: 27600
     components:
@@ -184470,7 +184474,7 @@ entities:
       lastSignals:
         DoorStatus: True
     - type: Door
-      secondsUntilStateChange: -2859.5857
+      secondsUntilStateChange: -2900.3096
       state: Opening
     - type: Airlock
       autoClose: False


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
fixed evac on box to have the evac airlocks facing east.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
boxx evac broke

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed Box's evac.

