### PR TITLE
Boston Accent Quick Fix

### DIFF
--- a/Content.Server/_Funkystation/Speech/EntitySystems/BostonAccentSystem.cs
+++ b/Content.Server/_Funkystation/Speech/EntitySystems/BostonAccentSystem.cs
@@ -20,8 +20,6 @@ public sealed class BostonAccentSystem : EntitySystem
     private static readonly Regex RegexUppercaseEndingEr = new(@"\BER(?=(s\b|\b))");
     private static readonly Regex RegexLowercaseEndingOr = new(@"\Bor(?=(s\b|\b))");
     private static readonly Regex RegexUppercaseEndingOr = new(@"\BOR(?=(s\b|\b))");
-    private static readonly Regex RegexLowercaseEndingA = new(@"\Ba(?=(s\b|\b))");
-    private static readonly Regex RegexUppercaseEndingA = new(@"\BA(?=(s\b|\b))");
     private static readonly Regex RegexLowercaseNty = new(@"\Bnt(?=(y|ie))");
     private static readonly Regex RegexUppercaseNty = new(@"\BNT(?=(Y|IE))");
     private static readonly Regex RegexApostropheT = new(@"'t", RegexOptions.IgnoreCase);
@@ -52,10 +50,6 @@ public sealed class BostonAccentSystem : EntitySystem
         // reactor -> reactah
         msg = RegexLowercaseEndingOr.Replace(msg, "ah");
         msg = RegexUppercaseEndingOr.Replace(msg, "AH");
-
-        // pizza -> pizzer
-        msg = RegexLowercaseEndingA.Replace(msg, "er");
-        msg = RegexUppercaseEndingA.Replace(msg, "ER");
 
         // bounty -> bounny
         msg = RegexLowercaseNty.Replace(msg, "nn");


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
LICENSE: MIT

## About the PR
<!-- What did you change? -->
The Boston accent changes "a" (like the word) to "er" and and "or" to "ah". This annoys me. Apparently I didn't test for this. Now it's fixed.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
![hard af](https://github.com/user-attachments/assets/888488ef-936c-423b-a72e-54df797db5fd)

## Technical details
<!-- Summary of code changes for easier review. -->
I added a total of sixteen characters to `BostonAccentSystem.cs`, 50% of them being `\`s and 50% of them being `B`s.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="258" height="212" alt="Screenshot_20260124_162252" src="https://github.com/user-attachments/assets/ed6fb2a5-f011-4efb-b988-772036934882" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: Made the Boston accent work as intended with words like "a" and "or".