### PR TITLE
Added sec SOP to the thin SOP 101 book.

### DIFF
--- a/Resources/Prototypes/_Funkystation/Entities/Objects/Misc/books.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Objects/Misc/books.yml
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2025 Komoni <131829655+Komonighub@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 corresp0nd <46357632+corresp0nd@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2026 Notarin Steele <424c414e4b@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
@@ -43,6 +44,7 @@
     - LegalSOP
     - MedicalSOP
     - ServiceSOP
+    - SecuritySOP
     - EngineeringSOP
     - CargoSOP
     - ScienceSOP


### PR DESCRIPTION
# About the PR
Despite the fact that in universe there are pages missing, the sec SOP missing is rather annoying, so this is a QOL addition to make IAA auditing sec easier.

# Why / Balance
One of IAAs duties is to audit sec. Without a guidebook entry, it is insinuated that they cannot audit sec, or simply just makes it harder for them.
Also the maintainer who added SOP 101 probably just forgot. Speaking to them personally they said they don't remember why it wasn't included.

# Technical details
Single YAML line addition.

**Changelog**
:cl:
- tweak: Added security department SOP to the SOP 101 book given to IAA.