### PR TITLE
Command Gets Bourgeoisie Pens

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -1053,7 +1053,7 @@
   - type: Pda
     id: HoSIDCard
     penSlot: # Funky
-      startingItem: LuxuryPen
+      startingItem: HoloflarePen
       priority: -1
       whitelist:
         tags:

--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -590,6 +590,12 @@
   components:
   - type: Pda
     id: QuartermasterIDCard
+    penSlot: # Funky
+      startingItem: LuxuryPen
+      priority: -1
+      whitelist:
+        tags:
+        - Write
   - type: Appearance
     appearanceDataInit:
      enum.PdaVisuals.PdaType:
@@ -829,6 +835,12 @@
   components:
   - type: Pda
     id: CEIDCard
+    penSlot: # Funky
+      startingItem: LuxuryPen
+      priority: -1
+      whitelist:
+        tags:
+        - Write
   - type: Appearance
     appearanceDataInit:
      enum.PdaVisuals.PdaType:
@@ -867,6 +879,12 @@
   components:
   - type: Pda
     id: CMOIDCard
+    penSlot: # Funky
+      startingItem: LuxuryPen
+      priority: -1
+      whitelist:
+        tags:
+        - Write
   - type: Appearance
     appearanceDataInit:
      enum.PdaVisuals.PdaType:
@@ -958,6 +976,12 @@
   components:
   - type: Pda
     id: RDIDCard
+    penSlot: # Funky
+      startingItem: LuxuryPen
+      priority: -1
+      whitelist:
+        tags:
+        - Write
   - type: Appearance
     appearanceDataInit:
      enum.PdaVisuals.PdaType:
@@ -1028,6 +1052,12 @@
   components:
   - type: Pda
     id: HoSIDCard
+    penSlot: # Funky
+      startingItem: LuxuryPen
+      priority: -1
+      whitelist:
+        tags:
+        - Write
   - type: Appearance
     appearanceDataInit:
      enum.PdaVisuals.PdaType:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
LICENSE: MIT
## About the PR
<!-- What did you change? -->

Command now get luxury pens instead of regular pens in their PDAs, barring Captain and HOP since they already have their own bespoke fountain pens, and the Head of Security, who gets a holoflare pen.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

We're trying to push the head of any given department away from being "[their department's main job]+" and to more of an overseer, or dare I say it, a desk jockey. Giving Command fancier pens helps reinforce that aspect of their job more, and a nice pen is a pretty typical possession for such a position. Giving them their own unique pens would also be an option, but I didn't want to step on the toes of Captain and HOP being a cut above in the paperwork department.

## Technical details
<!-- Summary of code changes for easier review. -->

Made some changes to `pda.yml`. That's it.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="741" height="411" alt="Screenshot_20260322_223002" src="https://github.com/user-attachments/assets/f3b277c3-a019-4295-92ac-8e112604d6b0" />

<img width="811" height="481" alt="Screenshot_20260323_152328" src="https://github.com/user-attachments/assets/66049320-9eb7-4172-bf3a-76d05c05ce8a" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

N/A.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->

:cl:
- tweak: The Head of Security now starts with a holoflare pen in their PDA.
- tweak: All Command members that don't already have their own pen now start with a luxury pen in their PDAs.
