### PR TITLE
fix visual bug with the grappling gun

### DIFF
--- a/Content.Client/Physics/JointVisualsOverlay.cs
+++ b/Content.Client/Physics/JointVisualsOverlay.cs
@@ -4,6 +4,7 @@
 // SPDX-FileCopyrightText: 2024 Plykiya <58439124+Plykiya@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
 // SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+// SPDX-FileCopyrightText: 2026 alex-infdev <185717397+alex-infdev@users.noreply.github.com>
 //
 // SPDX-License-Identifier: MIT
 

--- a/Content.Client/Physics/JointVisualsOverlay.cs
+++ b/Content.Client/Physics/JointVisualsOverlay.cs
@@ -40,9 +40,12 @@ public sealed class JointVisualsOverlay : Overlay
 
         args.DrawingHandle.SetTransform(Matrix3x2.Identity);
 
-        while (joints.MoveNext(out var visuals, out var xform))
+        while (joints.MoveNext(out var uid, out var visuals, out var xform))
         {
             if (xform.MapID != args.MapId)
+                continue;
+
+            if (_entManager.TryGetComponent<SpriteComponent>(uid, out var visualsSpriteComp) && !visualsSpriteComp.Visible)
                 continue;
 
             var other = _entManager.GetEntity(visuals.Target);

--- a/Content.Shared/Gibbing/Systems/GibbingSystem.cs
+++ b/Content.Shared/Gibbing/Systems/GibbingSystem.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2024 Jezithyr <jezithyr@gmail.com>
 // SPDX-FileCopyrightText: 2024 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
 // SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+// SPDX-FileCopyrightText: 2026 alex-infdev <185717397+alex-infdev@users.noreply.github.com>
 //
 // SPDX-License-Identifier: MIT
 

--- a/Content.Shared/Gibbing/Systems/GibbingSystem.cs
+++ b/Content.Shared/Gibbing/Systems/GibbingSystem.cs
@@ -11,6 +11,7 @@ using Content.Shared.Gibbing.Events;
 using Robust.Shared.Audio.Systems;
 using Robust.Shared.Containers;
 using Robust.Shared.Map;
+using Robust.Shared.Physics.Components;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Random;
@@ -141,33 +142,33 @@ public sealed class GibbingSystem : EntitySystem
             case GibContentsOption.Skip:
                 break;
             case GibContentsOption.Drop:
-            {
-                foreach (var container in validContainers)
                 {
-                    foreach (var ent in container.ContainedEntities)
+                    foreach (var container in validContainers)
                     {
-                        DropEntity(new Entity<GibbableComponent?>(ent, null), parentXform, randomSpreadMod,
-                            ref droppedEntities, launchGibs,
-                            launchDirection, launchImpulse, launchImpulseVariance, launchCone);
+                        foreach (var ent in container.ContainedEntities)
+                        {
+                            DropEntity(new Entity<GibbableComponent?>(ent, null), parentXform, randomSpreadMod,
+                                ref droppedEntities, launchGibs,
+                                launchDirection, launchImpulse, launchImpulseVariance, launchCone);
+                        }
                     }
-                }
 
-                break;
-            }
+                    break;
+                }
             case GibContentsOption.Gib:
-            {
-                foreach (var container in validContainers)
                 {
-                    foreach (var ent in container.ContainedEntities)
+                    foreach (var container in validContainers)
                     {
-                        GibEntity(new Entity<GibbableComponent?>(ent, null), parentXform, randomSpreadMod,
-                            ref droppedEntities, launchGibs,
-                            launchDirection, launchImpulse, launchImpulseVariance, launchCone);
+                        foreach (var ent in container.ContainedEntities)
+                        {
+                            GibEntity(new Entity<GibbableComponent?>(ent, null), parentXform, randomSpreadMod,
+                                ref droppedEntities, launchGibs,
+                                launchDirection, launchImpulse, launchImpulseVariance, launchCone);
+                        }
                     }
-                }
 
-                break;
-            }
+                    break;
+                }
         }
 
         switch (gibType)
@@ -175,17 +176,17 @@ public sealed class GibbingSystem : EntitySystem
             case GibType.Skip:
                 break;
             case GibType.Drop:
-            {
-                DropEntity(gibbable, parentXform, randomSpreadMod, ref droppedEntities, launchGibs,
-                    launchDirection, launchImpulse, launchImpulseVariance, launchCone);
-                break;
-            }
+                {
+                    DropEntity(gibbable, parentXform, randomSpreadMod, ref droppedEntities, launchGibs,
+                        launchDirection, launchImpulse, launchImpulseVariance, launchCone);
+                    break;
+                }
             case GibType.Gib:
-            {
-                GibEntity(gibbable, parentXform, randomSpreadMod, ref droppedEntities, launchGibs,
-                    launchDirection, launchImpulse, launchImpulseVariance, launchCone);
-                break;
-            }
+                {
+                    GibEntity(gibbable, parentXform, randomSpreadMod, ref droppedEntities, launchGibs,
+                        launchDirection, launchImpulse, launchImpulseVariance, launchCone);
+                    break;
+                }
         }
 
         if (playAudio)
@@ -229,7 +230,7 @@ public sealed class GibbingSystem : EntitySystem
             FlingDroppedEntity(gibbable, scatterDirection, scatterImpulse, scatterImpulseVariance, scatterCone);
         }
 
-        var gibbedEvent = new EntityGibbedEvent(gibbable, new List<EntityUid> {gibbable});
+        var gibbedEvent = new EntityGibbedEvent(gibbable, new List<EntityUid> { gibbable });
         RaiseLocalEvent(gibbable, ref gibbedEvent);
     }
 
@@ -322,10 +323,13 @@ public sealed class GibbingSystem : EntitySystem
     private void FlingDroppedEntity(EntityUid target, Vector2? direction, float impulse, float impulseVariance,
         Angle scatterConeAngle)
     {
+        if (!TryComp<PhysicsComponent>(target, out var physics))
+            return;
+
         var scatterAngle = direction?.ToAngle() ?? _random.NextAngle();
         var scatterVector = _random.NextAngle(scatterAngle - scatterConeAngle / 2, scatterAngle + scatterConeAngle / 2)
             .ToVec() * (impulse + _random.NextFloat(impulseVariance));
-        _physicsSystem.ApplyLinearImpulse(target, scatterVector);
+        _physicsSystem.ApplyLinearImpulse(target, scatterVector, body: physics);
     }
 
     private bool TryCreateRandomGiblet(GibbableComponent gibbable, EntityCoordinates coords,

--- a/Content.Shared/Weapons/Misc/SharedGrapplingGunSystem.cs
+++ b/Content.Shared/Weapons/Misc/SharedGrapplingGunSystem.cs
@@ -28,6 +28,7 @@ using Robust.Shared.Physics.Dynamics.Joints;
 using Robust.Shared.Physics.Systems;
 using Robust.Shared.Serialization;
 using Robust.Shared.Timing;
+using Robust.Shared.GameObjects;
 
 namespace Content.Shared.Weapons.Misc;
 
@@ -54,12 +55,31 @@ public abstract class SharedGrapplingGunSystem : EntitySystem
         SubscribeLocalEvent<GrapplingGunComponent, GunShotEvent>(OnGrapplingShot);
         SubscribeLocalEvent<GrapplingGunComponent, ActivateInWorldEvent>(OnGunActivate);
         SubscribeLocalEvent<GrapplingGunComponent, HandDeselectedEvent>(OnGrapplingDeselected);
+
+        SubscribeLocalEvent<GrapplingProjectileComponent, EntityTerminatingEvent>(OnGrapplingProjectileTerminating);
+    }
+
+    private void OnGrapplingProjectileTerminating(EntityUid uid, GrapplingProjectileComponent component, ref EntityTerminatingEvent args)
+    {
+        if (TryComp<ProjectileComponent>(uid, out var projectile) &&
+            projectile.Weapon != null &&
+            TryComp<GrapplingGunComponent>(projectile.Weapon.Value, out var gun))
+        {
+            // If the server projectile terminates (e.g. embed breaks), clean up the client tracking projectile too
+            if (gun.ClientProjectile != null && gun.Projectile == uid)
+            {
+                QueueDel(gun.ClientProjectile.Value);
+                gun.ClientProjectile = null;
+            }
+        }
     }
 
     private void OnGrappleJointRemoved(EntityUid uid, GrapplingProjectileComponent component, JointRemovedEvent args)
     {
-        if (_netManager.IsServer)
-            QueueDel(uid);
+        if (IsClientSide(uid))
+            return;
+
+        QueueDel(uid);
     }
 
     private void OnGrapplingShot(EntityUid uid, GrapplingGunComponent component, ref GunShotEvent args)
@@ -68,6 +88,9 @@ public abstract class SharedGrapplingGunSystem : EntitySystem
         {
             if (!HasComp<GrapplingProjectileComponent>(shotUid))
                 continue;
+
+            if (IsClientSide(shotUid.Value))
+                component.ClientProjectile = shotUid.Value;
 
             //todo: this doesn't actually support multigrapple
             // At least show the visuals.
@@ -126,18 +149,22 @@ public abstract class SharedGrapplingGunSystem : EntitySystem
 
     private void OnGunActivate(EntityUid uid, GrapplingGunComponent component, ActivateInWorldEvent args)
     {
-        if (!Timing.IsFirstTimePredicted || args.Handled || !args.Complex || component.Projectile is not {} projectile)
+        if (!Timing.IsFirstTimePredicted || args.Handled || !args.Complex || component.Projectile is not { } projectile)
             return;
 
         _audio.PlayPredicted(component.CycleSound, uid, args.User);
         _appearance.SetData(uid, SharedTetherGunSystem.TetherVisualsStatus.Key, true);
 
-        if (_netManager.IsServer)
-            QueueDel(projectile);
+        QueueDel(projectile);
+        if (component.ClientProjectile != null)
+        {
+            QueueDel(component.ClientProjectile.Value);
+            component.ClientProjectile = null;
+        }
 
         component.Projectile = null;
         SetReeling(uid, component, false, args.User);
-        _gun.ChangeBasicEntityAmmoCount(uid,  1);
+        _gun.ChangeBasicEntityAmmoCount(uid, 1);
 
         args.Handled = true;
     }

--- a/Content.Shared/Weapons/Misc/SharedGrapplingGunSystem.cs
+++ b/Content.Shared/Weapons/Misc/SharedGrapplingGunSystem.cs
@@ -7,6 +7,7 @@
 // SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
 // SPDX-FileCopyrightText: 2024 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+// SPDX-FileCopyrightText: 2026 alex-infdev <185717397+alex-infdev@users.noreply.github.com>
 //
 // SPDX-License-Identifier: MIT
 

--- a/Content.Shared/Weapons/Ranged/Components/GrapplingGunComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/GrapplingGunComponent.cs
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: 2024 Nemanja <98561806+EmoGarbage404@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 Roudenn <149893554+Roudenn@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+// SPDX-FileCopyrightText: 2026 alex-infdev <185717397+alex-infdev@users.noreply.github.com>
 //
 // SPDX-License-Identifier: MIT
 

--- a/Content.Shared/Weapons/Ranged/Components/GrapplingGunComponent.cs
+++ b/Content.Shared/Weapons/Ranged/Components/GrapplingGunComponent.cs
@@ -28,6 +28,12 @@ public sealed partial class GrapplingGunComponent : Component
     [DataField, AutoNetworkedField]
     public EntityUid? Projectile;
 
+    /// <summary>
+    /// Tracks the client-side predicted projectile entity so it can be cleaned up cleanly on the client visually.
+    /// </summary>
+    [ViewVariables(VVAccess.ReadWrite)]
+    public EntityUid? ClientProjectile;
+
     [ViewVariables(VVAccess.ReadWrite), DataField("reeling"), AutoNetworkedField]
     public bool Reeling;
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
Fixed several visual bugs with the grappling gun:
1. The rope visual would sometimes have a missing hook at the end
2. A second rope with a hook would spawn and just be there after retracting (only relogging or moving far away helped)
3. The hook and rope would sometimes visually disappear immediately upon hitting a wall or something, despite remaining functional mechanically

## Why / Balance
Fixes #2897 and it annoyed me so much I stopped playing salvaging for a while lol

## Technical details
- /Content.Client/Physics/JointVisualsOverlay.cs: Now respects `SpriteComponent.Visible`. 
- /Content.Shared/Weapons/Ranged/Components/GrapplingGunComponent.cs and Content.Shared/Weapons/Misc/SharedGrapplingGunSystem.cs: 
  - Added a ClientProjectile (Content.Client/_RMC14/Weapons/Ranged/Prediction/GunPredictionSystem.cs) field to track the player's locally predicted grappling hook.
  - Added an early return `if (IsClientSide(uid))` to OnGrappleJointRemoved (/Content.Shared/Weapons/Misc/SharedGrapplingGunSystem.cs). 
  - Subscribed to `EntityTerminatingEvent` for the server projectile. When the server hook is retracted, the local ClientProjectile (/Content.Client/_RMC14/Weapons/Ranged/Prediction/GunPredictionSystem.cs) is queued for deletion alongside it = no more duplicate rope

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
Before: 

https://github.com/user-attachments/assets/4c365101-ca97-45e1-921f-f75208fdd9f4

After:

https://github.com/user-attachments/assets/cae6cf94-edcc-401c-b289-2326d38a5a7b



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
None.

**Changelog**
:cl: amauralex
- fix: Fixed grappling gun bugs where the rope visual would persist on client after retracting
