### PR TITLE
[FIX] Bluespace Gas Vendors are now actually usable

### DIFF
--- a/Resources/Prototypes/_Funkystation/Entities/Structures/Machines/BluespaceGas/bluespace_gas.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Structures/Machines/BluespaceGas/bluespace_gas.yml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2025 Steve <marlumpy@gmail.com>
 # SPDX-FileCopyrightText: 2025 marc-pelletier <113944176+marc-pelletier@users.noreply.github.com>
 # SPDX-FileCopyrightText: 2025 taydeo <td12233a@gmail.com>
+# SPDX-FileCopyrightText: 2026 TrixxedHeart <46364955+TrixxedBit@users.noreply.github.com>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later AND MIT
 

--- a/Resources/Prototypes/_Funkystation/Entities/Structures/Machines/BluespaceGas/bluespace_gas.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Structures/Machines/BluespaceGas/bluespace_gas.yml
@@ -123,7 +123,8 @@
           True: { state: on }
           False: { state: off }
   - type: WallMount
-    arc: 180
+    arc: 90
+    direction: 130
   - type: Destructible
     thresholds:
     - trigger:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
Bluespace Gas Vendors had the wrong `arc` and `direction` set for the `WallMount` component causing it to be unusable from basically any direction except the backside, this fixes that.

## Why / Balance
bug bad

## Technical details
Adjusted `WallMount` component in `bluespace_gas.yml` to have the proper `arc` and `direction` values, making their interaction actually work properly.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Bluespace Gas Vendors now have the correct interaction directions
