### PR TITLE
Adds the minidragon as a wizard familiar

### DIFF
--- a/Content.IntegrationTests/Tests/_Funkystation/WizardFamiliar/WizardFamiliarTest.cs
+++ b/Content.IntegrationTests/Tests/_Funkystation/WizardFamiliar/WizardFamiliarTest.cs
@@ -1,0 +1,259 @@
+#nullable enable
+using System.Linq;
+using System.Numerics;
+using Content.IntegrationTests.Pair;
+using Content.Server._Funkystation.WizardFamiliar;
+using Content.Shared.Actions;
+using Content.Shared.Damage;
+using Content.Shared.Damage.Prototypes;
+using Content.Shared.Damage.Systems;
+using Content.Shared.FixedPoint;
+using Content.Shared.Mobs.Systems;
+using Content.Shared.NPC.Components;
+using Content.Shared.NPC.Systems;
+using Robust.Shared.GameObjects;
+using Robust.Shared.Map;
+using Robust.Shared.Prototypes;
+using Robust.Shared.Timing;
+
+namespace Content.IntegrationTests.Tests._Funkystation.WizardFamiliar;
+
+[TestFixture]
+public sealed class WizardFamiliarTest
+{
+    [Test]
+    public async Task SummonCreatesFamiliarWithCorrectComponents()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings
+        {
+            Dirty = true,
+            InLobby = false,
+            DummyTicker = false,
+        });
+
+        var server = pair.Server;
+        var testMap = await pair.CreateTestMap();
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var timing = server.ResolveDependency<IGameTiming>();
+        var actionSys = entMan.System<SharedActionsSystem>();
+        var factionSys = entMan.System<NpcFactionSystem>();
+
+        EntityUid wizard = default;
+        EntityUid? summonActionId = null;
+
+        await server.WaitPost(() =>
+        {
+            wizard = entMan.SpawnEntity("MobHuman", testMap.GridCoords);
+            summonActionId = actionSys.AddAction(wizard, "ActionSummonMiniDragon");
+            Assert.That(summonActionId, Is.Not.Null);
+            Assert.That(entMan.TryGetComponent(summonActionId!.Value, out InstantActionComponent? instantAction), Is.True);
+            actionSys.SetUseDelay(summonActionId.Value, null);
+            actionSys.PerformAction(wizard, null, summonActionId.Value, instantAction!, instantAction!.Event, timing.CurTime);
+        });
+
+        await server.WaitRunTicks(5);
+
+        await server.WaitAssertion(() =>
+        {
+            var familiars = entMan.EntityQuery<WizardFamiliarComponent>()
+                .Where(c => c.Wizard == wizard)
+                .Select(e => e.Owner)
+                .ToList();
+            Assert.That(familiars, Has.Count.EqualTo(1), "Exactly one familiar should exist");
+
+            var familiar = familiars[0];
+            Assert.That(entMan.GetComponent<MetaDataComponent>(familiar).EntityPrototype?.ID, Is.EqualTo("MobMiniDragonFamiliar"));
+
+            var familiarComp = entMan.GetComponent<WizardFamiliarComponent>(familiar);
+            Assert.That(familiarComp.Wizard, Is.EqualTo(wizard));
+
+            Assert.That(factionSys.IsIgnored(new Entity<FactionExceptionComponent?>(familiar, null), wizard), Is.True, "Wizard should be in familiar's FactionException.Ignored");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task SecondSummonBlockedWhileFirstAlive()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings
+        {
+            Dirty = true,
+            InLobby = false,
+            DummyTicker = false,
+        });
+
+        var server = pair.Server;
+        var testMap = await pair.CreateTestMap();
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var timing = server.ResolveDependency<IGameTiming>();
+        var actionSys = entMan.System<SharedActionsSystem>();
+
+        EntityUid wizard = default;
+        EntityUid? summonActionId = null;
+
+        await server.WaitPost(() =>
+        {
+            wizard = entMan.SpawnEntity("MobHuman", testMap.GridCoords);
+            summonActionId = actionSys.AddAction(wizard, "ActionSummonMiniDragon");
+            Assert.That(summonActionId, Is.Not.Null);
+            Assert.That(entMan.TryGetComponent(summonActionId!.Value, out InstantActionComponent? instantAction), Is.True);
+            actionSys.SetUseDelay(summonActionId.Value, null);
+            actionSys.PerformAction(wizard, null, summonActionId.Value, instantAction!, instantAction!.Event, timing.CurTime);
+        });
+
+        await server.WaitRunTicks(5);
+
+        await server.WaitPost(() =>
+        {
+            Assert.That(entMan.TryGetComponent(summonActionId!.Value, out InstantActionComponent? instantAction), Is.True);
+            actionSys.SetUseDelay(summonActionId.Value, null);
+            actionSys.PerformAction(wizard, null, summonActionId.Value, instantAction!, instantAction!.Event, timing.CurTime);
+        });
+
+        await server.WaitRunTicks(5);
+
+        await server.WaitAssertion(() =>
+        {
+            var familiars = entMan.EntityQuery<WizardFamiliarComponent>()
+                .Where(c => c.Wizard == wizard && !entMan.System<MobStateSystem>().IsDead(c.Owner))
+                .Select(e => e.Owner)
+                .ToList();
+            Assert.That(familiars, Has.Count.EqualTo(1), "Still only one living familiar after second summon attempt");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task FamiliarDeathTriggersCooldown()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings
+        {
+            Dirty = true,
+            InLobby = false,
+            DummyTicker = false,
+        });
+
+        var server = pair.Server;
+        var testMap = await pair.CreateTestMap();
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var timing = server.ResolveDependency<IGameTiming>();
+        var actionSys = entMan.System<SharedActionsSystem>();
+        var damageSys = entMan.System<DamageableSystem>();
+        var mobStateSys = entMan.System<MobStateSystem>();
+        var protoMan = server.ResolveDependency<IPrototypeManager>();
+
+        EntityUid wizard = default;
+        EntityUid? summonActionId = null;
+        EntityUid familiar = default;
+
+        await server.WaitPost(() =>
+        {
+            wizard = entMan.SpawnEntity("MobHuman", testMap.GridCoords);
+            summonActionId = actionSys.AddAction(wizard, "ActionSummonMiniDragon");
+            Assert.That(summonActionId, Is.Not.Null);
+            Assert.That(entMan.TryGetComponent(summonActionId!.Value, out InstantActionComponent? instantAction), Is.True);
+            actionSys.SetUseDelay(summonActionId.Value, null);
+            actionSys.PerformAction(wizard, null, summonActionId.Value, instantAction!, instantAction!.Event, timing.CurTime);
+        });
+
+        await server.WaitRunTicks(5);
+
+        await server.WaitPost(() =>
+        {
+            familiar = entMan.EntityQuery<WizardFamiliarComponent>()
+                .Where(c => c.Wizard == wizard)
+                .Select(e => e.Owner)
+                .First();
+            var damage = new DamageSpecifier(protoMan.Index<DamageGroupPrototype>("Toxin"), FixedPoint2.New(100000));
+            damageSys.TryChangeDamage(familiar, damage, true);
+        });
+
+        await server.WaitRunTicks(5);
+
+        await server.WaitAssertion(() =>
+        {
+            Assert.That(mobStateSys.IsDead(familiar), Is.True);
+            var action = entMan.GetComponent<InstantActionComponent>(summonActionId!.Value);
+            Assert.That(action.Cooldown, Is.Not.Null, "Summon action should have cooldown after familiar death");
+            Assert.That(action.Cooldown!.Value.End, Is.GreaterThan(timing.CurTime));
+        });
+
+        await pair.CleanReturnAsync();
+    }
+
+    [Test]
+    public async Task TeleportActionMovesFamiliarToWizard()
+    {
+        await using var pair = await PoolManager.GetServerClient(new PoolSettings
+        {
+            Dirty = true,
+            InLobby = false,
+            DummyTicker = false,
+        });
+
+        var server = pair.Server;
+        var testMap = await pair.CreateTestMap();
+        var entMan = server.ResolveDependency<IEntityManager>();
+        var timing = server.ResolveDependency<IGameTiming>();
+        var actionSys = entMan.System<SharedActionsSystem>();
+        var transformSys = entMan.System<SharedTransformSystem>();
+
+        EntityUid wizard = default;
+        EntityUid familiar = default;
+        EntityUid teleportActionId = default;
+
+        await server.WaitPost(() =>
+        {
+            wizard = entMan.SpawnEntity("MobHuman", testMap.GridCoords);
+            var summonActionId = actionSys.AddAction(wizard, "ActionSummonMiniDragon");
+            Assert.That(summonActionId, Is.Not.Null);
+            Assert.That(entMan.TryGetComponent(summonActionId!.Value, out InstantActionComponent? instantAction), Is.True);
+            actionSys.SetUseDelay(summonActionId.Value, null);
+            actionSys.PerformAction(wizard, null, summonActionId.Value, instantAction!, instantAction!.Event, timing.CurTime);
+        });
+
+        await server.WaitRunTicks(5);
+
+        await server.WaitPost(() =>
+        {
+            familiar = entMan.EntityQuery<WizardFamiliarComponent>()
+                .Where(c => c.Wizard == wizard)
+                .Select(e => e.Owner)
+                .First();
+            var familiarActions = entMan.GetComponent<ActionsComponent>(familiar);
+            teleportActionId = familiarActions.Actions
+                .FirstOrDefault(a =>
+                    entMan.TryGetComponent(a, out MetaDataComponent? m) &&
+                    m.EntityPrototype?.ID == "ActionMiniDragonTeleportToWizard");
+            Assert.That(teleportActionId, Is.Not.EqualTo(EntityUid.Invalid), "Familiar should have teleport action");
+        });
+
+        await server.WaitPost(() =>
+        {
+            transformSys.SetCoordinates(wizard, testMap.GridCoords.Offset(new Vector2(5, 5)));
+        });
+
+        await server.WaitRunTicks(5);
+
+        await server.WaitPost(() =>
+        {
+            Assert.That(entMan.TryGetComponent(teleportActionId, out InstantActionComponent? teleportAction), Is.True);
+            actionSys.SetUseDelay(teleportActionId, null);
+            actionSys.PerformAction(familiar, null, teleportActionId, teleportAction!, teleportAction!.Event, timing.CurTime);
+        });
+
+        await server.WaitRunTicks(5);
+
+        await server.WaitAssertion(() =>
+        {
+            var wizardPos = entMan.GetComponent<TransformComponent>(wizard).Coordinates;
+            var familiarPos = entMan.GetComponent<TransformComponent>(familiar).Coordinates;
+            Assert.That(familiarPos.EntityId, Is.EqualTo(wizardPos.EntityId), "Familiar should be on same grid as wizard");
+            Assert.That((familiarPos.Position - wizardPos.Position).Length(), Is.LessThan(1f), "Familiar should be near wizard after teleport");
+        });
+
+        await pair.CleanReturnAsync();
+    }
+}

--- a/Content.IntegrationTests/Tests/_Funkystation/WizardFamiliar/WizardFamiliarTest.cs
+++ b/Content.IntegrationTests/Tests/_Funkystation/WizardFamiliar/WizardFamiliarTest.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 Terkala <appleorange64@gmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 #nullable enable
 using System.Linq;
 using System.Numerics;

--- a/Content.Server/_Funkystation/WizardFamiliar/WizardFamiliarComponent.cs
+++ b/Content.Server/_Funkystation/WizardFamiliar/WizardFamiliarComponent.cs
@@ -1,0 +1,14 @@
+namespace Content.Server._Funkystation.WizardFamiliar;
+
+/// <summary>
+/// Marks an entity as a wizard's familiar. Stores the wizard who summoned them.
+/// </summary>
+[RegisterComponent]
+public sealed partial class WizardFamiliarComponent : Component
+{
+    /// <summary>
+    /// The wizard who summoned this familiar.
+    /// </summary>
+    [DataField]
+    public EntityUid? Wizard;
+}

--- a/Content.Server/_Funkystation/WizardFamiliar/WizardFamiliarComponent.cs
+++ b/Content.Server/_Funkystation/WizardFamiliar/WizardFamiliarComponent.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 Terkala <appleorange64@gmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 namespace Content.Server._Funkystation.WizardFamiliar;
 
 /// <summary>

--- a/Content.Server/_Funkystation/WizardFamiliar/WizardFamiliarSystem.cs
+++ b/Content.Server/_Funkystation/WizardFamiliar/WizardFamiliarSystem.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 Terkala <appleorange64@gmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using System.Numerics;
 using Content.Server.NPC;
 using Content.Server.NPC.Components;

--- a/Content.Server/_Funkystation/WizardFamiliar/WizardFamiliarSystem.cs
+++ b/Content.Server/_Funkystation/WizardFamiliar/WizardFamiliarSystem.cs
@@ -1,0 +1,134 @@
+using System.Numerics;
+using Content.Server.NPC;
+using Content.Server.NPC.Components;
+using Content.Server.NPC.HTN;
+using Content.Server.NPC.Systems;
+using Content.Server.Popups;
+using Content.Shared.Actions;
+using Content.Shared.Coordinates.Helpers;
+using Content.Shared.Magic.Events;
+using Content.Shared.Mobs;
+using Content.Shared.Mobs.Systems;
+using Content.Shared.NPC.Systems;
+using Content.Shared.Physics;
+using Content.Shared._Funkystation.WizardFamiliar;
+using Robust.Shared.Localization;
+using Robust.Shared.Map;
+
+namespace Content.Server._Funkystation.WizardFamiliar;
+
+public sealed class WizardFamiliarSystem : EntitySystem
+{
+    [Dependency] private readonly NPCSystem _npc = default!;
+    [Dependency] private readonly NpcFactionSystem _faction = default!;
+    [Dependency] private readonly SharedActionsSystem _actions = default!;
+    [Dependency] private readonly MobStateSystem _mobState = default!;
+    [Dependency] private readonly PopupSystem _popup = default!;
+    [Dependency] private readonly SharedTransformSystem _transform = default!;
+    [Dependency] private readonly IMapManager _mapManager = default!;
+
+    private const string SummonActionPrototype = "ActionSummonMiniDragon";
+    private const string TeleportActionPrototype = "ActionMiniDragonTeleportToWizard";
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<InstantSpawnSpellEvent>(OnInstantSpawnSpell, before: [typeof(Content.Shared.Magic.SharedMagicSystem)]);
+        SubscribeLocalEvent<WizardFamiliarComponent, MobStateChangedEvent>(OnFamiliarDeath);
+        SubscribeLocalEvent<WizardFamiliarComponent, MiniDragonTeleportToWizardEvent>(OnTeleportToWizard);
+    }
+
+    private void OnInstantSpawnSpell(InstantSpawnSpellEvent args)
+    {
+        if (args.Handled || args.Prototype != "MobMiniDragonFamiliar")
+            return;
+
+        var performer = args.Performer;
+
+        // Block if wizard already has a living familiar
+        var query = EntityQueryEnumerator<WizardFamiliarComponent>();
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            if (comp.Wizard != performer)
+                continue;
+            if (_mobState.IsDead(uid))
+                continue;
+
+            _popup.PopupEntity(Loc.GetString("wizard-familiar-already-summoned"), performer, performer);
+            args.Handled = true;
+            return;
+        }
+
+        var transform = Transform(performer);
+        var spawnPos = transform.Coordinates;
+        var dragon = Spawn("MobMiniDragonFamiliar", spawnPos.SnapToGrid(EntityManager, _mapManager));
+
+        EnsureComp<PreventCollideComponent>(dragon).Uid = performer;
+
+        if (TryComp<WizardFamiliarComponent>(dragon, out var familiarComp))
+        {
+            familiarComp.Wizard = performer;
+        }
+
+        _faction.IgnoreEntity((dragon, null), (performer, null));
+
+        if (TryComp<HTNComponent>(dragon, out var htn))
+            _npc.SetBlackboard(dragon, NPCBlackboard.FollowTarget, new EntityCoordinates(performer, Vector2.Zero), htn);
+
+        _actions.AddAction(dragon, TeleportActionPrototype);
+
+        args.Handled = true;
+    }
+
+    private void OnFamiliarDeath(EntityUid uid, WizardFamiliarComponent component, MobStateChangedEvent args)
+    {
+        if (args.NewMobState != MobState.Dead)
+            return;
+
+        var wizard = component.Wizard;
+        if (!wizard.HasValue || !Exists(wizard.Value))
+            return;
+
+        if (!TryComp<ActionsComponent>(wizard.Value, out var actions))
+            return;
+
+        foreach (var actionId in actions.Actions)
+        {
+            if (!TryComp(actionId, out MetaDataComponent? meta))
+                continue;
+            if (meta.EntityPrototype?.ID != SummonActionPrototype)
+                continue;
+
+            _actions.SetCooldown(actionId, TimeSpan.FromMinutes(10));
+            break;
+        }
+    }
+
+    private void OnTeleportToWizard(EntityUid uid, WizardFamiliarComponent component, MiniDragonTeleportToWizardEvent args)
+    {
+        if (args.Handled)
+            return;
+
+        var wizard = component.Wizard;
+        if (!wizard.HasValue || !Exists(wizard.Value) || Deleted(wizard.Value))
+        {
+            _popup.PopupEntity(Loc.GetString("wizard-familiar-wizard-gone"), uid, uid);
+            args.Handled = true;
+            return;
+        }
+
+        var wizardXform = Transform(wizard.Value);
+        var dragonXform = Transform(uid);
+        if (wizardXform.MapID != dragonXform.MapID)
+        {
+            _popup.PopupEntity(Loc.GetString("wizard-familiar-wizard-gone"), uid, uid);
+            args.Handled = true;
+            return;
+        }
+
+        _transform.SetCoordinates(uid, wizardXform.Coordinates);
+        _transform.AttachToGridOrMap(uid, dragonXform);
+        args.Handled = true;
+    }
+}

--- a/Content.Shared/_Funkystation/WizardFamiliar/MiniDragonTeleportToWizardEvent.cs
+++ b/Content.Shared/_Funkystation/WizardFamiliar/MiniDragonTeleportToWizardEvent.cs
@@ -1,0 +1,7 @@
+using Content.Shared.Actions;
+
+namespace Content.Shared._Funkystation.WizardFamiliar;
+
+public sealed partial class MiniDragonTeleportToWizardEvent : InstantActionEvent
+{
+}

--- a/Content.Shared/_Funkystation/WizardFamiliar/MiniDragonTeleportToWizardEvent.cs
+++ b/Content.Shared/_Funkystation/WizardFamiliar/MiniDragonTeleportToWizardEvent.cs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 Terkala <appleorange64@gmail.com>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
 using Content.Shared.Actions;
 
 namespace Content.Shared._Funkystation.WizardFamiliar;

--- a/Resources/Locale/en-US/_Funkystation/ghost/roles/ghost-role-component.ftl
+++ b/Resources/Locale/en-US/_Funkystation/ghost/roles/ghost-role-component.ftl
@@ -31,6 +31,10 @@ ghost-role-information-mini-dragon-rules = You are a Mini Dragon. You want to ga
                                         You are allowed to remember knowledge about the game in general, such as how to cook, how to use objects, etc.
                                         You are absolutely [color=red]NOT[/color] allowed to remember, say, the name, appearance, etc. of your previous character.
 
+ghost-role-information-mini-dragon-familiar-name = Wizard's Mini Dragon Familiar
+ghost-role-information-mini-dragon-familiar-description = A mini dragon summoned by a wizard to serve as a loyal familiar.
+ghost-role-information-mini-dragon-familiar-rules = You are a wizard's familiar. Follow your wizard's commands.
+
 ghost-role-information-mini-dragon-friendly-name = Domesticated Mini Dragon
 ghost-role-information-mini-dragon-friendly-description = A small dragon-like creature that likes to create hoards. This one seems to have been domesticated!
 ghost-role-information-mini-dragon-friendly-rules = You are a Domesticated Mini Dragon. Help the crew gather wealth!

--- a/Resources/Locale/en-US/_Funkystation/wizard-familiar/wizard-familiar.ftl
+++ b/Resources/Locale/en-US/_Funkystation/wizard-familiar/wizard-familiar.ftl
@@ -1,0 +1,2 @@
+wizard-familiar-already-summoned = You already have a living familiar!
+wizard-familiar-wizard-gone = Your wizard is no longer available.

--- a/Resources/Locale/en-US/actions/actions/dragon.ftl
+++ b/Resources/Locale/en-US/actions/actions/dragon.ftl
@@ -15,3 +15,6 @@ devour-action-popup-message-fail-target-not-valid = That doesn't look particular
 devour-action-popup-message-fail-target-alive = You can't consume creatures that are alive!
 
 dragon-spawn-action-popup-message-fail-no-eggs = You don't have the stamina to do that!
+
+action-mini-dragon-teleport-to-wizard-name = Teleport to Wizard
+action-mini-dragon-teleport-to-wizard-description = Teleport to your wizard master's location.

--- a/Resources/Locale/en-US/store/spellbook-catalog.ftl
+++ b/Resources/Locale/en-US/store/spellbook-catalog.ftl
@@ -82,6 +82,9 @@ spellbook-staff-animation-description = Bring inanimate objects to life!
 
 # Events
 
+spellbook-event-summon-mini-dragon-name = Summon Mini Dragon
+spellbook-event-summon-mini-dragon-description = Summon a loyal mini dragon familiar to aid you in your magical endeavors.
+
 spellbook-event-summon-ghosts-name = Summon Ghosts
 spellbook-event-summon-ghosts-description = Who ya gonna call?
 

--- a/Resources/Prototypes/Catalog/spellbook_catalog.yml
+++ b/Resources/Prototypes/Catalog/spellbook_catalog.yml
@@ -3,10 +3,10 @@
 # SPDX-FileCopyrightText: 2024 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 NathanRosica <nathanrosica@gmail.com>
 # SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
-# SPDX-FileCopyrightText: 2025 Terkala <appleorange64@gmail.com>
 # SPDX-FileCopyrightText: 2025 pa.pecherskij <pa.pecherskij@interfax.ru>
 # SPDX-FileCopyrightText: 2025 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2026 Terkala <appleorange64@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 

--- a/Resources/Prototypes/Catalog/spellbook_catalog.yml
+++ b/Resources/Prototypes/Catalog/spellbook_catalog.yml
@@ -279,6 +279,19 @@
 
 # Event
 - type: listing
+  id: SpellbookEventSummonMiniDragon
+  name: spellbook-event-summon-mini-dragon-name
+  description: spellbook-event-summon-mini-dragon-description
+  productAction: ActionSummonMiniDragon
+  cost:
+    WizCoin: 0
+  categories:
+  - SpellbookEvents
+  conditions:
+  - !type:ListingLimitedStockCondition
+    stock: 1
+
+- type: listing
   id: SpellbookEventSummonGhosts
   name: spellbook-event-summon-ghosts-name
   description: spellbook-event-summon-ghosts-description

--- a/Resources/Prototypes/GameRules/pests.yml
+++ b/Resources/Prototypes/GameRules/pests.yml
@@ -8,6 +8,7 @@
 # SPDX-FileCopyrightText: 2025 empty0set <empty0set@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2026 Terkala <appleorange64@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 

--- a/Resources/Prototypes/GameRules/pests.yml
+++ b/Resources/Prototypes/GameRules/pests.yml
@@ -27,7 +27,6 @@
     children:
     - id: KingRatMigration
     - id: SnailMigration
-    - id: MiniDragonMigration
 
 # events
 
@@ -77,24 +76,7 @@
     - id: SpawnPointGhostRatKing
       prob: 0.001
     
-# Funky Start
-- type: entity
-  id: MiniDragonMigration
-  parent: BaseStationEventLongDelay #funky
-  components:
-  - type: StationEvent
-    earliestStart: 15
-    weight: 3
-    duration: 20
-    minimumPlayers: 1
-  - type: VentCrittersRule
-    min: 1 # DeltaV
-    max: 3 # DeltaV
-    playerRatio: 70 # DeltaV: Mostly ignore player scaling
-    table: !type:GroupSelector # DeltaV: EntityTable instead of spawn entries
-      children:
-      - id: SpawnPointGhostMiniDragon
-# Funky End
+# MiniDragonMigration removed: mini-dragon is now a wizard familiar (SpellbookEvents)
 
 - type: entity
   id: CockroachMigration

--- a/Resources/Prototypes/Magic/event_spells.yml
+++ b/Resources/Prototypes/Magic/event_spells.yml
@@ -11,6 +11,36 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 
 - type: entity
+  id: ActionSummonMiniDragon
+  name: Summon Mini Dragon
+  description: Summons a loyal mini dragon familiar to aid you in your magical endeavors.
+  components:
+  - type: Magic
+    requiresClothes: true
+  - type: InstantAction
+    useDelay: 600
+    itemIconStyle: BigAction
+    icon:
+      sprite: _Funkystation/Mobs/Pets/minidragon.rsi
+      state: icon
+    event: !type:InstantSpawnSpellEvent
+      prototype: MobMiniDragonFamiliar
+      posData: !type:TargetCasterPos
+
+- type: entity
+  id: ActionMiniDragonTeleportToWizard
+  name: Teleport to Wizard
+  description: Teleport to your wizard master's location.
+  components:
+  - type: InstantAction
+    useDelay: 300
+    itemIconStyle: BigAction
+    icon:
+      sprite: Objects/Magic/magicactions.rsi
+      state: blink
+    event: !type:MiniDragonTeleportToWizardEvent
+
+- type: entity
   id: ActionSummonGhosts
   name: Summon Ghosts
   description: Makes all current ghosts permanently visible

--- a/Resources/Prototypes/Magic/event_spells.yml
+++ b/Resources/Prototypes/Magic/event_spells.yml
@@ -4,9 +4,10 @@
 # SPDX-FileCopyrightText: 2024 metalgearsloth <31366439+metalgearsloth@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 NathanRosica <nathanrosica@gmail.com>
 # SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
-# SPDX-FileCopyrightText: 2025 Terkala <appleorange64@gmail.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2026 Terkala <appleorange64@gmail.com>
 # SPDX-FileCopyrightText: 2026 W.xyz() <84605679+pirakaplant@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2026 w.xyz() <84605679+pirakaplant@users.noreply.github.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 

--- a/Resources/Prototypes/_Funkystation/Entities/Mobs/Player/minidragon.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Mobs/Player/minidragon.yml
@@ -230,3 +230,48 @@
       factions:
       - Passive
     - type: FactionException
+
+- type: entity
+  name: wizard's mini dragon familiar
+  parent: BaseMobMiniDragon
+  id: MobMiniDragonFamiliar
+  description: A mini dragon summoned by a wizard to serve as a loyal familiar. It follows its master's commands.
+  components:
+    - type: Sprite
+      layers:
+      - map: [ "enum.DamageStateVisualLayers.Base" ]
+        state: alive
+      - map: [ "enum.DamageStateVisualLayers.BaseUnshaded" ]
+        state: mouth
+        shader: unshaded
+    - type: RandomSprite
+      available:
+      - enum.DamageStateVisualLayers.Base:
+          alive: Rainbow
+        enum.DamageStateVisualLayers.BaseUnshaded:
+          mouth: ""
+    - type: GhostRole
+      prob: 1
+      makeSentient: true
+      allowSpeech: true
+      allowMovement: true
+      name: ghost-role-information-mini-dragon-familiar-name
+      description: ghost-role-information-mini-dragon-familiar-description
+      rules: ghost-role-information-mini-dragon-familiar-rules
+      raffle:
+        settings: default
+      mindRoles:
+      - MindRoleGhostRoleFamiliar
+    - type: GhostTakeoverAvailable
+    - type: NpcFactionMember
+      factions:
+      - Wizard
+    - type: FactionException
+    - type: WizardFamiliar
+    - type: HTN
+      rootTask:
+        task: DragonCarpCompound
+      blackboard:
+        NavSmash: !type:Bool
+          true
+    - type: Actions

--- a/Resources/Prototypes/_Funkystation/Entities/Mobs/Player/minidragon.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Mobs/Player/minidragon.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2026 SigmaTheDragon <162711378+SigmaTheDragon@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2026 Terkala <appleorange64@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Removed Minidragon from the event pool. It's now a wizard event spell. It summons a mini-dragon, that is a ghost role. The minidragon has a spell to teleport it to the wizard (if on same map, ie: both on station), incase it gets separated.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Mini-dragon behavior wasn't really working out with their intended role. So instead of removing them, the wizard now gets a familiar.

## Technical details
<!-- Summary of code changes for easier review. -->
Added 2 spells, and a little system that tracks who summoned the dragon so it can teleport to its master.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Terkala
- tweak: Mini-Dragons are now a 0 cost Wizard Familiar, and no longer spawn via events.
