### PR TITLE
Removing Atmospheric Technician

### DIFF
--- a/Resources/Locale/en-US/job/job-alt-names.ftl
+++ b/Resources/Locale/en-US/job/job-alt-names.ftl
@@ -16,12 +16,12 @@ job-name-alt-cargotech-3 = Logistics Clerk
 
 job-name-alt-salvage-1 = Shaft Miner
 
-job-name-alt-atmos-1 = Fire Suppression Specialist
-
 job-name-alt-engineer-1 = Maintenance Technician
 job-name-alt-engineer-2 = Mechanic
 job-name-alt-engineer-3 = Electrician
 job-name-alt-engineer-4 = Engine Operator
+job-name-alt-atmos-1 = Fire Suppression Specialist
+job-name-alt-atmos-2 = Atmospheric Technician
 
 job-name-alt-scientist-1 = Xenoarchaeologist
 job-name-alt-scientist-2 = Anomaly Researcher

--- a/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/engineer.yml
@@ -139,17 +139,10 @@
       - id: ClothingMaskGasAtmos
       - id: ClothingOuterSuitAtmosFire
       - id: ClothingHeadHelmetAtmosFire
-      - id: GasAnalyzer
       - id: MedkitOxygenFilled
       - id: HolofanProjector
-      - id: RPD #funkystation
       - id: DoorRemoteFirefight # Goobstation - re adding fire door remote
-      - id: HolotapeProjector #funky!
-      - id: RCD
-      - id: RCDAmmo
       - id: ClothingBackpackFirefighterTank
-      - id: MaterialBag #funky!
-      - id: MetalFoamGrenade #funky!
 
 - type: entity
   id: LockerAtmosphericsFilled
@@ -161,17 +154,12 @@
       - id: ClothingMaskGasAtmos
       - id: ClothingOuterSuitAtmosFire
       - id: ClothingHeadHelmetAtmosFire
-      - id: GasAnalyzer
+      - id: OxygenTankFilled
+      - id: NitrogenTankFilled
       - id: MedkitOxygenFilled
       - id: HolofanProjector
-      - id: RPD #funkystation
       - id: DoorRemoteFirefight # Goobstation - re adding fire door remote
-      - id: HolotapeProjector #funky!
-      - id: RCD
-      - id: RCDAmmo
       - id: ClothingBackpackFirefighterTank
-      - id: MaterialBag #funky!
-      - id: MetalFoamGrenade #funky!
 
 - type: entity
   id: LockerEngineerFilledHardsuit
@@ -188,6 +176,7 @@
       - id: ClothingMaskGas
       - id: ClothingShoesBootsMag
       - id: RCD
+      - id: RPD #funkystation
       - id: RCDAmmo
       - id: BoxInflatable # funky
       - id: MaterialBag #funky!
@@ -205,6 +194,7 @@
       - id: ClothingMaskGas
       - id: trayScanner
       - id: RCD
+      - id: RPD #funkystation
       - id: RCDAmmo
       - id: BoxInflatable # funky
       - id: MaterialBag #funky!

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -167,7 +167,7 @@
 - type: entity
   id: LockerAtmospherics
   parent: LockerBase
-  name: atmospheric technician's locker
+  name: atmospheric equipment locker
   components:
   - type: Appearance
   - type: EntityStorageVisuals

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -30,6 +30,7 @@
 # SPDX-FileCopyrightText: 2024 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 ArtisticRoomba <145879011+ArtisticRoomba@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 JoulesBerg <104539820+JoulesBerg@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 YaraaraY <158123176+YaraaraY@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/station_engineer.yml
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: 2024 Mr. 27 <45323883+Dutch-VanDerLinde@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 Pancake <Pangogie@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 CalicoDragon <110030310+CalicoDragon@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 MaiaArai <158123176+YaraaraY@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Mora <46364955+TrixxedHeart@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Sofia Gilsanz <softie.gd@gmail.com>

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/station_engineer.yml
@@ -171,18 +171,6 @@
     jumpsuit: ClothingUniformJumpskirtSeniorEngineer
   groupBy: "senior"
 
-- type: loadout
-  id: AtmosphericTechnicianJumpsuit
-  equipment:
-    jumpsuit: ClothingUniformJumpsuitBaggyAtmos
-  groupBy: "jumpsuit"
-
-- type: loadout
-  id: AtmosphericTechnicianJumpskirt
-  equipment:
-    jumpsuit: ClothingUniformJumpskirtBaggyAtmosTied
-  groupBy: "jumpsuit"
-
 # Back
 - type: loadout
   id: StationEngineerBackpack
@@ -205,10 +193,6 @@
   equipment:
     outerClothing: ClothingOuterVestHazard
 
-- type: loadout
-  id: AtmosphericTechnicianWintercoat
-  equipment:
-    outerClothing: ClothingOuterWinterAtmos
 
 - type: loadout
   id: StationEngineerWintercoat

--- a/Resources/Prototypes/Loadouts/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/Loadouts/Jobs/Engineering/station_engineer.yml
@@ -171,6 +171,18 @@
     jumpsuit: ClothingUniformJumpskirtSeniorEngineer
   groupBy: "senior"
 
+- type: loadout
+  id: AtmosphericTechnicianJumpsuit
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitBaggyAtmos
+  groupBy: "jumpsuit"
+
+- type: loadout
+  id: AtmosphericTechnicianJumpskirt
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtBaggyAtmosTied
+  groupBy: "jumpsuit"
+
 # Back
 - type: loadout
   id: StationEngineerBackpack
@@ -192,6 +204,11 @@
   id: StationEngineerOuterVest
   equipment:
     outerClothing: ClothingOuterVestHazard
+
+- type: loadout
+  id: AtmosphericTechnicianWintercoat
+  equipment:
+    outerClothing: ClothingOuterWinterAtmos
 
 - type: loadout
   id: StationEngineerWintercoat

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1238,6 +1238,8 @@
   - SeniorEngineerJumpsuitArmored
   - SeniorEngineerJumpsuit
   - SeniorEngineerJumpskirt
+  - AtmosphericTechnicianJumpsuit
+  - AtmosphericTechnicianJumpskirt
 
 - type: loadoutGroup
   id: StationEngineerBackpack
@@ -1254,6 +1256,7 @@
   loadouts:
   - StationEngineerOuterVest
   - StationEngineerWintercoat
+  - AtmosphericTechnicianWintercoat
 
 - type: loadoutGroup
   id: StationEngineerBelt

--- a/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
@@ -21,6 +21,7 @@
 # SPDX-FileCopyrightText: 2024 Mr. 27 <45323883+Dutch-VanDerLinde@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
 # SPDX-FileCopyrightText: 2024 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 MaiaArai <158123176+YaraaraY@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Minerva <218184747+mnva0@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2025 Teasq <Xerithin@gmail.com>

--- a/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
@@ -51,8 +51,6 @@
   - !type:GiveItemOnHolidaySpecial
     holiday: FirefighterDay
     prototype: FireAxe
-  alternateTitles:
-  - AtmosphericTechnicianFirefighter
 
 - type: startingGear
   id: AtmosphericTechnicianGear
@@ -63,7 +61,3 @@
   #storage:
     #back:
     #- Stuff
-
-- type: jobAlternateTitle
-  id: AtmosphericTechnicianFirefighter
-  name: job-name-alt-atmos-1

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -53,15 +53,9 @@
   description: job-description-ce
   playTimeTracker: JobChiefEngineer
   requirements:
-    - !type:RoleTimeRequirement
-      role: JobAtmosphericTechnician
-      time: 36000 #10 hrs
-    - !type:RoleTimeRequirement
-      role: JobStationEngineer
-      time: 36000 #10 hrs
-    - !type:DepartmentTimeRequirement #redundant but consistent
+    - !type:DepartmentTimeRequirement
       department: Engineering
-      time: 72000 #20 hrs
+      time: 90000 #25 hrs
     - !type:OverallPlaytimeRequirement
       time: 90000 #25 hrs
   weight: 10

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -40,6 +40,7 @@
 # SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2024 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 MaiaArai <158123176+YaraaraY@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Mish <bluscout78@yahoo.com>
 # SPDX-FileCopyrightText: 2025 Teasq <Xerithin@gmail.com>
 # SPDX-FileCopyrightText: 2025 YaraaraY <158123176+YaraaraY@users.noreply.github.com>

--- a/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
@@ -26,6 +26,7 @@
 # SPDX-FileCopyrightText: 2024 GitHubUser53123 <110841413+GitHubUser53123@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 Mr. 27 <45323883+Dutch-VanDerLinde@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 MaiaArai <158123176+YaraaraY@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Mish <bluscout78@yahoo.com>
 # SPDX-FileCopyrightText: 2025 Teasq <Xerithin@gmail.com>
 # SPDX-FileCopyrightText: 2025 YaraaraY <158123176+YaraaraY@users.noreply.github.com>

--- a/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
@@ -49,12 +49,13 @@
   - Maintenance
   - Engineering
   - External
-  extendedAccess:
   - Atmospherics
   alternateTitles:
   - StationEngineerMaintenanceTechnician
+  - StationEngineerFirefighter
   - StationEngineerMechanic
   - StationEngineerElectrician
+  - StationEngineerAtmosphericTechnician
   - StationEngineerEngineOperator
 
 - type: startingGear
@@ -82,3 +83,10 @@
   id: StationEngineerEngineOperator
   name: job-name-alt-engineer-4
 
+- type: jobAlternateTitle
+  id: StationEngineerFirefighter
+  name: job-name-alt-atmos-1
+
+- type: jobAlternateTitle
+  id: StationEngineerAtmosphericTechnician
+  name: job-name-alt-atmos-2

--- a/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
@@ -41,6 +41,7 @@
   - Maintenance
   - Engineering
   - External
+  - Atmospherics
 
 - type: startingGear
   id: TechnicalAssistantGear

--- a/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
@@ -20,6 +20,7 @@
 # SPDX-FileCopyrightText: 2024 Whisper <121047731+QuietlyWhisper@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Mish <bluscout78@yahoo.com>
+# SPDX-FileCopyrightText: 2025 YaraaraY <158123176+YaraaraY@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT

--- a/Resources/Prototypes/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Roles/Jobs/departments.yml
@@ -32,6 +32,7 @@
 # SPDX-FileCopyrightText: 2025 JoulesBerg <104539820+JoulesBerg@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Quantum-cross <7065792+Quantum-cross@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2025 YaraaraY <158123176+YaraaraY@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 empty0set <16693552+empty0set@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 empty0set <empty0set@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 kbarkevich <24629810+kbarkevich@users.noreply.github.com>

--- a/Resources/Prototypes/Roles/Jobs/departments.yml
+++ b/Resources/Prototypes/Roles/Jobs/departments.yml
@@ -153,7 +153,7 @@
   description: department-Engineering-description
   color: "#EFB341"
   roles:
-  - AtmosphericTechnician
+# - AtmosphericTechnician - Funky, Goodbye forever Atmos :wave:
   - ChiefEngineer
   - StationEngineer
   - TechnicalAssistant

--- a/Resources/Prototypes/_Funkystation/Guidebook/sop.yml
+++ b/Resources/Prototypes/_Funkystation/Guidebook/sop.yml
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: 2025 CMM <funkycmm>
 # SPDX-FileCopyrightText: 2025 Colin Moore <funkycmm>
 # SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2025 YaraaraY <158123176+YaraaraY@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 corresp0nd <46357632+corresp0nd@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 ferynn <117872973+ferynn@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 ferynn <witchy.girl.me@gmail.com>

--- a/Resources/Prototypes/_Funkystation/Guidebook/sop.yml
+++ b/Resources/Prototypes/_Funkystation/Guidebook/sop.yml
@@ -313,7 +313,6 @@
   children:
   - CESOP
   - StationEngineerSOP
-  - AtmosphericSOP
 
 - type: guideEntry
   id: CESOP
@@ -324,11 +323,6 @@
   id: StationEngineerSOP
   name: guide-entry-stationengineer-sop
   text: "/ServerInfo/Funkystation/Guidebook/Engineering/StationEngineerSOP.xml"
-
-- type: guideEntry
-  id: AtmosphericSOP
-  name: guide-entry-atmospheric-sop
-  text: "/ServerInfo/Funkystation/Guidebook/Engineering/AtmosphericSOP.xml"
 
 # CARGO
 

--- a/Resources/ServerInfo/Funkystation/Guidebook/Engineering/EngineeringSOP.txt
+++ b/Resources/ServerInfo/Funkystation/Guidebook/Engineering/EngineeringSOP.txt
@@ -39,7 +39,7 @@ SPDX-License-Identifier: MIT
 
   [bold]6.[/bold] Engineers must constantly monitor the Supermatter engine if it is online and under emitter fire;
 
-  [bold]7.[/bold] Engineers must respond promptly to breaches, regardless of size. Failure to report within fifteen (15) minutes will be considered a breach of Standard Operating Procedure, unless there are no spare Engineers to report or an Atmospheric Technician has arrived on scene first. All Hazard Zones must be cordoned off with Engineering Tape or holobarriers, for the safety of crewmembers;
+  [bold]7.[/bold] Engineers must respond promptly to breaches, regardless of size. Failure to report within fifteen (15) minutes will be considered a breach of Standard Operating Procedure, unless there are no spare Engineers to report. All Hazard Zones must be cordoned off with Engineering Tape or holobarriers, for the safety of crewmembers;
 
   [bold]8.[/bold] Engineers are permitted to hack doors to gain unauthorized access to locations if said locations happen to require urgent repairs;
 
@@ -47,19 +47,15 @@ SPDX-License-Identifier: MIT
 
   [bold]10.[/bold] Engineers must ensure there is at least one (1) engineering hardsuit available on the station at all times, unless there is an emergency that requires the use of all suits.
 
-  # Atmospheric Technician
+  [bold]11.[/bold] Engineers are permitted to completely repipe the Atmospherics Piping Setup, provided they do not pump harmful gases into distro;
 
-  [bold]1.[/bold] Atmospheric Technicians are permitted to completely repipe the Atmospherics Piping Setup, provided they do not pump harmful gases into distro or waste;
+  [bold]12.[/bold] Engineers are [bold]not[/bold] permitted to create volatile or harmful mixes to use outside atmospherics;
 
-  [bold]2.[/bold] Atmospheric Technicians are not permitted to create volatile or harmful mixes to use outside atmospherics;
+  [bold]13.[/bold] Engineers are [bold]not[/bold] permitted to take the axe out of its case out-side of a construction zone or if there is an immediate and urgent threat to their life or urgent access to crisis locations is necessary. The axe must be returned to the case afterwards, and the case locked;
 
-  [bold]3.[/bold] Atmospheric Technicians are not permitted to take the axe out of its case out-side of a construction zone or if there is an immediate and urgent threat to their life or urgent access to crisis locations is necessary. The axe must be returned to the case afterwards, and the case locked;
+  [bold]14.[/bold] Engineers are [bold]not[/bold] permitted to tamper with the default values on Air Alarms outside of atmospherics without express permission from CE;
 
-  [bold]4.[/bold] Atmospheric Technicians are not permitted to tamper with the default values on Air Alarms outside of atmospherics without express permission from CE;
+  [bold]15.[/bold] Engineers must periodically check on the Central Alarms Computer, in periods of, at most, thirty (30) minutes;
 
-  [bold]5.[/bold] Atmospheric Technicians must periodically check on the Central Alarms Computer, in periods of, at most, thirty (30) minutes;
-
-  [bold]6.[/bold] Atmospheric Technicians must respond promptly to piping and station breaches. Failure to report within fifteen (15) minutes will be considered a breach of Standard Operating Procedure, unless there are no spare Atmospheric Technicians to report, or an Engineer has arrived at scene first. All Hazard Zones must be cordoned off with firelocks, for the safety of all crewmembers;
-
-  [bold]7.[/bold] Atmospheric Technicians must ensure that distro has a steady supply of the appropriate mix and ensure the station remains breathable
+  [bold]16.[/bold] Engineers must ensure that distro has a steady supply of the appropriate mix and ensure the station remains breathable.
 </Document>

--- a/Resources/ServerInfo/Funkystation/Guidebook/Engineering/EngineeringSOP.xml
+++ b/Resources/ServerInfo/Funkystation/Guidebook/Engineering/EngineeringSOP.xml
@@ -3,9 +3,8 @@
 
   - [textlink="Chief Engineer" link="CESOP"]
   - [textlink="Station Engineer" link="StationEngineerSOP"]
-  - [textlink="Atmospheric Technician" link="AtmosphericSOP"]
 
 <Box>
-[color=#999999][italic]"Atmospheric Technicians are [bolditalic]not[/bolditalic] permitted to take the axe out of its case out-side of a construction zone or if there is an immediate and urgent threat to their life or urgent access to crisis locations is necessary. The axe must be returned to the case afterwards, and the case locked;"[/italic] - Atmospheric Technician SOP {3}[/color]
+[color=#999999][italic]"Engineers are permitted to carry out solo reconstruction/rebuilding/personal projects if there is no damage to the station that requires fixing;"[/italic] - Station Engineer SOP {4}[/color]
 </Box>
 </Document>

--- a/Resources/ServerInfo/Funkystation/Guidebook/Engineering/StationEngineerSOP.xml
+++ b/Resources/ServerInfo/Funkystation/Guidebook/Engineering/StationEngineerSOP.xml
@@ -20,11 +20,23 @@ SPDX-License-Identifier: MIT
 
 [bold]6.[/bold] Engineers must constantly monitor the Supermatter engine if it is online and under emitter fire;
 
-[bold]7.[/bold] Engineers must respond promptly to breaches, regardless of size. Failure to report within fifteen (15) minutes will be considered a breach of Standard Operating Procedure, unless there are no spare Engineers to report or an [color=#f39f27]Atmospheric Technician[/color] has arrived on scene first. All Hazard Zones must be cordoned off with Engineering Tape or Holobarriers, for the safety of crewmembers;
+[bold]7.[/bold] Engineers must respond promptly to breaches, regardless of size. Failure to report within fifteen (15) minutes will be considered a breach of Standard Operating Procedure, unless there are no spare Engineers to report All Hazard Zones must be cordoned off with Engineering Tape or Holobarriers, for the safety of crewmembers;
 
 [bold]8.[/bold] Engineers are permitted to hack doors to gain unauthorized access to locations if said locations happen to require [bold]urgent[/bold] repairs;
 
 [bold]9.[/bold] Engineers are to maintain the integrity of the Station's Power Network;
 
 [bold]10.[/bold] Engineers must ensure there is at least one (1) engineering hardsuit available on the station at all times, unless there is an emergency that requires the use of all suits.
+
+[bold]11.[/bold] Engineers are permitted to completely repipe the Atmospherics Piping Setup, provided they do not pump harmful gases into distro;
+
+[bold]12.[/bold] Engineers are [bold]not[/bold] permitted to create volatile or harmful mixes to use outside atmospherics;
+
+[bold]13.[/bold] Engineers are [bold]not[/bold] permitted to take the axe out of its case out-side of a construction zone or if there is an immediate and urgent threat to their life or urgent access to crisis locations is necessary. The axe must be returned to the case afterwards, and the case locked;
+
+[bold]14.[/bold] Engineers are [bold]not[/bold] permitted to tamper with the default values on Air Alarms outside of atmospherics without express permission from CE;
+
+[bold]15.[/bold] Engineers must periodically check on the Central Alarms Computer, in periods of, at most, thirty (30) minutes;
+
+[bold]16.[/bold] Engineers must ensure that distro has a steady supply of the appropriate mix and ensure the station remains breathable.
 </Document>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
This PR:
- Removes Atmospheric Technician as a selectable role
- Adds Atmospherics access to Station Engineers and Technical Assistants
- Renames Atmospheric Technician's locker to Atmospheric Equipment locker
- Edits the fills of the Atmos lockers, removing the things you can get from ordinary Engineering lockers
- Edits the fills of the Engineering lockers, adding to them an RPD
- Adds "Atmospheric Technician" and "Fire Suppression Specialist" as cosmetic titles for Station Engineers
- Adds Atmos' old uniforms to be selectable by Station Engineers
- Changes Chief Engineer job requirements to 25 hours in the Engineering department
- Merges the Atmospheric Technician's SOP into Station Engineer's
<!-- What did you change? -->

## Why / Balance
tl;dr Atmos existing is completely unnecessary and takes away from the rest of engineering and encourages NITRP behaviour

There's several reasons why this is being done.

Atmos techs have a tendency to isolate themselves from the rest of the crew to work on personal projects that often offer very little benefit to the story of the round or other players around them. Folding them into Station Engineer has a lot of benefits. It encourages better teamwork, better mentoring of TAs, actual interaction with the rest of their department and the station as a whole, etc, rather than what happens 90% of the time where the Atmos bay is treated as some secret land no one but atmos is allowed to step foot in.

By keeping atmos separate, it creates a false perception that atmospherics is incredibly difficult and requires a "special" type of player, when basic atmospherics like piping in distro and waste, setting up scrubbers and vents, filtering out bad gasses, is incredibly simple. Merging the roles would encourage all Engineers to learn at least the basics of atmos, preventing the stupid scenario where the only Atmos tech dies, and the 5 surviving Engis stand around helplessly watching the SM fill with trit because "that's not my job.", or where half the station is spaced and covered in hull breaches and the 3 Atmosians on duty refuse to go fix it because "that's Engi's job."

If Atmos is just a specialization within the wider Engineering department, the Chief Engineer can much more easily order those players to help with the general station emergencies. It forces the funny gas mixers to actually be part of the wider team rather than some separate entity, and go, god forbid, ROLEPLAY AND INTERACT WITH THE CREW

This also merges Atmos content into Engineering, too. No longer is the SM something only 3, maybe 4 people get to interact with. You don't have to wait for an atmosian to deign grace you with their presence to go fill in a room or fight a fire or install some scrubbers. This lets engineering WORK
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
YAML maxxing.
<!-- Summary of code changes for easier review. -->

## Media
![what_the_thump](https://github.com/user-attachments/assets/88afc922-a408-43cb-a2bc-12a6a2614f2a)
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl: AraiMaia
- remove: Removed Atmospheric Technician.
- add: New cosmetic titles for Station Engineer: Atmospheric Technician and Fire Suppression Specialist
- tweak: Changed the fills of Atmos and Engineering lockers
- tweak: Added the Atmos clothes to Station Engineer loadout
- tweak: Station Engineers and TAs now get Atmos Access
- tweak: Chief Engineer job requirement is now 25 hours in the Engineering department
- tweak: Merged Atmos SOP into Station Engineer SOP
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
