### PR TITLE
Fix build issue on Oxygen reagent [Bugfix]

### DIFF
--- a/Resources/Prototypes/Reagents/gases.yml
+++ b/Resources/Prototypes/Reagents/gases.yml
@@ -28,6 +28,7 @@
 # SPDX-FileCopyrightText: 2025 corresp0nd <46357632+corresp0nd@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 pa.pecherskij <pa.pecherskij@interfax.ru>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2026 Mora <46364955+TrixxedHeart@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2026 Steve <marlumpy@gmail.com>
 # SPDX-FileCopyrightText: 2026 TrixxedHeart <46364955+TrixxedBit@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2026 marc-pelletier <113944176+marc-pelletier@users.noreply.github.com>


### PR DESCRIPTION
## About the PR
The fix for Vox had an issue causing entities to modify the gas in their lungs more than once. This fixes that issue. 

Vox and Plasma breathers have both been tested and both die from taking in Oxygen as they should. 

## Why / Balance
Bug fix. 

## Technical details
Modify lung gas is only applied to Oxygen once and excludes anyone with a Thaven, Vox or Plasma Breather organ. 

## Requirements
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.

**Changelog**
:cl:
- fix: Fixed issue with entities modifying lung gas more than once.
