### PR TITLE
Welding sparks exception fix

### DIFF
--- a/Content.Client/_Goobstation/Tools/WeldingSparksAnimationSystem.cs
+++ b/Content.Client/_Goobstation/Tools/WeldingSparksAnimationSystem.cs
@@ -1,4 +1,6 @@
+// SPDX-FileCopyrightText: 2025 MaiaArai <158123176+YaraaraY@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 YaraaraY <158123176+YaraaraY@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2026 SabreML <57483089+SabreML@users.noreply.github.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR

Fixes https://github.com/funky-station/funky-station/pull/2366#issuecomment-3762688876 (I forgot to verify that `sparksEnt` actually existed in the original Goob PR)

Currently if `sparksEnt` is somehow invalid the method just passes it along to `AnimationPlayerSystem.Play()` without actually checking anything, causing an exception further on. With this change it instead returns early and skips the animation entirely.

This doesn't actually fix the *cause* of the sparks entity not existing, but I have absolutely no idea how that could happen outside of weird clientside sync stuff, since the event gets raised immediately after the effect is spawned.
Client stuff is weird 🤷

## Why / Balance

Exception fix! (I may as well fix bugs I caused myself rather than someone else having to do it)

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
Nothing player-facing.
