### PR TITLE
An additional jug of chlorine for Chemvends

### DIFF
--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
@@ -12,6 +12,7 @@
 # SPDX-FileCopyrightText: 2025 pa.pecherskij <pa.pecherskij@interfax.ru>
 # SPDX-FileCopyrightText: 2025 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2026 WhityCyssius <pkmnwhity@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
@@ -25,7 +25,7 @@
     BoxBeaker: 1
     JugAluminium: 2
     JugCarbon: 4
-    JugChlorine: 1
+    JugChlorine: 2
     JugCopper: 2
     JugEthanol: 2
     JugFluorine: 1
@@ -62,7 +62,7 @@
     BoxBeaker: 1
     JugAluminium: 2
     JugCarbon: 4
-    JugChlorine: 1
+    JugChlorine: 2
     JugCopper: 2
     JugEthanol: 2
     JugFluorine: 1

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/chemvend.yml
@@ -5,6 +5,7 @@
 # SPDX-FileCopyrightText: 2024 Tadeo <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2024 wafehling <wafehling@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 Fenn <162015305+TooSillyFennec@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2025 MaiaArai <158123176+YaraaraY@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 QueerCats <jansencheng3@gmail.com>
 # SPDX-FileCopyrightText: 2025 Tay <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2025 YaraaraY <158123176+YaraaraY@users.noreply.github.com>
@@ -13,6 +14,7 @@
 # SPDX-FileCopyrightText: 2025 slarticodefast <161409025+slarticodefast@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
 # SPDX-FileCopyrightText: 2026 WhityCyssius <pkmnwhity@gmail.com>
+# SPDX-FileCopyrightText: 2026 whitycyssius <pkmnwhity@gmail.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 


### PR DESCRIPTION

<!-- LICENSE: AGPL-->
## About the PR

An extra jug of chlorine, totaling two jugs, has been added to chemvends

## Why / Balance

The main thought process about this change was about certain chemical reactions that someone might require in a given round and how long it takes to restock them. Currently, Chemical Dispensers have 200u of chlorine inside them. In a typical round of around 2-3 chemists, this gives each chemist around 200u of chlorine to work with plus whatever they can share with the single jug of chlorine inside the Chemvend. For any reason chlorine might run out, such as specific chemicals requested on a large-scale _(EX: Phalanxamine, Lenturi, Saline etc.)_, this requires chemists to usually order either an entire restock of the Chemvend machine for chlorine, buy specific chemical block crates or result in alternative sources for chlorine, which can simply be resolved by adding an extra jug of chlorine to Chemvends in the first place.

**This simple change makes it so chemists in a given round don't have to waste time trying to find chlorine or wait around for restocks and instead get straight to making chemicals.**

## Technical details

Within the "chemvend.yml" file, increased the JugChlorine amount by 1, totalling 2.

## Media


The Video below showcases the Chemvend spawning with two chlorine jugs & restocking with two chlorine jugs.

https://github.com/user-attachments/assets/8f23ae8e-77cf-4bf7-9573-dbb6731be4fa



## Requirements

- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.


## Breaking changes
None

**Changelog**
:cl: WhityCyssius
- tweak: An extra jug of chlorine for Chemvends has been added.

