### PR TITLE
Borg Slash/Piercing Damage Resist Change

### DIFF
--- a/Resources/Prototypes/_Goobstation/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_Goobstation/Damage/modifier_sets.yml
@@ -13,6 +13,8 @@
 - type: damageModifierSet
   id: Silicon
   coefficients:
+    Slash: 0.8
+    Piercing: 0.8
     Heat: 0.8
   flatReductions:
     Blunt: 5

--- a/Resources/Prototypes/_Goobstation/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_Goobstation/Damage/modifier_sets.yml
@@ -16,8 +16,8 @@
     Heat: 0.8
   flatReductions:
     Blunt: 5
-    Slash: 5
-    Piercing: 5
+    Slash: 1
+    Piercing: 1
 
 - type: damageModifierSet
   id: SiliconProtected


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
Reduces Cyborg's flat damage reduction to make them more vulnerable to slashing and piercing damage. (But NOT Syndicate Assault Borg).

Their -5 flat damage reduction for slash/piercing has been altered to -1 flat damage reduction, and 20% resistances to slash and piercing. Blunt is unchanged.

## Why / Balance
Cyborgs get involved with combat a bit more on occasion, which is fine! What's less fine is how tanky and survivable they are for this purpose versus most things, especially random-generated station threats such as snakes, and some other antagonists, such as Zombies and Rat Kings (they are entirely immune to this one, basically). This heavily tones down how easily they can deal with most threats, while still maintaining their blunt resistance (punching one is still ineffective, you need some kind of weapon, including other species' claws). Most station threats that should do more to Cyborgs do small amounts of slash or piercing damage.

Borgs are still immune to tiny things such as mouse bites like this, but are not functionally immune to any creature of note otherwise. 

In lieu of their flat damage resistance, they now have a 20% reduction on slash and piercing so that they take *some* reduced damage from bigger attacks, while still accumulating damage overall whenever struck, and being more able to be damaged in a mixed fashion (such as by Zombies or Rats). The breakpoint for this being stronger than prior is a single damage type doing roughly more than 25 damage of 1 single slash/piercing damage type in a single hit, it is otherwise worse protection.

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- tweak: Cyborgs, with exception to the Syndie Assault Borg, have had their flat damage reduction against Slash and Piercing reduced from -5 to -1, making them no longer functionally immune to most smaller threats.
- tweak: Affected Cyborgs now have a -20% damage resistance to Piercing and Slash, instead of 0% resistance.
