### PR TITLE
Added sec SOP to the thin SOP 101 book.

### DIFF
--- a/Resources/Prototypes/_Funkystation/Entities/Objects/Misc/books.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Objects/Misc/books.yml
@@ -43,6 +43,7 @@
     - LegalSOP
     - MedicalSOP
     - ServiceSOP
+    - SecuritySOP
     - EngineeringSOP
     - CargoSOP
     - ScienceSOP


### PR DESCRIPTION
Despite the fact that in universe there are pages missing, the sec SOP missing is rather annoying, so this is a QOL addition to make IAA auditing sec easier.