### PR TITLE
Fix tritium and hydrogen fires breaking laws of physics [Bugfix]

### DIFF
--- a/Content.Server/Atmos/Reactions/TritiumFireReaction.cs
+++ b/Content.Server/Atmos/Reactions/TritiumFireReaction.cs
@@ -13,12 +13,12 @@
 // SPDX-FileCopyrightText: 2024 Ilya246 <57039557+Ilya246@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 Jezithyr <jezithyr@gmail.com>
 // SPDX-FileCopyrightText: 2024 Leon Friedrich <60421075+ElectroJr@users.noreply.github.com>
-// SPDX-FileCopyrightText: 2025 Steve <marlumpy@gmail.com>
 // SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
-// SPDX-FileCopyrightText: 2025 marc-pelletier <113944176+marc-pelletier@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 // SPDX-FileCopyrightText: 2026 Sarah C <93578146+SapphicOverload@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 Steve <marlumpy@gmail.com>
+// SPDX-FileCopyrightText: 2026 marc-pelletier <113944176+marc-pelletier@users.noreply.github.com>
 //
 // SPDX-License-Identifier: MIT
 

--- a/Content.Server/_Funkystation/Atmos/Reactions/HydrogenFireReaction.cs
+++ b/Content.Server/_Funkystation/Atmos/Reactions/HydrogenFireReaction.cs
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 2025 Steve <marlumpy@gmail.com>
 // SPDX-FileCopyrightText: 2025 marc-pelletier <113944176+marc-pelletier@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+// SPDX-FileCopyrightText: 2026 Steve <marlumpy@gmail.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 


### PR DESCRIPTION
## About the PR
This changes hydrogen fires to act just like Tritium fires. Also, removes the burst of free energy created when using high oxygen-to-tritium ratios. This will nerf tritium and hydrogen fires quite a bit.

## Why / Balance
Bugfix. Tritium and hydrogen burns were producing too much water vapor and energy in comparison to what was actually burned. 

## Technical details
Changes a line to use the minimum value between Tritium in the mix and Oxygen/2 in the mix, rather than the maximum, preventing energy from being created out of nothing but oxygen, and preventing more of your tritium from being consumed before it can be scrubbed. Same change is also applied to Hydrogen. 

## Media
None

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
Nerfs Tritium and Hydrogen fires

**Changelog**
:cl:
- fix: Tritium and hydrogen fires no longer overproduce water vapor or energy. 
