### PR TITLE
Fix: Cosmic Cult description tweak & Lorem Ipsum removal

### DIFF
--- a/Resources/Prototypes/_DV/CosmicCult/Tileset/converter.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Tileset/converter.yml
@@ -11,7 +11,7 @@
   parent: BaseStructure
   id: CosmicBorgChantry
   name: Vacuous Chantry
-  description: Lorem Ipsum
+  description: Malign energies gather within, coalescing something yet-to-be.
   placement:
     mode: AlignTileAny
   components:

--- a/Resources/Prototypes/_DV/CosmicCult/Tileset/structures.yml
+++ b/Resources/Prototypes/_DV/CosmicCult/Tileset/structures.yml
@@ -287,7 +287,7 @@
   id: CosmicVacuousSpire
   parent: BaseStructure
   name: vacuous spire
-  description: Also known as the "chuuni fork".
+  description: Its surface shifts and moves strangely, despite no visible power source...
   components:
   - type: Pullable
   - type: Anchorable


### PR DESCRIPTION
## About the PR
Fixes the Vacuous Chantry's description, which was accidentally left as "Lorem Ipsum".
Adjusts the Vacuous Spire's description to be more sauceful.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
N/A

**Changelog**
:cl:
- fix: The description of the Vacuous Spire is now more sauceful, and the Vacuous Chantry has had its description corrected.