### PR TITLE
fix tail and helmet suit piece clipping

### DIFF
--- a/Content.Shared/Clothing/EntitySystems/ClothingSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/ClothingSystem.cs
@@ -235,7 +235,7 @@ public abstract class ClothingSystem : EntitySystem
         args.Additive += ent.Comp.StripDelay;
     }
 
-    private void CheckEquipmentForLayerHide(EntityUid equipment, EntityUid equipee)
+    public void CheckEquipmentForLayerHide(EntityUid equipment, EntityUid equipee)
     {
         if (TryComp(equipment, out HideLayerClothingComponent? clothesComp) && TryComp(equipee, out HumanoidAppearanceComponent? appearanceComp))
             ToggleVisualLayers(equipee, clothesComp.Slots, appearanceComp.HideLayersOnEquip);

--- a/Content.Shared/Clothing/EntitySystems/MultiVisualStateSystem.cs
+++ b/Content.Shared/Clothing/EntitySystems/MultiVisualStateSystem.cs
@@ -4,12 +4,14 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 using Content.Shared.Clothing.Components;
+using Robust.Shared.Containers;
 
 namespace Content.Shared.Clothing.EntitySystems;
 
 public sealed class MultiVisualStateSystem : EntitySystem
 {
     [Dependency] private readonly ClothingSystem _clothingSystem = default!;
+    [Dependency] private readonly SharedContainerSystem _containerSys = default!;
 
     public override void Initialize()
     {
@@ -47,5 +49,8 @@ public sealed class MultiVisualStateSystem : EntitySystem
 
         _clothingSystem.SetEquippedPrefix(uid, finalPrefix);
         Dirty(uid, comp);
+
+        if (_containerSys.TryGetContainingContainer((uid, null, null), out var container))
+            _clothingSystem.CheckEquipmentForLayerHide(uid, container.Owner);
     }
 }

--- a/Content.Shared/Humanoid/HumanoidAppearanceComponent.cs
+++ b/Content.Shared/Humanoid/HumanoidAppearanceComponent.cs
@@ -96,7 +96,7 @@ public sealed partial class HumanoidAppearanceComponent : Component
     ///     Which layers of this humanoid that should be hidden on equipping a corresponding item..
     /// </summary>
     [DataField]
-    public HashSet<HumanoidVisualLayers> HideLayersOnEquip = [HumanoidVisualLayers.Hair];
+    public HashSet<HumanoidVisualLayers> HideLayersOnEquip = [HumanoidVisualLayers.Hair, HumanoidVisualLayers.Snout, HumanoidVisualLayers.HeadTop, HumanoidVisualLayers.HeadSide, HumanoidVisualLayers.Tail];
 
     /// <summary>
     /// The profile that this entity was originally spawned with.

--- a/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/arachnid.yml
@@ -140,7 +140,6 @@
       - map: [ "belt" ]
       - map: [ "id" ]
       - map: [ "outerClothing" ]
-      - map: [ "enum.HumanoidVisualLayers.Tail" ] # Mentioned in moth code: This needs renaming lol.
       - map: [ "back" ]
       - map: [ "neck" ]
       - map: [ "enum.HumanoidVisualLayers.FacialHair" ]
@@ -149,6 +148,7 @@
       - map: [ "enum.HumanoidVisualLayers.HeadTop" ]
       - map: [ "mask" ]
       - map: [ "head" ]
+      - map: [ "enum.HumanoidVisualLayers.Tail" ] # Mentioned in moth code: This needs renaming lol.
       - map: [ "pocket1" ]
       - map: [ "pocket2" ]
       - map: ["enum.HumanoidVisualLayers.Handcuffs"]

--- a/Resources/Prototypes/Entities/Mobs/Species/base.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/base.yml
@@ -541,9 +541,9 @@
     - map: [ "enum.HumanoidVisualLayers.Hair" ]
     - map: [ "enum.HumanoidVisualLayers.HeadSide" ]
     - map: [ "enum.HumanoidVisualLayers.HeadTop" ]
-    - map: [ "enum.HumanoidVisualLayers.Tail" ]
     - map: [ "mask" ]
     - map: [ "head" ]
+    - map: [ "enum.HumanoidVisualLayers.Tail" ]
     - map: [ "pocket1" ]
     - map: [ "pocket2" ]
   - type: Appearance

--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -49,6 +49,7 @@
     species: Moth
     hideLayersOnEquip:
     - HeadTop
+    - Tail
   - type: Hunger
   - type: Thirst
   - type: Icon
@@ -144,7 +145,6 @@
       - map: [ "belt" ]
       - map: [ "id" ]
       - map: [ "outerClothing" ]
-      - map: [ "enum.HumanoidVisualLayers.Tail" ] #in the utopian future we should probably have a wings enum inserted here so everyhting doesn't break
       - map: [ "back" ]
       - map: [ "neck" ]
       - map: [ "enum.HumanoidVisualLayers.FacialHair" ]
@@ -153,6 +153,7 @@
       - map: [ "enum.HumanoidVisualLayers.HeadTop" ]
       - map: [ "mask" ]
       - map: [ "head" ]
+      - map: [ "enum.HumanoidVisualLayers.Tail" ] #in the utopian future we should probably have a wings enum inserted here so everyhting doesn't break
       - map: [ "pocket1" ]
       - map: [ "pocket2" ]
       - map: [ "clownedon" ] # Dynamically generated

--- a/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
@@ -70,6 +70,7 @@
     - Snout
     - HeadTop
     - HeadSide
+    - Tail
   - type: Hunger
   - type: Puller
     needsHands: false
@@ -233,6 +234,7 @@
     - Snout
     - HeadTop
     - HeadSide
+    - Tail
   - type: Inventory
     speciesId: reptilian
     #funky start  

--- a/Resources/Prototypes/Entities/Mobs/Species/vox.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vox.yml
@@ -67,6 +67,7 @@
     hideLayersOnEquip: #imp
     - HeadSide
     - Hair
+    - Tail
     #- type: VoxAccent # Not yet coded
   - type: Speech
     speechVerb: Vox
@@ -151,9 +152,9 @@
     - map: [ "enum.HumanoidVisualLayers.Hair" ]
     - map: [ "enum.HumanoidVisualLayers.HeadSide" ]
     - map: [ "enum.HumanoidVisualLayers.HeadTop" ]
-    - map: [ "enum.HumanoidVisualLayers.Tail" ]
     - map: [ "mask" ]
     - map: [ "head" ]
+    - map: [ "enum.HumanoidVisualLayers.Tail" ]
     - map: [ "pocket1" ]
     - map: [ "pocket2" ]
     - map: [ "enum.HumanoidVisualLayers.Handcuffs" ]
@@ -274,13 +275,13 @@
     - map: [ "enum.HumanoidVisualLayers.Hair" ]
     - map: [ "enum.HumanoidVisualLayers.HeadSide" ]
     - map: [ "enum.HumanoidVisualLayers.HeadTop" ]
-    - map: [ "enum.HumanoidVisualLayers.Tail" ]
     - map: [ "mask" ]
     - map: [ "enum.PaperLabelVisuals.Layer" ] # Funky edit
       sprite: "_DV/Objects/Misc/stickies.rsi"
       state: "sticky_face-VOX"
       visible: false
     - map: [ "head" ]
+    - map: [ "enum.HumanoidVisualLayers.Tail" ]
     - map: [ "pocket1" ]
     - map: [ "pocket2" ]
     - map: [ "enum.HumanoidVisualLayers.Handcuffs" ]

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/harpy.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/harpy.yml
@@ -103,7 +103,6 @@
       - map: [ "back" ]
       - map: [ "enum.HumanoidVisualLayers.FacialHair" ]
       - map: [ "enum.HumanoidVisualLayers.HeadSide" ]
-      - map: [ "enum.HumanoidVisualLayers.Tail" ]
       - map: [ "pocket1" ]
       - map: [ "pocket2" ]
       - map: [ "clownedon" ] # Dynamically generated
@@ -121,6 +120,7 @@
       - map: [ "enum.HumanoidVisualLayers.HeadTop" ]
       - map: [ "mask" ]
       - map: [ "head" ]
+      - map: [ "enum.HumanoidVisualLayers.Tail" ]
       - map: [ "singingLayer" ]
         sprite: _DV/Effects/harpysinger.rsi
         state: singing_music_notes
@@ -234,7 +234,6 @@
       - map: [ "enum.HumanoidVisualLayers.FacialHair" ]
       - map: [ "enum.HumanoidVisualLayers.HeadSide" ]
       - map: [ "enum.HumanoidVisualLayers.HeadTop" ]
-      - map: [ "enum.HumanoidVisualLayers.Tail" ]
       - map: [ "pocket1" ]
       - map: [ "pocket2" ]
       - map: [ "clownedon" ] # Dynamically generated
@@ -251,6 +250,7 @@
       - map: [ "enum.HumanoidVisualLayers.Hair" ]
       - map: [ "mask" ]
       - map: [ "head" ]
+      - map: [ "enum.HumanoidVisualLayers.Tail" ]
 
 - type: entity
   id: ActionHarpyPlayMidi

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/rodentia.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/rodentia.yml
@@ -104,9 +104,9 @@
       - map: [ "enum.HumanoidVisualLayers.Hair" ]
       - map: [ "enum.HumanoidVisualLayers.HeadSide" ]
       - map: [ "enum.HumanoidVisualLayers.HeadTop" ]
-      - map: [ "enum.HumanoidVisualLayers.Tail" ]
       - map: [ "mask" ]
       - map: [ "head" ]
+      - map: [ "enum.HumanoidVisualLayers.Tail" ]
       - map: [ "pocket1" ]
       - map: [ "pocket2" ]
       - map: [ "clownedon" ] # Dynamically generated

--- a/Resources/Prototypes/_DV/Entities/Mobs/Species/vulpkanin.yml
+++ b/Resources/Prototypes/_DV/Entities/Mobs/Species/vulpkanin.yml
@@ -104,9 +104,9 @@
       - map: [ "enum.HumanoidVisualLayers.Hair" ]
       - map: [ "enum.HumanoidVisualLayers.HeadSide" ]
       - map: [ "enum.HumanoidVisualLayers.HeadTop" ]
-      - map: [ "enum.HumanoidVisualLayers.Tail" ]
       - map: [ "mask" ]
       - map: [ "head" ]
+      - map: [ "enum.HumanoidVisualLayers.Tail" ]
       - map: [ "pocket1" ]
       - map: [ "pocket2" ]
       - map: [ "clownedon" ] # Dynamically generated

--- a/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
+++ b/Resources/Prototypes/_EinsteinEngines/Entities/Mobs/Player/silicon_base.yml
@@ -171,9 +171,9 @@
           state: "sticky_face"
           visible: false
         - map: ["head"]
+        - map: ["enum.HumanoidVisualLayers.Tail"]
         - map: ["pocket1"]
         - map: ["pocket2"]
-        - map: ["enum.HumanoidVisualLayers.Tail"]
         - map: ["clownedon"] # Dynamically generated
           sprite: "Effects/creampie.rsi"
           state: "creampie_human"


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
Fixes a visual bug where tails would clip "under" large headwear like the Atmos hardsuit helmet. Because the head layer previously rendered on top of the Tail layer, tails appeared to stick out of hardsuits only to be visually sliced off by the bottom of the helmet. 

This PR resolves the clipping by adjusting the sprite layer render order for all tailed species, placing `enum.HumanoidVisualLayers.Tail` below the `head` layer in their `Sprite` component configuration so tails properly render over helmets.

Additionally, this PR fixes some other bugs I found while trying to fix the clipping:
1. helmets were not explicitly triggering layer-hide checks on toggle, preventing server state from updating layer visibility reliably.
2. `Tail` was missing from `HideLayersOnEquip` globally and in species overrides, preventing any future specialized clothing from natively hiding tails even if it requested to.

## Why / Balance
Fixes #3068 

## Technical details
- reordered the `Sprite` layers list in vulpkanin.yml, harpy.yml, rodentia.yml vox.yml, moth.yml, base.yml, arachnid.yml, and silicon_base.ym to move `Tail` after `head`.
- added `Tail` to defaults and `hideLayersOnEquip` overrides in reptilian.yml, moth.yml, and vox.yml
- exposed CheckEquipmentForLayerHide publicly and invoked it in `MultiVisualStateSystem.UpdateVisuals` so helmet toggles trigger proper layer updates.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="573" height="649" alt="Screenshot_20260329_195100" src="https://github.com/user-attachments/assets/20620eda-f76e-4d59-b8a5-1e3a5b45fdea" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Tails no longer visually clip underneath large helmets and hardsuits.
- fix: Toggleable hardsuit helmets now properly update their hidden visual layers over the network when toggled.
