### PR TITLE
Cigarette Cartons are for Cigarettes V2

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/cartons.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Smokeables/Cigarettes/cartons.yml
@@ -37,6 +37,10 @@
   - type: Storage
     grid:
     - 0,0,4,1
+    whitelist:
+      tags:
+        - Matchstick
+        - Cigarette
   - type: StorageFill
     contents:
       - id: CigPackGreen

--- a/Resources/Prototypes/Entities/Objects/Tools/matches.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/matches.yml
@@ -35,6 +35,10 @@
   - type: Storage
     grid:
     - 0,0,6,1
+    whitelist:
+      tags:
+        - Matchstick
+        - Cigarette
   - type: Item
     size: Small
   - type: EmitSoundOnPickup


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
Cigarette cartons and Matchstick Boxes get whitelists for matchsticks and cigarettes. Yes this is a mald PR.

## Why / Balance
Currently cigarette cartons (and matchstick boxes) are used by paramedics to store chemicals in bottles. 

The effective chem storage of 2 cartons is 600u, plus it is subdivided for ease of use. 

A jug, which takes up the same bag space, and cannot fit in a pocket, is 200u. 

This is quite frankly ridiculous. 

## Technical details
YML addition, replicating whitelists from other inventories.

## Media
<img width="432" height="233" alt="image" src="https://github.com/user-attachments/assets/15597434-0414-41ea-9c0d-99c34e3cc840" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
NA

**Changelog**
:cl:
- add: Whitelist for Cigarette Carton and Matchstick Box
