### PR TITLE
Disabling the changeling game modes (fixed)

### DIFF
--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -40,11 +40,11 @@
 - type: weightedRandom # All dual antag gamemodes are goobstation
   id: Secret
   weights:
-    Traitor: 0.25
-    Changeling: 0.13 # Goobstation unique antag
-    Traitorling: 0.12 # funky | up from 0.12 to replace survival/ramping
-    Nukeops: 0.15
-    Survival: 0.10
-    BloodCult: 0.10
-    CosmicCult: 0.10
+    Traitor: 0.30
+   # Changeling: 0.13 # Goobstation unique antag
+   # Traitorling: 0.12 # funky | up from 0.12 to replace survival/ramping
+    Nukeops: 0.20
+    Survival: 0.15
+    BloodCult: 0.15
+    CosmicCult: 0.15
     BlobTraitor: 0.05

--- a/Resources/Prototypes/secret_weights.yml
+++ b/Resources/Prototypes/secret_weights.yml
@@ -33,6 +33,7 @@
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2025 willow <willowzeta632146@proton.me>
 # SPDX-FileCopyrightText: 2025 wilowzeta <willowzeta632146@proton.me>
+# SPDX-FileCopyrightText: 2026 Masterelzoi <58088854+Masterelzoi@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2026 Terkala <appleorange64@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
I commented out the changeling game modes and increased other game modes percent chance to fire to compensate
<!-- What did you change? -->

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Changelings are littered with problems in game. From shitcode, to terrible balancing creating an unfun experience for all but the ling player, incentivising murder boning with little RP and killing corporate secret leak RP, i think changelings need to be fully removed until a rework is created. I will go over why i think changelings are very problematic in detail:

### **Unbalanced**
Changelings are incredibly unbalanced. There is a clear difference between being strong in a fight, and not giving someone a chance to fight back. Changelings are team antagonists, despite being arguably the strongest 1v1 antagonist in the game other than maybe an maxxed out heratic. With certain ability combinations, changelings can run from or to you at Mach 10 with their epi dose and strain muscle abilities. Making you near impossible to catch or kill other than spraying and praying. Their weapon paired with this makes them deal 20 damage per very fast swing, all while being much much faster than you. Not to mention a sting that instantly blinds you and one that freezes and KO's you. It simply is not a fair or fun thing to fight. Even if you manage to get a stun off. Lings can head slug or cuff shatter, so you have to do the WHOLE process again. Additionally with the move to more laser based weapons for sec, lings have the equivalent of an EMP implant in the form of their screech. Leaving secoffs with only their combat knife if they aren't armed on red alert. This isn't even mentioning that for some reason lings are a TEAM ANTAG. The only reason this hasn't been more problematic is a lot of people don't even realise that lings are team antags. If they do realise this however and properly coordinate with one another. There is literally nothing security or the rest of the crew can do about it. In the standard changeling game mode on high pop there is typically 5 changelings. One changeling has a TTK of under 4 seconds when they are only using the sword on a secoff in normal armour. So see the issue with 5 lings jumping you? Even if sec is a coordinated group going into a head on head confrontation, if its in maints which lets be honest it always is, the lings have a ridiculous amount of advantages. From speed to abilities, they then can eat sec essentially running free on board. I have personally been in these rounds, and heard horror stories too. Coordinated changeling groups are nigh unbeatable. With no do-after point and clicks they can incapacitate groups of sec easily if they are just somewhat coordinated. This is me only mentioning some of the ridiculously strong things changelings can do as i could go on and on about it, but i feel this covers enough to give you the gist of the issue

### **RP issues**
changelings no matter the round become the sole focus of sec. security has next to no time to actually rp with antags that aren't the changelings. We don't have time to solve the case of "who stole the hypo spray" or "why did the person wake up naked from the sacrifice" when a changeling is mass murdering and callouts are flying round every minute of a new body has been found in maints. This is just stressful and not fun. It takes away the fun butting of heads with sec from all the other antags in a round with changelings. RP with antags is fun, and changelings shouldn't be depriving sec or the other antags of it by merely doing their goals. Reducing the amount changelings have to kill isn't a good solution either. As as mentioned above changelings are REALLY strong, so they can complete their objectives without getting caught extremely easily. Changelings wont even risk taunting or fucking with sec, because when they are discovered they are just rr'ed immediately. Additionally, as changelings can kill anyone to achieve their goal, there is literally no incentive to do it creatively. Instead john tider is getting jumped in maints because its just the easiest way to complete their goals. Sure they have one person they specifically have to kill, but this simply isn't enough. Most changelings anyway don't even bother killing them, and just silent dna absorb their target to shift on evac. I can say from a lot of experience, changeling rounds are always the same. There is no incentive to do things creatively and you cant make them too easy that there is no conflict. I don't believe there is a good balance to be found, and think without a full rework, this issue just wont be solved. Additionally due to wanted status jank when changelings shift, blood tests having no downsides and changelings killing to many people to allow them to RR all their kills. Changelings have no way at all to reintegrate with the crew as a new identity. Instead they are forced to go loud as soon as they are discovered and just murder bone and hide in maints until their objectives are completed. This is not fun for anyone.

### **nobody cares about corporate secrets leaks anymore**
When corporate secrets are revealed nowadays. Most of the crew could not care less. I think changelings are fully to blame for this. EVERY changeling shift either by some officer slipping up in person or on comms and the ai announcing it, people metaing their way to the chappal when they ooc know its changelings to see someone get cremated, or someone just witnessing a changeling do anything. Suddenly a tiny section the crew is screaming to arrest the cap for ashing a crew and start riots while most act like nothing is happening. Its ALWAYS the same round. So much so that when corporate secrets are leaked in non changeling shifts, people don't even react. They certainly used too, and it was a fun thing to quell out and interact with. Now nobody cares. No actual conflicts occur, no protests about why was this kept from us. no trying to get command arrested. just nothing. I fully believe the leaking of corporate secrets EVERY changeling round (which are common as changelings have a 25% chance to show up) made people stop caring due to how samey it feels. This normally is super fun rp which is very sad to see it go in the way it has.


All in all changelings aren't fun for anybody but the changelings, and don't promote good gameplay from their design. As a rework of them is in progress, i think its best just to remove them, until such a time the rework is completed. I mean, when's the last time somebody other than a ling said "that was a fun ling round"


## Technical details
Commented out the changeling game mode percent chances and redistributed them among the other game modes

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
🆑 
- remove: Changeling and traitorling game modes from secret rotation