### PR TITLE
Eden minor patches

### DIFF
--- a/Resources/Maps/_Funkystation/eden.yml
+++ b/Resources/Maps/_Funkystation/eden.yml
@@ -74220,8 +74220,6 @@ entities:
       pos: -8.5,2.5
       parent: 2
     - type: DisposalUnit
-      recentlyEjected:
-      - invalid
   - uid: 693
     components:
     - type: Transform


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
A missing pipe segment that got forgotten after Christmas Eden was gone, a directional button fixed, reindeer enclosure fixed

## Why / Balance
For better gameplay

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Changelog

🆑 salpphie
- add: Added proper geneticist minus the role and a single pipe bend to the map Eden. 
- remove: Removed TEG from atmos on the map Eden.
- tweak: Fixed Minor walls, doors, flooring, button, and connections to the silo on the map Eden.