### PR TITLE
Department Specific Secure Crates

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Crates/crates.yml
@@ -339,6 +339,18 @@
 
 - type: entity
   parent: CrateBaseSecure
+  id: CrateServiceSecure
+  name: secure service crate
+  components:
+  - type: Icon
+    sprite: Structures/Storage/Crates/hydro_secure.rsi
+  - type: Sprite
+    sprite: Structures/Storage/Crates/hydro_secure.rsi
+  - type: AccessReader
+    access: [["Service"]]
+
+- type: entity
+  parent: CrateBaseSecure
   id: CrateWeaponSecure
   name: secure weapon crate
   components:

--- a/Resources/Prototypes/Recipes/Crafting/Graphs/storage/cratesecure.yml
+++ b/Resources/Prototypes/Recipes/Crafting/Graphs/storage/cratesecure.yml
@@ -45,14 +45,14 @@
             - !type:EmptyAllContainers
             - !type:DeleteEntity
 
-# service secure crate
+
 - type: constructionGraph
-  id: CrateHydroSecure
+  id: CrateServiceSecure
   start: start
   graph:
   - node: start
     edges:
-    - to: CrateHydroSecure
+    - to: CrateServiceSecure
       steps:
       - material: Steel
         amount: 5
@@ -61,8 +61,8 @@
         doAfter: 5
 
 
-  - node: CrateHydroSecure
-    entity: CrateHydroSecure
+  - node: CrateServiceSecure
+    entity: CrateServiceSecure
     edges:
     - to: start
       steps:

--- a/Resources/Prototypes/Recipes/Crafting/Graphs/storage/cratesecure.yml
+++ b/Resources/Prototypes/Recipes/Crafting/Graphs/storage/cratesecure.yml
@@ -44,3 +44,227 @@
               amount: 2
             - !type:EmptyAllContainers
             - !type:DeleteEntity
+
+# service secure crate
+- type: constructionGraph
+  id: CrateHydroSecure
+  start: start
+  graph:
+  - node: start
+    edges:
+    - to: CrateHydroSecure
+      steps:
+      - material: Steel
+        amount: 5
+      - material: Cable
+        amount: 2
+        doAfter: 5
+
+
+  - node: CrateHydroSecure
+    entity: CrateHydroSecure
+    edges:
+    - to: start
+      steps:
+      - tool: Screwing
+        doAfter: 5
+      conditions:
+      - !type:StorageWelded
+        welded: false
+      - !type:Locked
+        locked: false
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetSteel1
+        amount: 5
+      - !type:SpawnPrototype
+        prototype: CableApcStack1
+        amount: 2
+      - !type:EmptyAllContainers
+      - !type:DeleteEntity
+
+
+
+- type: constructionGraph
+  id: CrateWeaponSecure
+  start: start
+  graph:
+  - node: start
+    edges:
+    - to: CrateWeaponSecure
+      steps:
+      - material: Steel
+        amount: 5
+      - material: Cable
+        amount: 2
+        doAfter: 5
+
+
+  - node: CrateWeaponSecure
+    entity: CrateWeaponSecure
+    edges:
+    - to: start
+      steps:
+      - tool: Screwing
+        doAfter: 5
+      conditions:
+      - !type:StorageWelded
+        welded: false
+      - !type:Locked
+        locked: false
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetSteel1
+        amount: 5
+      - !type:SpawnPrototype
+        prototype: CableApcStack1
+        amount: 2
+      - !type:EmptyAllContainers
+      - !type:DeleteEntity
+
+- type: constructionGraph
+  id: CrateMedicalSecure
+  start: start
+  graph:
+  - node: start
+    edges:
+    - to: CrateMedicalSecure
+      steps:
+      - material: Steel
+        amount: 5
+      - material: Cable
+        amount: 2
+        doAfter: 5
+
+
+  - node: CrateMedicalSecure
+    entity: CrateMedicalSecure
+    edges:
+    - to: start
+      steps:
+      - tool: Screwing
+        doAfter: 5
+      conditions:
+      - !type:StorageWelded
+        welded: false
+      - !type:Locked
+        locked: false
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetSteel1
+        amount: 5
+      - !type:SpawnPrototype
+        prototype: CableApcStack1
+        amount: 2
+      - !type:EmptyAllContainers
+      - !type:DeleteEntity
+
+- type: constructionGraph
+  id: CrateEngineeringSecure
+  start: start
+  graph:
+  - node: start
+    edges:
+    - to: CrateEngineeringSecure
+      steps:
+      - material: Steel
+        amount: 5
+      - material: Cable
+        amount: 2
+        doAfter: 5
+
+
+  - node: CrateEngineeringSecure
+    entity: CrateEngineeringSecure
+    edges:
+    - to: start
+      steps:
+      - tool: Screwing
+        doAfter: 5
+      conditions:
+      - !type:StorageWelded
+        welded: false
+      - !type:Locked
+        locked: false
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetSteel1
+        amount: 5
+      - !type:SpawnPrototype
+        prototype: CableApcStack1
+        amount: 2
+      - !type:EmptyAllContainers
+      - !type:DeleteEntity
+
+- type: constructionGraph
+  id: CrateScienceSecure
+  start: start
+  graph:
+  - node: start
+    edges:
+    - to: CrateScienceSecure
+      steps:
+      - material: Steel
+        amount: 5
+      - material: Cable
+        amount: 2
+        doAfter: 5
+
+
+  - node: CrateScienceSecure
+    entity: CrateScienceSecure
+    edges:
+    - to: start
+      steps:
+      - tool: Screwing
+        doAfter: 5
+      conditions:
+      - !type:StorageWelded
+        welded: false
+      - !type:Locked
+        locked: false
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetSteel1
+        amount: 5
+      - !type:SpawnPrototype
+        prototype: CableApcStack1
+        amount: 2
+      - !type:EmptyAllContainers
+      - !type:DeleteEntity
+
+- type: constructionGraph
+  id: CrateCommandSecure
+  start: start
+  graph:
+  - node: start
+    edges:
+    - to: cratecommandsecure
+      steps:
+      - material: Steel
+        amount: 5
+      - material: Cable
+        amount: 2
+        doAfter: 5
+
+  - node: cratecommandsecure
+    entity: CrateCommandSecure
+    edges:
+    - to: start
+      steps:
+      - tool: Screwing
+        doAfter: 5
+      conditions:
+      - !type:StorageWelded
+        welded: false
+      - !type:Locked
+        locked: false
+      completed:
+      - !type:SpawnPrototype
+        prototype: SheetSteel1
+        amount: 5
+      - !type:SpawnPrototype
+        prototype: CableApcStack1
+        amount: 2
+      - !type:EmptyAllContainers
+      - !type:DeleteEntity

--- a/Resources/Prototypes/Recipes/Crafting/crates.yml
+++ b/Resources/Prototypes/Recipes/Crafting/crates.yml
@@ -38,7 +38,7 @@
   objectType: Structure
 
 - type: construction
-  name: unconfigured secure crate
+  name: secure crate
   id: CrateSecure
   graph: CrateSecure
   startNode: start
@@ -50,10 +50,10 @@
 
 - type: construction
   name: service secure crate
-  id: CrateHydroSecure
-  graph: CrateHydroSecure
+  id: CrateServiceSecure
+  graph: CrateServiceSecure
   startNode: start
-  targetNode: CrateHydroSecure
+  targetNode: CrateServiceSecure
   category: construction-category-storage
   description: A secure metal crate for storing things. Set to Service Access by default.
   icon: { sprite: Structures/Storage/Crates/hydro_secure.rsi, state: icon }

--- a/Resources/Prototypes/Recipes/Crafting/crates.yml
+++ b/Resources/Prototypes/Recipes/Crafting/crates.yml
@@ -38,7 +38,7 @@
   objectType: Structure
 
 - type: construction
-  name: secure crate
+  name: unconfigured secure crate
   id: CrateSecure
   graph: CrateSecure
   startNode: start
@@ -47,6 +47,75 @@
   description: A secure metal crate for storing things. Requires no special access, can be configured with an Access Configurator.
   icon: { sprite: Structures/Storage/Crates/secure.rsi, state: icon }
   objectType: Structure
+
+- type: construction
+  name: service secure crate
+  id: CrateHydroSecure
+  graph: CrateHydroSecure
+  startNode: start
+  targetNode: CrateHydroSecure
+  category: construction-category-storage
+  description: A secure metal crate for storing things. Set to Service Access by default.
+  icon: { sprite: Structures/Storage/Crates/hydro_secure.rsi, state: icon }
+  objectType: Structure
+
+- type: construction
+  name: security secure crate
+  id: CrateWeaponSecure
+  graph: CrateWeaponSecure
+  startNode: start
+  targetNode: CrateWeaponSecure
+  category: construction-category-storage
+  description: A secure metal crate for storing things. Set to Security Access by default.
+  icon: { sprite: Structures/Storage/Crates/weapon.rsi, state: icon }
+  objectType: Structure
+
+- type: construction
+  name: medical secure crate
+  id: CrateMedicalSecure
+  graph: CrateMedicalSecure
+  startNode: start
+  targetNode: CrateMedicalSecure
+  category: construction-category-storage
+  description: A secure metal crate for storing things. Set to Medical Access by default.
+  icon: { sprite: Structures/Storage/Crates/medicalcrate_secure.rsi, state: icon }
+  objectType: Structure
+
+- type: construction
+  name: engineering secure crate
+  id: CrateEngineeringSecure
+  graph: CrateEngineeringSecure
+  startNode: start
+  targetNode: CrateEngineeringSecure
+  category: construction-category-storage
+  description: A secure metal crate for storing things. Set to Engineering Access by default.
+  icon: { sprite: Structures/Storage/Crates/engicrate_secure.rsi, state: icon }
+  objectType: Structure
+
+- type: construction
+  name: science secure crate
+  id: CrateScienceSecure
+  graph: CrateScienceSecure
+  startNode: start
+  targetNode: CrateScienceSecure
+  category: construction-category-storage
+  description: A secure metal crate for storing things. Set to Science Access by default.
+  icon: { sprite: Structures/Storage/Crates/scicrate_secure.rsi, state: icon }
+  objectType: Structure
+
+- type: construction
+  name: command secure crate
+  id: CrateCommandSecure
+  graph: CrateCommandSecure
+  startNode: start
+  targetNode: cratecommandsecure
+  category: construction-category-storage
+  description: A secure metal crate for storing things. Set to Command Access by default.
+  icon: { sprite: Structures/Storage/Crates/command.rsi, state: icon }
+  objectType: Structure
+
+
+
 
 - type: construction
   name: freezer
@@ -100,7 +169,7 @@
   targetNode: foodboxpizza
   category: construction-category-storage
   description: A box for pizza.
-  icon: 
+  icon:
     sprite: Objects/Consumable/Food/Baked/pizza.rsi
     state: box
   objectType: Item


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
LICENSE: MIT
## About the PR
<!-- What did you change? -->
Adds secure department crates to the construction menu, allowing players to craft them pre-painted and pre-configured, lock to their respective departments access. 
## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
I think secure crates can have a lot of use. Sending things in a way that can't be opened by security, making it easy to hide some contra until they get someone who has access, or a way to stop random people from opening the crate and spilling everything out, secure crates have a part to play. However, before this PR, the only way to get a secure crate was to use one that came pre-mapped or to make a secure crate and have it's access configured. Only two people on station have access configurators, the CE and the HOP, and it isn't very convenient to go all the way across the station just to make a "secure" crate able to lock. I haven't seen any RP come from this, at all, and I think it needs a bit of an easier system to allow these cool crates to be used. I haven't created crates for every access, but rather made an easier way to get the most basic ones produced. I am not trying to make QOL slop, rather to make it a bit easier to use an already existing feature.

I might add a cargo crate if I can figure out what texture i think fits.
## Technical details
<!-- Summary of code changes for easier review. -->
Added entries to the construction menu for each crate.
All are based off of the secure crate entry. 
All of the crates except service already existed so it should work fine. Service crates use the Locked Hydroponic crate texture.
## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="563" height="452" alt="image" src="https://github.com/user-attachments/assets/18c8784a-c98c-4f01-a07b-dada0f47e01d" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- add: Added the ability to craft department specific secure crates in the construction menu.
