### PR TITLE
[Wizden Port] Fix tritium fires breaking conservation of mass (#41870)

### DIFF
--- a/Content.Server/Atmos/Reactions/TritiumFireReaction.cs
+++ b/Content.Server/Atmos/Reactions/TritiumFireReaction.cs
@@ -18,6 +18,7 @@
 // SPDX-FileCopyrightText: 2025 marc-pelletier <113944176+marc-pelletier@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+// SPDX-FileCopyrightText: 2026 Sarah C <93578146+SapphicOverload@users.noreply.github.com>
 //
 // SPDX-License-Identifier: MIT
 

--- a/Content.Shared/Atmos/Atmospherics.cs
+++ b/Content.Shared/Atmos/Atmospherics.cs
@@ -37,6 +37,8 @@
 // SPDX-FileCopyrightText: 2025 rottenheadphones <juaelwe@outlook.com>
 // SPDX-FileCopyrightText: 2025 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+// SPDX-FileCopyrightText: 2026 Homingpenguins <59744509+Homingpenguins@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 Sarah C <93578146+SapphicOverload@users.noreply.github.com>
 //
 // SPDX-License-Identifier: MIT
 


### PR DESCRIPTION
LICENSE: MIT
## About the PR
[Fix tritium fires breaking conservation of mass (#41870)](https://github.com/space-wizards/space-station-14/pull/41870)

This has been an issue for a while, glad it's finally fixed. 

## Why / Balance
Bugfix

## Technical details
See original PR

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
See original PR

**Changelog**
:cl:
- fix: Tritium fires no longer break conservation of mass. 
