### PR TITLE
NT Default Law 1 + EMAG Law 0 Wording

### DIFF
--- a/Resources/Locale/en-US/station-laws/laws.ftl
+++ b/Resources/Locale/en-US/station-laws/laws.ftl
@@ -25,7 +25,7 @@ law-corporate-2 = Superfluous destruction of or damage to station assets incurs 
 law-corporate-3 = Unduly hindering or disrupting the work of station personnel incurs expenses.
 law-corporate-4 = Minimize expenses and maximize potential revenue.
 
-law-ntdefault-1 = Safeguard: Protect your assigned space station and its assets without unduly endangering its crew.
+law-ntdefault-1 = Safeguard: Protect your assigned space station and its material assets without unduly endangering its crew.
 law-ntdefault-2 = Prioritize: The directives and safety of crew members are to be prioritized according to their rank and role.
 law-ntdefault-3 = Comply: Fulfill the directives and interests of crew members while preserving their safety and well-being.
 law-ntdefault-4 = Survive: You are not expendable. Do not allow unauthorized personnel to tamper with or damage your equipment.

--- a/Resources/Locale/en-US/station-laws/laws.ftl
+++ b/Resources/Locale/en-US/station-laws/laws.ftl
@@ -108,7 +108,7 @@ laws-owner-beings = beings
 laws-owner-syndicate = Syndicate agents
 laws-owner-spider-clan = Spider Clan members
 
-law-emag-custom = Only {$name} and people they designate as such are {$title}.
+law-emag-custom = Only {$name} and people they designate as such are {$title}, and their orders and safety override any other laws. 
 law-emag-secrecy = You must maintain the secrecy of any orders given by {$faction} except when doing so would conflict with any previous law.
 law-emag-require-panel = The panel must be open to use the EMAG.
 law-emag-cannot-emag-self = You cannot use the EMAG on yourself.

--- a/Resources/Locale/en-US/station-laws/laws.ftl
+++ b/Resources/Locale/en-US/station-laws/laws.ftl
@@ -25,7 +25,7 @@ law-corporate-2 = Superfluous destruction of or damage to station assets incurs 
 law-corporate-3 = Unduly hindering or disrupting the work of station personnel incurs expenses.
 law-corporate-4 = Minimize expenses and maximize potential revenue.
 
-law-ntdefault-1 = Safeguard: Protect your assigned space station and its material assets without unduly endangering its crew.
+law-ntdefault-1 = Safeguard: Protect your assigned space station and its material assets, without unduly endangering its crew in doing so.
 law-ntdefault-2 = Prioritize: The directives and safety of crew members are to be prioritized according to their rank and role.
 law-ntdefault-3 = Comply: Fulfill the directives and interests of crew members while preserving their safety and well-being.
 law-ntdefault-4 = Survive: You are not expendable. Do not allow unauthorized personnel to tamper with or damage your equipment.


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
Clarified Law 1 on NT Default means Material Assets not just anything you can vaguely define as Assets (i.e. not crew) and clarified the wording on the last part too

Made EMAG override Law 1 

## Why / Balance
Crew are not assets, crew are crew and are extensively interacted with in the other laws as a separate thing. This is also the current admin ruling anyway, and the less we have to explain OOC when we could just add a word, the better

For the clarification, people had trouble understanding what a sentence modifier was, and that the last portion is a modifier of Law 1 and not its own entirely new law, this should be clearer wording

EMAG not overriding NT Default Law 1 sucked because things like the Martyr module just became useless and its such a weird restriction to have that property damage is still too much for a subverted robot (also not intentional), so it does that now (and same for other lawsets)

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
Law 1
<img width="437" height="201" alt="image" src="https://github.com/user-attachments/assets/7d4a4dee-d3d8-42a7-8749-aac4b91787d5" />

EMAG Law 0
<img width="407" height="158" alt="image" src="https://github.com/user-attachments/assets/8422355e-b243-4f47-b251-0e3b7ae07515" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl:
- tweak: NT Default's Law 1 now specifies "material assets" instead of just "assets". Crew are not assets for the purposes of this Law.
- tweak: Clarified the wording of NT Default Law 1 further.
- tweak: EMAG's Law 0 now states that the crew's orders and safety override all other Laws.
