### PR TITLE
remove atmos access from TAs

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/technical_assistant.yml
@@ -42,7 +42,6 @@
   - Maintenance
   - Engineering
   - External
-  - Atmospherics
 
 - type: startingGear
   id: TechnicalAssistantGear


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
tay said so

## Why / Balance
yeah sure

## Technical details
removed it from the job poroto

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- remove: Technical Assistants no longer have Atmospherics access by default
