### PR TITLE
Update Packed for the week of February 2nd

### DIFF
--- a/Resources/Maps/_Funkystation/packed.yml
+++ b/Resources/Maps/_Funkystation/packed.yml
@@ -1,3 +1,64 @@
+# SPDX-FileCopyrightText: 2021 AJCM-git <60196617+AJCM-git@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2021 E F R <602406+Efruit@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2021 Elijahrane <60792108+Elijahrane@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2021 Mith-randalf <84274729+Mith-randalf@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2021 Paul Ritter <ritter.paul1@googlemail.com>
+# SPDX-FileCopyrightText: 2021 buletsponge <96000213+buletsponge@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2021 wrexbe <81056464+wrexbe@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2022 0x6273 <0x40@keemail.me>
+# SPDX-FileCopyrightText: 2022 20kdc <asdd2808@gmail.com>
+# SPDX-FileCopyrightText: 2022 Kara <lunarautomaton6@gmail.com>
+# SPDX-FileCopyrightText: 2022 Moony <moonheart08@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2022 Morbo <14136326+Morb0@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2022 Myctai <108953437+Myctai@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2022 Peptide90 <78795277+Peptide90@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2022 TaralGit <76408146+TaralGit@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2022 TimrodDX <timrod@gmail.com>
+# SPDX-FileCopyrightText: 2022 Veritius <veritiusgaming@gmail.com>
+# SPDX-FileCopyrightText: 2022 and_a <and_a@DESKTOP-RJENGIR>
+# SPDX-FileCopyrightText: 2022 corentt <36075110+corentt@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2022 metalgearsloth <comedian_vs_clown@hotmail.com>
+# SPDX-FileCopyrightText: 2022 mirrorcult <lunarautomaton6@gmail.com>
+# SPDX-FileCopyrightText: 2022 moonheart08 <moonheart08@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 778b <33431126+778b@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 DrSmugleaf <DrSmugleaf@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Eoin Mcloughlin <helloworld@eoinrul.es>
+# SPDX-FileCopyrightText: 2023 Jackrost <jackrost@mail.ru>
+# SPDX-FileCopyrightText: 2023 Kevin Zheng <kevinz5000@gmail.com>
+# SPDX-FileCopyrightText: 2023 LankLTE <135308300+LankLTE@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Leon Friedrich <60421075+ElectroJr@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 TsjipTsjip <19798667+TsjipTsjip@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 Ubaser <134914314+UbaserB@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2023 eoineoineoin <github@eoinrul.es>
+# SPDX-FileCopyrightText: 2024 Aiden <aiden@djkraz.com>
+# SPDX-FileCopyrightText: 2024 Aidenkrz <aiden@djkraz.com>
+# SPDX-FileCopyrightText: 2024 Brandon Hu <103440971+Brandon-Huu@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Emisse <99158783+Emisse@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 JustCone <141039037+JustCone14@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 Krunklehorn <42424291+Krunklehorn@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 NkoKirkto <153374559+NkoKirkto@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 NkoKirkto <halloleute640mail.com>
+# SPDX-FileCopyrightText: 2024 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
+# SPDX-FileCopyrightText: 2024 Piras314 <p1r4s@proton.me>
+# SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2024 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Aviu00 <93730715+Aviu00@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 CalicoDragon <110030310+CalicoDragon@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Huhm-1 <cameronhillard40@gmail.com>
+# SPDX-FileCopyrightText: 2025 Icepick <122653407+Icepicked@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2025 corresp0nd <46357632+corresp0nd@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 kbarkevich <24629810+kbarkevich@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 rottenheadphones <juaelwe@outlook.com>
+# SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2026 88tv <131759102+88tv@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2026 8tv <eightev@gmail.com>
+#
+# SPDX-License-Identifier: MIT
+
 meta:
   format: 7
   category: Map


### PR DESCRIPTION
LICENSE: MIT
## About the PR
Updated Packed to keep to modern standards.

Specifically...
* Added the Power Transmission Point and Compressed Matter Fabricator south of engineering, in space,
* Fixed signage which pointed crew looking for evac west, when it should have pointed east,
* Added the laundry machines in the old washroom, which is now a laundromat,
* Added the atmospheric reserves computer,
* Replaced the gas miners with gas extractors,
* Added the money cabinet to atmos,
* Removed unnecessary amounts of loot in engineering,
* Added the pipe scrubber to atmos,
* Linked the medical scanner to the genetics console in genetics,
* Added a button allowing players to leave medical (if the CMO unlocks it),
* Fixed science's fax machine showing as "Unknown",
* Added a station beacon to the genetics room,
* Added extra firelocks in maintenance northwest of security,
* Added a "Docking arm" station beacon to secondary evac,
* Make the security entrance brig-locked instead of security locked,
* Connect science to the distro pipenet,
* Move chemistry around to fit the sink somewhere reachable,
* Made Captain's room easier to break into,
* Added a funny door in genpop.

## Why / Balance
Updating to keep modern and to adjust for feedback.

## Technical details

## Media
<img width="1172" height="1018" alt="image" src="https://github.com/user-attachments/assets/1ade3fd4-82ec-49d5-991c-96d7150ae970" />
<img width="836" height="497" alt="image" src="https://github.com/user-attachments/assets/7652fa62-f5c8-45a5-80f0-e0d9170c9e30" />
<img width="4800" height="3776" alt="Packed release 1" src="https://github.com/user-attachments/assets/fb20892b-a4ef-455e-81d6-5bcef1c2e768" />

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- add: Added the Power Transmission Point and Compressed Matter Fabricator to Packed.
- fix: Fixed direction of evacuation signage in Packed.
- tweak: Reworked the washroom to a laundromat in Packed.
- add: Added atmospheric reserves items (AIR computer, gas extractors, money cabinet) to atmospherics in Packed.
- add: Added Geiger counters to various locations in Packed.
- remove: Removed excess materials and loot within the Engineering department in Packed.
- add: Added a pipe scrubber to the atmospherics bay in Packed.
- fix: Linked a previously unlinked medical scanner and genetics console in Packed.
- fix: Fixed a previously unnamed science fax machine in Packed.
- add: Added a station beacon to Genetics and Secondary Evac (Docking Arm) in Packed.
- add: Added extra firelocks in northern maintenance in Packed.
- fix: Made the security entrance brig-locked instead of security-locked in Packed.
- fix: Connected the science department's pipenet to distro in Packed.
- fix: Reorganized the chemistry room to move the sink in Packed.
- add: Added a weakness to Captain's room in Packed.
- add: Added a funny door to genpop in Packed.