### PR TITLE
Github Bot changes relating to Status

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,6 +5,7 @@
 # SPDX-FileCopyrightText: 2024 lzk <124214523+lzk228@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2024 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2026 Komoni <131829655+Komonighub@users.noreply.github.com>
 #
 # SPDX-License-Identifier: MIT
 

--- a/.github/workflows/labeler-failedreview.yml
+++ b/.github/workflows/labeler-failedreview.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Komoni <131829655+Komonighub@users.noreply.github.com>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 name: "Labels: Changes Requested"
 
 on:


### PR DESCRIPTION
<!--- LICENSE: AGPL -->
## About the PR
More github bot changes

## Why / Balance
I hate the labeller

## Technical details
Adds a new workflow, removing "Status: Needs Review" while giving "Status: Awaiting Changes" when a review is sent with type "changes-requested" and this PR also adds the dummy filename trick mentioned in labeler issue 763's comments

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
Shouldn't be any

No changelog because this is not a game PR and doesn't need to be featured in changes