### PR TITLE
Fix Void Heretic blade crafting failing in space

### DIFF
--- a/Content.Server/_Goobstation/Heretic/Ritual/CustomBehavior.Temperature.cs
+++ b/Content.Server/_Goobstation/Heretic/Ritual/CustomBehavior.Temperature.cs
@@ -33,7 +33,12 @@ namespace Content.Server.Heretic.Ritual;
 
         var mix = _atmos.GetTileMixture(args.Platform);
 
-        if (mix == null || mix.TotalMoles == 0) // just accept space as it is
+        if (mix == null)
+            return true;
+
+        // treat near-vacuum as space
+        // because breathing can temporarily leave residual gas in space before it gets removed
+        if (mix.TotalMoles <= 0.1)
             return true;
 
         if (mix.Temperature > Atmospherics.T0C + MaxThreshold)


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Fixes an issue where Void Heretics are unable to create their void blade while in space, showing the message "it isn't cold enough in here".

This occurs because breathing produces small amounts of gas which can temporarily remain on a space tile. This residual gas increases the tile temperature and causes the ritual check to fail.

The atmos system appears to remove gas in space only after it reaches a certain threshold (0.1 moles). This change treats near-vacuum tiles as space so the ritual behaves as intended.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Simple bugfix.

## Technical details
<!-- Summary of code changes for easier review. -->
Replaced the previous space detection (`mix.TotalMoles == 0`) with a more tolerant check (`mix.TotalMoles <= 0.1`) to account for residual gas.
This is a bit of a dirty fix, but I've been told Heretics are expected to be reworked soon, so a more robust solution didn’t seem worth it for now.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

Before:
<img width="1119" height="852" alt="{FFD7DCB8-8244-487E-AEED-5993B6384F6D}" src="https://github.com/user-attachments/assets/ce4fce4b-b048-4de9-8716-a0fdf239e7f7" />

After:
<img width="1408" height="1080" alt="{0391A6E1-E914-4C98-A5B1-6BE91D2BBC71}" src="https://github.com/user-attachments/assets/330373bb-5457-4b09-aec9-aef1644fa0e1" />



## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl: WiZ88
- Fix: Fixed a bug where Void Heretics couldn't craft their blade while in space.
