### PR TITLE
commented out CCI spawnpoint on centcom.yml

### DIFF
--- a/Resources/Maps/_Harmony/centcomm.yml
+++ b/Resources/Maps/_Harmony/centcomm.yml
@@ -41,6 +41,8 @@
 # SPDX-FileCopyrightText: 2025 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2025 wilowzeta <willowzeta632146@proton.me>
+# SPDX-FileCopyrightText: 2026 unknown <kit.ds.kat@gmail.com>
+# SPDX-FileCopyrightText: 2026 willow <willowzeta632146@proton.me>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Removed CCI as a roundstart ghostrole
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
There's been plenty of discussion around CCI as a ghostrole but most of it is pretty scattered. Others and myself didn't realize CCI was becoming round start due to overlooking the PR that added it, hence the mald PR here instead of a comment before it was merged.

Messages from Central Command are a big deal. They hold nearly ultimate power, being able to overrule the Magistrate and NTR (and with that, pretty much any role on the station.) From a narrative perspective command should be terrified of Central getting involved, they are likely overseeing multiple stations and their eyes on you most certainly means you're doing something wrong. What helps with this is that they are rare, getting a fax back is very uncommon, which further props up their importance.

In game, we've been able to treat communication from Central Command like a big deal because up until now it's always been an admin spawn. Meaning that the message is either written by an admin themselves, or by someone who's been allowed to play a CCI by ahelping, who is thus endorsed by an admin to play one and/or has direct admin oversight. This gives players the OOC assurance that any communication from Central Command is accurate, valid and appropriate to the situation.

CCI as a round start ghostrole removes this assurance, and in it's current implementation leaves a lot unclear. I would propose keeping the role as an admin only spawn.

If there **is** a desire for a round start CCI ghostrole I would like to still temporarily remove it until it's more clearly implemented, for which I propose one of the following two solutions:

1. Write clear rules about that a CCI can and cannot approve and how they should behave in the guidebook and Rule 15. Keep their power above the Magi and NTR but seriously raise the playtime requirements. (I would suggest either 50 hours of magistrate as that requirement itself involves a lot of time in high-responsibility roles, or 100 hours in central command)
2. Write clear rules about that a CCI can and cannot approve and how they should behave in the guidebook and Rule 15. Do not allow them to overrule or order around Magi and NTR and keep the current playtime requirements. Make it possible for the station to differentiate between a CCI and a CCO by giving them different stamps. [EDIT] Additionally remove the holocall and have their communications console access revoked so they communicate only by faxing.
## Technical details
<!-- Summary of code changes for easier review. -->
Commented out the CentComIntern spawnpoint on _Harmony/centcom.yml [EDIT] removed instead of commented out
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
None.
## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Delta
- remove: Central Command Intern as a ghostrole at the start of the round

