### PR TITLE
Eden Spring Fixes + More + Remove Atmos Tech Spawns

### DIFF
--- a/Resources/Maps/_Funkystation/eden.yml
+++ b/Resources/Maps/_Funkystation/eden.yml
@@ -13876,8 +13876,6 @@ entities:
       rot: -1.5707963267948966 rad
       pos: -26.5,-27.5
       parent: 2
-    - type: DeviceNetwork
-      - 17450
   - uid: 14654
     components:
     - type: Transform


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
Changed Medical to accommodate new medical bed + items + geneticist + connected it with viro
Atmos tech is removed from the map, atmos is still "there" until a later date and kind of for flavor for now.
Security no longer has any brigmed/medical in it and has been given a firing range.

## Why / Balance
It was needed.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl: salpphie
- add: Added geneticist to medical and firing range to security on Eden.
- remove: Removed Atmos Tech spawns.
- tweak: Changed medical department layout a bit to accommodate the new medical changes.

