### PR TITLE
Add Mindcontrol + Fast Draw Implant to Nukie Uplink

### DIFF
--- a/Resources/Prototypes/_Funkystation/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Funkystation/Catalog/uplink_catalog.yml
@@ -206,6 +206,23 @@
       - NukeOpsUplink # I don't really wanna mess with nukie balancing
   saleLimit: 1
 
+# Implants
+
+- type: listing
+  id: UplinkFastDrawImplanter
+  name: Fast Draw implanter
+  description: A syringe with tools for quick implant removal. It has small gold stars on its body.
+  productEntity: RevsFastDrawImplanter
+  cost:
+    Telecrystal: 20
+  categories:
+  - UplinkImplants
+  conditions:
+  - !type:StoreWhitelistCondition
+    whitelist:
+      tags:
+      - NukeOpsUplink
+
 # Pointless
 
 - type: listing

--- a/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
@@ -254,8 +254,8 @@
           - NukeOpsUplink # i guess we dont let nukies have this, they have to mutch TC
   saleLimit: 1
   
- - type: listing
-  id: UplinkMindcontrolImplanter
+- type: listing
+  id: UplinkMindcontrolImplanterNukie
   name: uplink-mindcontrol-implant-name
   description: uplink-mindcontrol-implant-desc
   icon: { sprite: /Textures/Objects/Specific/Medical/syndi_implanter.rsi, state: implanter0 }

--- a/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
@@ -253,6 +253,23 @@
         tags:
           - NukeOpsUplink # i guess we dont let nukies have this, they have to mutch TC
   saleLimit: 1
+  
+ - type: listing
+  id: UplinkMindcontrolImplanter
+  name: uplink-mindcontrol-implant-name
+  description: uplink-mindcontrol-implant-desc
+  icon: { sprite: /Textures/Objects/Specific/Medical/syndi_implanter.rsi, state: implanter0 }
+  productEntity: MindcontrolImplanter
+  cost:
+    Telecrystal: 65
+  categories:
+    - UplinkImplants
+  conditions:
+    - !type:StoreWhitelistCondition
+        whitelist:
+            tags:
+            - NukeOpsUplink # _Funkystation - they can have it, as a treat
+  saleLimit: 1
 
 - type: listing
   id: UplinkSmokeImplanter

--- a/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
@@ -22,6 +22,7 @@
 # SPDX-FileCopyrightText: 2025 pa.pecherskij <pa.pecherskij@interfax.ru>
 # SPDX-FileCopyrightText: 2025 starch <starchpersonal@gmail.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2026 TrixxedHeart <46364955+TrixxedBit@users.noreply.github.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 

--- a/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/_Goobstation/Catalog/uplink_catalog.yml
@@ -248,28 +248,6 @@
     Telecrystal: 30
   categories:
     - UplinkImplants
-  conditions:
-    - !type:StoreWhitelistCondition
-      blacklist:
-        tags:
-          - NukeOpsUplink # i guess we dont let nukies have this, they have to mutch TC
-  saleLimit: 1
-  
-- type: listing
-  id: UplinkMindcontrolImplanterNukie
-  name: uplink-mindcontrol-implant-name
-  description: uplink-mindcontrol-implant-desc
-  icon: { sprite: /Textures/Objects/Specific/Medical/syndi_implanter.rsi, state: implanter0 }
-  productEntity: MindcontrolImplanter
-  cost:
-    Telecrystal: 65
-  categories:
-    - UplinkImplants
-  conditions:
-    - !type:StoreWhitelistCondition
-        whitelist:
-            tags:
-            - NukeOpsUplink # _Funkystation - they can have it, as a treat
   saleLimit: 1
 
 - type: listing


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
Adds the mind control implant and fast draw implant (20 TC) to the nukie uplink

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Opens up for more interesting gimmick ops

## Technical details
Removes the blacklist condition from the mindshield implant

Adds the Fast Draw implanter to the Nukie uplink for 20 tc

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- add: Added mind control implants to the Nukie uplink
- add: Added fast draw implanter to the Nukie uplink
