### PR TITLE
Add brass to maintenance loot

### DIFF
--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/maintenance.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/maintenance.yml
@@ -47,6 +47,7 @@
 # SPDX-FileCopyrightText: 2025 BuildTools <unconfigured@null.spigotmc.org>
 # SPDX-FileCopyrightText: 2025 DevilishMilk <michaellapjr@gmail.com>
 # SPDX-FileCopyrightText: 2025 Dragon232347 <122056448+Dragon232347@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Ilya Mikheev <me@ilyamikcoder.com>
 # SPDX-FileCopyrightText: 2025 IronDragoon <8961391+IronDragoon@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 MaiaArai <158123176+YaraaraY@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Mish <bluscout78@yahoo.com>


### PR DESCRIPTION
LICENSE: MIT
## About the PR
Adds brass to the maintenance loot table (specifically, the tools one). Easy as that.

## Why / Balance
Brass, as a material, doesn't see any use at all basically. The primary use for it would be some sort of gimmick, but when you are considering to do one, you rarely consider beginning it with a cargo run. Does anyone really remember brass exists, anyway?

Now it's something that can be found during your tide session, and with it, you can find inspiration. Perhaps people will remember this is a thing now!

## Technical details
YAMLmaxxing

## Media
<img width="416" height="193" alt="Снимок экрана_20251229_201849" src="https://github.com/user-attachments/assets/79fc2c4c-97e6-4088-99fb-23a645775fa2" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
Nah

**Changelog**
:cl:
- add: Brass sheets can be found in maintenance now.