### PR TITLE
Genetics research crash fix [Bug fix]

### DIFF
--- a/Content.Server/_Funkystation/Genetics/Systems/DnaScannerConsoleSystem.cs
+++ b/Content.Server/_Funkystation/Genetics/Systems/DnaScannerConsoleSystem.cs
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Steve <marlumpy@gmail.com>
+// SPDX-FileCopyrightText: 2026 marc-pelletier <113944176+marc-pelletier@users.noreply.github.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using System.Linq;
 using Content.Server._Funkystation.Genetics.Components;
 using Content.Server.Medical.Components;


### PR DESCRIPTION
## About the PR
Was accidentally dirtying the ResearchPointSourceComponent which is non-networked. This PR just removes that as it's obviously not needed for anything. 

## Why / Balance
Bugfix

## Technical details
See above. 

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Fixed issue with genetics console crashing on research point change. 
