### PR TITLE
Add atmos device order number to examine description

### DIFF
--- a/Content.Server/Atmos/Piping/EntitySystems/AtmosDeviceSystem.cs
+++ b/Content.Server/Atmos/Piping/EntitySystems/AtmosDeviceSystem.cs
@@ -11,6 +11,7 @@
 // SPDX-FileCopyrightText: 2024 Tayrtahn <tayrtahn@gmail.com>
 // SPDX-FileCopyrightText: 2024 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+// SPDX-FileCopyrightText: 2026 Steve <marlumpy@gmail.com>
 //
 // SPDX-License-Identifier: MIT
 

--- a/Resources/Locale/en-US/_Funkystation/atmos/piping/entitysystems/atmos-device-system.ftl
+++ b/Resources/Locale/en-US/_Funkystation/atmos/piping/entitysystems/atmos-device-system.ftl
@@ -1,0 +1,1 @@
+atmos-device-examine-order = It is device order #{ $index }


### PR DESCRIPTION
## About the PR
Simple PR to add the device order number to the description of examined atmos devices.

## Why / Balance
This will allow players to troubleshoot issues with gas flow more easily.

## Technical details
Finds the location of the device in the hashset on examine. Keeps changes minimal but could be more efficient to instead log the order with the device. 

## Media
<img width="587" height="561" alt="image" src="https://github.com/user-attachments/assets/875d00e8-5e79-4ac5-b742-65a1c379cb6b" />


## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None

**Changelog**
:cl:
- tweak: Atmospheric devices will now show their device order on examine.
