### PR TITLE
Add Word Highlights for Central Command VIPs

### DIFF
--- a/Resources/Locale/en-US/_Funkystation/chat/highlights.ftl
+++ b/Resources/Locale/en-US/_Funkystation/chat/highlights.ftl
@@ -1,0 +1,4 @@
+# Central Command
+highlights-magistrate = Magistrate, "Magi", "CCV", Central Command VIP, "CC", Central Command, Central, Judge, Arbitrator, Chief Adjudicator, Adjudicator, Judicial Administrator, Chief Legal Officer, "CLO"
+highlights-nanotrasen-representative = Nanotrasen Representative, Representative, "Rep", "NTR", "NTRep", "CCV", Central Command VIP, "CC", Central Command, Central, Liaison, Compliance Executive, "NCE", Advisor
+highlights-internal-affairs-agent = Internal Affairs Agent, "IAA", "IA", "CCV", Central Command VIP, "CC", Central Command, Central, Sapient Resources, Sapient Resources Agent, "SRA", Compliance Officer

--- a/Resources/Locale/en-US/_Funkystation/chat/highlights.ftl
+++ b/Resources/Locale/en-US/_Funkystation/chat/highlights.ftl
@@ -1,4 +1,4 @@
 # Central Command
 highlights-magistrate = Magistrate, "Magi", "CCV", Central Command VIP, "CC", Central Command, Central, Judge, Arbitrator, Chief Adjudicator, Adjudicator, Judicial Administrator, Chief Legal Officer, "CLO"
-highlights-nanotrasen-representative = Nanotrasen Representative, Representative, "Rep", "NTR", "NTRep", "CCV", Central Command VIP, "CC", Central Command, Central, Liaison, Compliance Executive, "NCE", Advisor
-highlights-internal-affairs-agent = Internal Affairs Agent, "IAA", "IA", "CCV", Central Command VIP, "CC", Central Command, Central, Sapient Resources, Sapient Resources Agent, "SRA", Compliance Officer
+highlights-nanotrasen-representative = Nanotrasen Representative, Representative, "Rep", "NTR", "NTRep", "CCV", Central Command VIP, "CC", Central Command, Central, Liaison, Compliance Executive, "NCE", Advisor, Audit, Auditor
+highlights-internal-affairs-agent = Internal Affairs Agent, "IAA", "IA", "CCV", Central Command VIP, "CC", Central Command, Central, Sapient Resources, Sapient Resources Agent, "SRA", Compliance Officer, Audit, Auditor


### PR DESCRIPTION
LICENSE: MIT
## About the PR
Adds numerous chat highlights for Central Command VIP roles. Also includes highlights based on alternate job titles.

## Why / Balance
i dont wanna keep having to copy paste my highlights in.

## Technical details
- Added `Locale\en-US\_Funkystation\chat\highlights.ftl`
- Added autofill chat highlights for Magistrate, Nanotrasen Representative, and Internal Affairs Agent

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- add: Added autofill highlights for Magistrate, Nanotrasen Representative, and Internal Affairs Agents
