### PR TITLE
fix Impaired Mobility affects floating and using a jetpack

### DIFF
--- a/Content.Shared/Traits/Assorted/ImpairedMobilitySystem.cs
+++ b/Content.Shared/Traits/Assorted/ImpairedMobilitySystem.cs
@@ -2,11 +2,13 @@
 //
 // SPDX-License-Identifier: MIT
 
+using Content.Shared.Gravity;
+using Content.Shared.Hands.Components;
+using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Movement.Systems;
 using Content.Shared.Stunnable;
-using Content.Shared.Hands.EntitySystems;
-using Content.Shared.Hands.Components;
 using Content.Shared.Wieldable.Components;
+using Robust.Shared.Physics.Components;
 
 namespace Content.Shared.Traits.Assorted;
 
@@ -17,11 +19,15 @@ public sealed class ImpairedMobilitySystem : EntitySystem
 {
     [Dependency] private readonly SharedHandsSystem _hands = default!;
     [Dependency] private readonly MovementSpeedModifierSystem _speedModifier = default!;
+    [Dependency] private readonly SharedGravitySystem _gravity = default!;
+
     public override void Initialize()
     {
         SubscribeLocalEvent<ImpairedMobilityComponent, ComponentInit>(OnInit);
         SubscribeLocalEvent<ImpairedMobilityComponent, ComponentShutdown>(OnShutdown);
         SubscribeLocalEvent<ImpairedMobilityComponent, RefreshMovementSpeedModifiersEvent>(OnRefreshMovementSpeed);
+        SubscribeLocalEvent<ImpairedMobilityComponent, EntParentChangedMessage>(OnEntParentChanged);
+        SubscribeLocalEvent<GravityChangedEvent>(OnGravityChanged);
     }
 
     private void OnInit(Entity<ImpairedMobilityComponent> ent, ref ComponentInit args)
@@ -34,10 +40,30 @@ public sealed class ImpairedMobilitySystem : EntitySystem
         _speedModifier.RefreshMovementSpeedModifiers(ent);
     }
 
+    private void OnEntParentChanged(EntityUid uid, ImpairedMobilityComponent comp, ref EntParentChangedMessage args)
+    {
+        _speedModifier.RefreshMovementSpeedModifiers(uid);
+    }
+
+    private void OnGravityChanged(ref GravityChangedEvent args)
+    {
+        var query = EntityQueryEnumerator<ImpairedMobilityComponent, TransformComponent>();
+        while (query.MoveNext(out var uid, out var comp, out var xform))
+        {
+            if (xform.GridUid == args.ChangedGridIndex)
+            {
+                _speedModifier.RefreshMovementSpeedModifiers(uid);
+            }
+        }
+    }
+
     // Handles movement speed for entities with impaired mobility.
     // Applies a speed penalty, but counteracts it if the entity is holding a non-wielded mobility aid.
     private void OnRefreshMovementSpeed(Entity<ImpairedMobilityComponent> ent, ref RefreshMovementSpeedModifiersEvent args)
     {
+        if (_gravity.IsWeightless(ent))
+            return;
+
         if (HasMobilityAid(ent.Owner))
             return;
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Characters with  impaired mobility now float and fly with the jetpack with the same speed as characters without that trait without needing to use a cane.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #3082 
Why would you need a cane to go fast in zero gravity?

## Technical details
<!-- Summary of code changes for easier review. -->
- added a SharedGravitySystem dependency to ImpairedMobilitySystem.
- created a check in OnRefreshMovementSpeedModifiers that skips applying the negative SpeedModifier dynamically if _gravity.IsWeightless() evaluates to true.
- added subscribers to EntParentChangedMessage and GravityChangedEvent to properly recalculate speed modifiers specifically when characters transition into or out of zero gravity areas

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
-

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Impaired Mobility trait now does not affect floating and using a jetpack
