### PR TITLE
Fixed Syndicate Synthesis Specialist Spawn Announcement

### DIFF
--- a/Resources/Prototypes/_DV/GameRules/unknown_shuttles.yml
+++ b/Resources/Prototypes/_DV/GameRules/unknown_shuttles.yml
@@ -62,7 +62,7 @@
   id: SynthesisSpecialist
   components:
   - type: StationEvent
-    startAnnouncement: false # Impstation no announcement
+    startAnnouncement: station-event-unknown-shuttle-incoming # Unknown shuttle announcement, changed from "false" which caused a CC announcement saying: False.
     weight: 4
     minimumPlayers: 20
     maxOccurrences: 1


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEATURE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
Made the Syndicate Synthesis Specialist spawn use the unknown shuttle announcement instead of "false"
<!-- What did you change? -->

## Why / Balance
There had to have been signs... it just announces:
CC Announcement:
False
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
One line of YAML 
<!-- Summary of code changes for easier review. -->


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ x ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ x ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

**Changelog**
:cl:
- fix: Fixed an issue that caused a Central Command announcement stating: false
