### PR TITLE
Security equipment crates no longer have disablers in them

### DIFF
--- a/Resources/Prototypes/_Funkystation/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/_Funkystation/Catalog/Fills/Crates/armory.yml
@@ -40,8 +40,8 @@
 - type: entity
   id: CrateSecurityEquipment
   parent: CrateSecgear
-  name: security equipment crate 
-  description: Supplies for protecting and serving, contains a armor vest, helmet, flash, disabler, security glasses and belt, holobarrier projector, jackboots, seclite and the security guidebooks. Requires Security access to open.
+  name: security equipment crate
+  description: Supplies for protecting and serving. Contains a armor vest, helmet, flash, security glasses and belt, holobarrier projector, jackboots, seclite and the security guidebooks. Requires Security access to open. # Funky - updated description and also made grammar a tiny bit nicer
   components:
   - type: StorageFill
     contents:
@@ -49,7 +49,7 @@
     - id: ClothingHeadHelmetBasic
     - id: Flash
     - id: ClothingBeltSecurityFilled
-    - id: WeaponDisabler
+    #- id: WeaponDisabler # Funky
     - id: FlashlightSeclite
     - id: ClothingEyesGlassesSecurity
     - id: BookSecurity
@@ -58,7 +58,7 @@
 - type: entity
   id: CrateSecurityBasicArmor
   parent: CrateSecgear
-  name: standard armor crate 
+  name: standard armor crate
   description: Contains three sets of standard issue security armor vests and helmets. Requires Security access to open.
   components:
   - type: StorageFill


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
LICENSE: MIT
## About the PR
<!-- What did you change? -->

I commented out the disabler from the security equipment crate.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

The disabler is meant to be unobtainable now (see #2828) and this is an oversight.

## Technical details
<!-- Summary of code changes for easier review. -->

Two lines of YAML.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

<img width="423" height="442" alt="Screenshot_20260330_120442" src="https://github.com/user-attachments/assets/af0ea73a-dcd3-4bb2-b236-e1ce1fd24578" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- fix: The security equipment crate no longer has a disabler.