### PR TITLE
Adjust AI shop action timers

### DIFF
--- a/Resources/Prototypes/_DV/Actions/station_ai.yml
+++ b/Resources/Prototypes/_DV/Actions/station_ai.yml
@@ -1,4 +1,6 @@
 # SPDX-FileCopyrightText: 2025 YaraaraY <158123176+YaraaraY@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2026 8tv <eightev@gmail.com>
+# SPDX-FileCopyrightText: 2026 MaiaArai <158123176+YaraaraY@users.noreply.github.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 


### PR DESCRIPTION
LICENSE: MIT
## About the PR
Adjusted AI action timers based on personal preference.

Specifically...
* The RGB lighting action has been increased from a cool down of 30 seconds to 180 seconds.
* The light synthesizer action has been decreased from a cool down of 300 seconds to 150 seconds.
* The emergency sealant action has been decreased from a cool down of 300 seconds to 240 seconds.

## Why / Balance
I dislike seeing RGB lighting in-game so often. When AI chooses it, I want them to have access to it less often. 
I think the light synthesizer is a very nice QOL feature limited severely by how often it can be used. Five minutes is overkill; two and a half should be enough to keep janitors useful. 
Emergency sealant is also useful, but I still think five minutes is overkill. Four minutes is a step towards something more reasonable.

## Technical details
yml

## Media

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes

**Changelog**
:cl:
- tweak: Increased the cooldown on the Station AI's RGB lighting action to 180 seconds (previously 30 seconds).
- tweak: Decreased the cooldown on the Station AI's light synthesizer action to 150 seconds (previously 300 seconds).
- tweak: Decreased the cooldown on the Station AI's emergency sealant action to 240 seconds (previously 300 seconds).