### PR TITLE
Central Command fixes

### DIFF
--- a/Resources/Maps/_Harmony/centcomm.yml
+++ b/Resources/Maps/_Harmony/centcomm.yml
@@ -53,7 +53,7 @@ meta:
   engineVersion: 268.0.0
   forkId: ""
   forkVersion: ""
-  time: 02/26/2026 21:46:08
+  time: 03/05/2026 13:31:39
   entityCount: 7017
 maps: []
 grids:
@@ -22651,6 +22651,20 @@ entities:
       rot: 3.141592653589793 rad
       pos: 46.5,25.5
       parent: 1
+- proto: GasPassiveVent
+  entities:
+  - uid: 2828
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 44.5,25.5
+      parent: 1
+  - uid: 2829
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 42.5,25.5
+      parent: 1
 - proto: GasPipeBend
   entities:
   - uid: 2831
@@ -29184,20 +29198,6 @@ entities:
       targetTemperature: 73.15
     - type: ApcPowerReceiver
       powerDisabled: False
-- proto: GasVentPump
-  entities:
-  - uid: 2828
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 44.5,25.5
-      parent: 1
-  - uid: 2829
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 42.5,25.5
-      parent: 1
 - proto: GasVentPumpAlt2
   entities:
   - uid: 3373


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
Oops, this is horribly late. Better late than never, I suppose.

Removes the RnD servers from CC, and also add lights to botany.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: CC got some necessary not-at-all-hotfixes.

