### PR TITLE
Frontal lisp fixes

### DIFF
--- a/Content.Server/Speech/EntitySystems/FrontalLispSystem.cs
+++ b/Content.Server/Speech/EntitySystems/FrontalLispSystem.cs
@@ -15,11 +15,14 @@ public sealed class FrontalLispSystem : EntitySystem
     [Dependency] private readonly ReplacementAccentSystem _replacement = default!;
 
     // @formatter:off
-    private static readonly Regex RegexUpperTh = new(@"T+S+|S+C+(?=[IEY]+)|C+(?=[IEY]+)|PS+|(S+T+|T+)(?=I+O+U*N*)|C+H+(?=I*E*)|Z+|S+X+(?=E+)");
+    private static readonly Regex RegexUpperTh = new(@"T+S+(?=[\p{Lu}\W])|S+C+(?=[IEY]+)|C+(?=[IEY]+)|PS+(?=[\p{Lu}\W])|(S+T+|T+)(?=I+O+U*N*)|C+H+(?=I*E*)|Z+(?=[\p{Lu}\W])|S+(?=[\p{Lu}\W])|X+(?=E+)");
     private static readonly Regex RegexLowerTh = new(@"t+s+|s+c+(?=[iey]+)|c+(?=[iey]+)|ps+|(s+t+|t+)(?=i+o+u*n*)|c+h+(?=i*e*)|z+|s+|x+(?=e+)");
-     private static readonly Regex RegexSentenceTh = new(@"T+[Ss]+|S+[Cc]+(?=[iey]+)|C+(?=[iey]+)|P[Ss]+|(S+[Tt]+|T+)(?=i+o+u*n*)|C+h+(?=i*e*)|Z+|S+|X+(?=e+)"); // Funky
-    private static readonly Regex RegexUpperEcks = new(@"E+[Xx]+Cc*|X+");
-    private static readonly Regex RegexLowerEcks = new(@"e+x+c*|x+");
+    private static readonly Regex RegexSentenceTh = new(@"T+s+|S+c+(?=[iey]+)|C+(?=[iey]+)|Ps+|(S+T+|T+)(?=i+o+u*n*)|C+h+(?=i*e*)|Z+|S+|X+(?=e+)"); // Funky
+    private static readonly Regex RegexUpperEcks = new(@"E+[Xx]+[Cc]*|(?<![AaIiOoUu])X+(?=-*\p{Lu})"); // Funky - For edge cases like "X-ray"
+    private static readonly Regex RegexLowerEcks = new(@"e+x+c*|(?<![AaIiOoUu])x+");
+    private static readonly Regex RegexSentenceEcks = new(@"Ee*x+c*]*|(?<![AaIiOoUu])X+(?!\p{Lu})"); // Funky
+    private static readonly Regex RegexUpperEcksAfterVowel = new(@"(?=[AaIiOoUu])X+(?=\p{Lu})"); // Funky
+    private static readonly Regex RegexLowerEcksAfterVowel = new(@"(?=[AaIiOoUu])x+"); // Funky
     // @formatter:on
 
     public override void Initialize()
@@ -41,6 +44,9 @@ public sealed class FrontalLispSystem : EntitySystem
         // handles ex(c), x
         message = RegexUpperEcks.Replace(message, "EKTH");
         message = RegexLowerEcks.Replace(message, "ekth");
+        message = RegexSentenceEcks.Replace(message, "Ekth");
+        message = RegexUpperEcksAfterVowel.Replace(message, "KTH");
+        message = RegexLowerEcksAfterVowel.Replace(message, "kth");
 
         args.Message = message;
     }

--- a/Content.Server/Speech/EntitySystems/FrontalLispSystem.cs
+++ b/Content.Server/Speech/EntitySystems/FrontalLispSystem.cs
@@ -28,7 +28,7 @@ public sealed class FrontalLispSystem : EntitySystem
     public override void Initialize()
     {
         base.Initialize();
-        SubscribeLocalEvent<FrontalLispComponent, AccentGetEvent>(OnAccent);
+        SubscribeLocalEvent<FrontalLispComponent, AccentGetEvent>(OnAccent, after: new[] {typeof(BostonAccentSystem)}); // Funky - Fixes a weird conflict with the Boston accent
     }
 
     private void OnAccent(EntityUid uid, FrontalLispComponent component, AccentGetEvent args)

--- a/Content.Server/Speech/EntitySystems/FrontalLispSystem.cs
+++ b/Content.Server/Speech/EntitySystems/FrontalLispSystem.cs
@@ -11,11 +11,14 @@ namespace Content.Server.Speech.EntitySystems;
 
 public sealed class FrontalLispSystem : EntitySystem
 {
+    [Dependency] private readonly ReplacementAccentSystem _replacement = default!;
+
     // @formatter:off
-    private static readonly Regex RegexUpperTh = new(@"[T]+[Ss]+|[S]+[Cc]+(?=[IiEeYy]+)|[C]+(?=[IiEeYy]+)|[P][Ss]+|([S]+[Tt]+|[T]+)(?=[Ii]+[Oo]+[Uu]*[Nn]*)|[C]+[Hh]+(?=[Ii]*[Ee]*)|[Z]+|[S]+|[X]+(?=[Ee]+)");
-    private static readonly Regex RegexLowerTh = new(@"[t]+[s]+|[s]+[c]+(?=[iey]+)|[c]+(?=[iey]+)|[p][s]+|([s]+[t]+|[t]+)(?=[i]+[o]+[u]*[n]*)|[c]+[h]+(?=[i]*[e]*)|[z]+|[s]+|[x]+(?=[e]+)");
-    private static readonly Regex RegexUpperEcks = new(@"[E]+[Xx]+[Cc]*|[X]+");
-    private static readonly Regex RegexLowerEcks = new(@"[e]+[x]+[c]*|[x]+");
+    private static readonly Regex RegexUpperTh = new(@"T+S+|S+C+(?=[IEY]+)|C+(?=[IEY]+)|PS+|(S+T+|T+)(?=I+O+U*N*)|C+H+(?=I*E*)|Z+|S+X+(?=E+)");
+    private static readonly Regex RegexLowerTh = new(@"t+s+|s+c+(?=[iey]+)|c+(?=[iey]+)|ps+|(s+t+|t+)(?=i+o+u*n*)|c+h+(?=i*e*)|z+|s+|x+(?=e+)");
+     private static readonly Regex RegexSentenceTh = new(@"T+[Ss]+|S+[Cc]+(?=[iey]+)|C+(?=[iey]+)|P[Ss]+|(S+[Tt]+|T+)(?=i+o+u*n*)|C+h+(?=i*e*)|Z+|S+|X+(?=e+)"); // Funky
+    private static readonly Regex RegexUpperEcks = new(@"E+[Xx]+Cc*|X+");
+    private static readonly Regex RegexLowerEcks = new(@"e+x+c*|x+");
     // @formatter:on
 
     public override void Initialize()
@@ -28,9 +31,12 @@ public sealed class FrontalLispSystem : EntitySystem
     {
         var message = args.Message;
 
+        message = _replacement.ApplyReplacements(message, "lisp"); // Funky - This ReplacementAccent is under the _Funkystation namespace since it originates from here.
+
         // handles ts, sc(i|e|y), c(i|e|y), ps, st(io(u|n)), ch(i|e), z, s
         message = RegexUpperTh.Replace(message, "TH");
         message = RegexLowerTh.Replace(message, "th");
+        message = RegexSentenceTh.Replace(message, "Th");
         // handles ex(c), x
         message = RegexUpperEcks.Replace(message, "EKTH");
         message = RegexLowerEcks.Replace(message, "ekth");

--- a/Content.Server/Speech/EntitySystems/FrontalLispSystem.cs
+++ b/Content.Server/Speech/EntitySystems/FrontalLispSystem.cs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2023 dahnte <70238020+dahnte@users.noreply.github.com>
 // SPDX-FileCopyrightText: 2024 Pieter-Jan Briers <pieterjan.briers+git@gmail.com>
 // SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+// SPDX-FileCopyrightText: 2026 W.xyz() <84605679+pirakaplant@users.noreply.github.com>
 //
 // SPDX-License-Identifier: MIT
 

--- a/Resources/Locale/en-US/_Funkystation/accent/lisp.ftl
+++ b/Resources/Locale/en-US/_Funkystation/accent/lisp.ftl
@@ -1,0 +1,46 @@
+# Basically any initialism that has a "S" or "C" in it needs to be corrected
+
+accent-lisp-words-1 = cburn
+accent-lisp-words-replacement-1 = Thee-BURN
+
+accent-lisp-words-2 = cburns
+accent-lisp-words-replacement-2 = Thee-BURNs
+
+accent-lisp-words-3 = cc
+accent-lisp-words-replacement-3 = Theethee
+
+accent-lisp-words-4 = cci
+accent-lisp-words-replacement-4 = Theethee-I
+
+accent-lisp-words-5 = ccis
+accent-lisp-words-replacement-5 = Theethee-Is
+
+accent-lisp-words-6 = cco
+accent-lisp-words-replacement-6 = Theethee-O
+
+accent-lisp-words-7 = ccos
+accent-lisp-words-replacement-7 = Theethee-Os
+
+accent-lisp-words-8 = ce
+accent-lisp-words-replacement-8 = Thee-E
+
+accent-lisp-words-9 = ces
+accent-lisp-words-replacement-9 = Thee-Es
+
+accent-lisp-words-10 = cmo
+accent-lisp-words-replacement-10 = Thee-MO
+
+accent-lisp-words-11 = cmos
+accent-lisp-words-replacement-11 = Thee-MOs
+
+accent-lisp-words-12 = rcd
+accent-lisp-words-replacement-12 = R-Thee-D
+
+accent-lisp-words-13 = rcds
+accent-lisp-words-replacement-13 = R-Thee-Ds
+
+accent-lisp-words-14 = tc
+accent-lisp-words-replacement-14 = T-Thee
+
+accent-lisp-words-15 = tcs
+accent-lisp-words-replacement-15 = T-Thees

--- a/Resources/Prototypes/_Funkystation/Accents/word_replacements.yml
+++ b/Resources/Prototypes/_Funkystation/Accents/word_replacements.yml
@@ -4,7 +4,9 @@
 # SPDX-FileCopyrightText: 2025 w.xyz() <84605679+pirakaplant@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2026 Mora <46364955+TrixxedHeart@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2026 TrixxedHeart <46364955+TrixxedBit@users.noreply.github.com>
+# SPDX-FileCopyrightText: 2026 W.xyz() <84605679+pirakaplant@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2026 hey-it-stev <stev.dominions@gmail.com>
+# SPDX-FileCopyrightText: 2026 stev <steeeve.ransom@gmail.com>
 #
 # SPDX-License-Identifier: MIT
 

--- a/Resources/Prototypes/_Funkystation/Accents/word_replacements.yml
+++ b/Resources/Prototypes/_Funkystation/Accents/word_replacements.yml
@@ -1329,3 +1329,22 @@
     accent-euphemist-words-429: accent-euphemist-replacement-429
     accent-euphemist-words-430: accent-euphemist-replacement-430
     accent-euphemist-words-431: accent-euphemist-replacement-431
+
+- type: accent
+  id: lisp
+  wordReplacements:
+    accent-lisp-words-1: accent-lisp-words-replacement-1
+    accent-lisp-words-2: accent-lisp-words-replacement-2
+    accent-lisp-words-3: accent-lisp-words-replacement-3
+    accent-lisp-words-4: accent-lisp-words-replacement-4
+    accent-lisp-words-5: accent-lisp-words-replacement-5
+    accent-lisp-words-6: accent-lisp-words-replacement-6
+    accent-lisp-words-7: accent-lisp-words-replacement-7
+    accent-lisp-words-8: accent-lisp-words-replacement-8
+    accent-lisp-words-9: accent-lisp-words-replacement-9
+    accent-lisp-words-10: accent-lisp-words-replacement-10
+    accent-lisp-words-11: accent-lisp-words-replacement-11
+    accent-lisp-words-12: accent-lisp-words-replacement-12
+    accent-lisp-words-13: accent-lisp-words-replacement-13
+    accent-lisp-words-14: accent-lisp-words-replacement-14
+    accent-lisp-words-15: accent-lisp-words-replacement-15


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
LICENSE: MIT
## About the PR
<!-- What did you change? -->

The frontal lisp now plays a lot more nicely with capitalised words and all the relevant initialisms I could think of (CBURN*, CC, CCI, CCO, CE, CMO, RCD, and TC, as well as their plurals). It does have that weird thing where capitalising the initialism properly makes it look like you're yelling, but that's more of a general issue with replacement accents. It also plays better with the Boston accent because that's the only conflict I've noticed with other accents.

\* yes, CBURN is an acronym, but the first letter is still pronounced as an individual letter!

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Because I can.

## Technical details
<!-- Summary of code changes for easier review. -->

I added another regex to `FrontalLispSystem` and reorganised the existing ones a bit, both to make the accent work but also to remove the extraneous square brackets. I also made a `ReplacementAccent` for the sake of replacing initialisms. It's also coded to fire after the Boston accent to avoid "n's" getting transcribed to "n'h".

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="271" height="180" alt="Screenshot_20260321_162257" src="https://github.com/user-attachments/assets/5e6c7486-d8ab-40ee-8249-bd61a6dbd9f9" />
<img width="271" height="180" alt="Screenshot_20260321_162310" src="https://github.com/user-attachments/assets/c2b74f92-db92-4a3d-bf8c-41d64f0c60c7" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: The frontal lisp now transcribes capitalised words and initialisms better, and also works better with the Boston accent.