### PR TITLE
Makes SM hallucinations be local to the SM

### DIFF
--- a/Content.Server/_EE/Supermatter/Systems/SupermatterSystem.Processing.cs
+++ b/Content.Server/_EE/Supermatter/Systems/SupermatterSystem.Processing.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2025 BrightNibbleston <218794821+BrightNibbleston@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 BrightNibbleston <brightnibbleston@gmail.com>
 // SPDX-FileCopyrightText: 2025 Do You Like Beans <bowenjonathan407@gmail.com>
+// SPDX-FileCopyrightText: 2025 Homingpenguins <59744509+Homingpenguins@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Homingpenguins <asadellace4@gmail.com>
 // SPDX-FileCopyrightText: 2025 Steve <marlumpy@gmail.com>
 // SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
@@ -10,6 +11,7 @@
 // SPDX-FileCopyrightText: 2025 marc-pelletier <113944176+marc-pelletier@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+// SPDX-FileCopyrightText: 2026 MeowVal <meowval@catkatnya.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 

--- a/Content.Server/_EE/Supermatter/Systems/SupermatterSystem.Processing.cs
+++ b/Content.Server/_EE/Supermatter/Systems/SupermatterSystem.Processing.cs
@@ -847,7 +847,15 @@ public sealed partial class SupermatterSystem
                 _paracusia.SetSounds(mob, paracusiaSounds, paracusia);
                 _paracusia.SetTime(mob, paracusiaMinTime, paracusiaMaxTime, paracusia);
                 _paracusia.SetDistance(mob, paracusiaDistance, paracusia);
+                _hallucinating.Add(mob);
             }
+        }
+
+        foreach (var mob in _hallucinating.Except(lookup).ToList())
+        {
+            // Mob left the hallucination area of the supermatter
+            RemComp<ParacusiaComponent>(mob);
+            _hallucinating.Remove(mob);
         }
 
         sm.PsyCoefficient = Math.Clamp(sm.PsyCoefficient + psyDiff, 0f, 1f);

--- a/Content.Server/_EE/Supermatter/Systems/SupermatterSystem.Processing.cs
+++ b/Content.Server/_EE/Supermatter/Systems/SupermatterSystem.Processing.cs
@@ -849,15 +849,15 @@ public sealed partial class SupermatterSystem
                 _paracusia.SetSounds(mob, paracusiaSounds, paracusia);
                 _paracusia.SetTime(mob, paracusiaMinTime, paracusiaMaxTime, paracusia);
                 _paracusia.SetDistance(mob, paracusiaDistance, paracusia);
-                _hallucinating.Add(mob);
+                sm.Hallucinating.Add(mob);
             }
         }
 
-        foreach (var mob in _hallucinating.Except(lookup).ToList())
+        foreach (var mob in sm.Hallucinating.Except(lookup).ToList())
         {
             // Mob left the hallucination area of the supermatter
             RemComp<ParacusiaComponent>(mob);
-            _hallucinating.Remove(mob);
+            sm.Hallucinating.Remove(mob);
         }
 
         sm.PsyCoefficient = Math.Clamp(sm.PsyCoefficient + psyDiff, 0f, 1f);

--- a/Content.Server/_EE/Supermatter/Systems/SupermatterSystem.cs
+++ b/Content.Server/_EE/Supermatter/Systems/SupermatterSystem.cs
@@ -1,7 +1,9 @@
+// SPDX-FileCopyrightText: 2025 Drywink <43855731+Drywink@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 Drywink <hugogrethen@gmail.com>
 // SPDX-FileCopyrightText: 2025 VMSolidus <evilexecutive@gmail.com>
 // SPDX-FileCopyrightText: 2025 corresp0nd <46357632+corresp0nd@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+// SPDX-FileCopyrightText: 2026 MeowVal <meowval@catkatnya.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 

--- a/Content.Server/_EE/Supermatter/Systems/SupermatterSystem.cs
+++ b/Content.Server/_EE/Supermatter/Systems/SupermatterSystem.cs
@@ -75,8 +75,6 @@ public sealed partial class SupermatterSystem : EntitySystem
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
 
-    private readonly HashSet<Entity<MobStateComponent>> _hallucinating = new();
-
     public override void Initialize()
     {
         base.Initialize();

--- a/Content.Server/_EE/Supermatter/Systems/SupermatterSystem.cs
+++ b/Content.Server/_EE/Supermatter/Systems/SupermatterSystem.cs
@@ -73,6 +73,8 @@ public sealed partial class SupermatterSystem : EntitySystem
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly IRobustRandom _random = default!;
 
+    private readonly HashSet<Entity<MobStateComponent>> _hallucinating = new();
+
     public override void Initialize()
     {
         base.Initialize();

--- a/Content.Shared/_EE/Supermatter/Components/SupermatterComponent.cs
+++ b/Content.Shared/_EE/Supermatter/Components/SupermatterComponent.cs
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: 2025 corresp0nd <46357632+corresp0nd@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 marc-pelletier <113944176+marc-pelletier@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+// SPDX-FileCopyrightText: 2026 MeowVal <meowval@catkatnya.com>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 

--- a/Content.Shared/_EE/Supermatter/Components/SupermatterComponent.cs
+++ b/Content.Shared/_EE/Supermatter/Components/SupermatterComponent.cs
@@ -9,6 +9,7 @@
 using Content.Shared.Atmos;
 using Content.Shared.DeviceLinking;
 using Content.Shared.DoAfter;
+using Content.Shared.Mobs.Components;
 using Content.Shared.Radio;
 using Content.Shared.Speech;
 using Robust.Shared.Audio;
@@ -236,6 +237,12 @@ public sealed partial class SupermatterComponent : Component
     /// </summary>
     [DataField]
     public float AnomalyPyroChance = 2500f;
+
+    /// <summary>
+    /// The Entities that are hallucinating because of the suppermatter.
+    /// </summary>
+    [DataField]
+    public HashSet<Entity<MobStateComponent>> Hallucinating = new();
 
     #endregion
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
 LICENSE: AGPL AND MIT
## About the PR
<!-- What did you change? -->
Made the SM hallucinations dissapear if you walked far enough from the SM.
Delam SM still affects everyone for the rest of the round globaly.
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Would make the SM hallucinations immunity trate less releveant for people not near the SM.
Was a bit odd that as soon as you got near the SM you would always behaunted by it's hallucinations no matter where you are on the station. Now it's just when you are near it that you feel the wrath of the SM.

## Technical details
<!-- Summary of code changes for easier review. -->
Added a new HasSet that contains the mobs that have the hallucinations from the SM to the SupermatterComponent that is applied to mobs through the HandleVision function. Each tick loops through the HasSet containing mobs that got the hallucinations added by HandelVision and removes them if they are no longer in the lookup HasSet that HandleVision uses to see mobs that are in range of the SM for hallucinations.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
At the SM
<img width="894" height="1327" alt="image" src="https://github.com/user-attachments/assets/f6bcb585-040a-4d7e-b499-c37a881459d5" />

After walking away from the SM
<img width="964" height="894" alt="image" src="https://github.com/user-attachments/assets/795d5416-c7b4-4d84-8f80-31d114d0ccbf" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ✅ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ✅ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl: MeowVal
- tweak; SM hallucinations are now localized to the area around SM 
