### PR TITLE
Genetic armor coefficient fixes [Bug fix]

### DIFF
--- a/Resources/Prototypes/_Funkystation/Genetics/genetic_mutations.yml
+++ b/Resources/Prototypes/_Funkystation/Genetics/genetic_mutations.yml
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2026 Steve <marlumpy@gmail.com>
+# SPDX-FileCopyrightText: 2026 marc-pelletier <113944176+marc-pelletier@users.noreply.github.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 # Speech mutations
 - type: geneticMutation
   id: CowboyAccent


### PR DESCRIPTION
## About the PR
Fixes the incorrect coefficients causing damage to 9x instead of dropping by 10%

## Why / Balance
Bugfix

## Technical details
None

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
None

**Changelog**
:cl:
- fix: Armor mutations will no longer cause you to explode from a punch.
