### PR TITLE
Making blood cultists not deconvert from splashing

### DIFF
--- a/Content.Server/_Funkystation/BloodCult/EntitySystems/BloodCultistReactionSystem.cs
+++ b/Content.Server/_Funkystation/BloodCult/EntitySystems/BloodCultistReactionSystem.cs
@@ -4,7 +4,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later OR MIT
 
 using Content.Server.Fluids.EntitySystems;
-using Content.Server.GameTicking.Rules;
 using Content.Server.Body.Systems;
 using Content.Server.Body.Components;
 using Content.Server.Popups;
@@ -28,7 +27,6 @@ namespace Content.Server.BloodCult.EntitySystems;
 /// This includes:
 /// - Blood consumption (ingestion) -> causes bleeding, restores blood levels, adds to ritual pool
 /// - Sanguine Perniculate (touch) -> heals holy damage
-/// - Holy Water (touch) -> deals additional holy damage
 /// </summary>
 public sealed class BloodCultistReactionSystem : EntitySystem
 {
@@ -36,7 +34,6 @@ public sealed class BloodCultistReactionSystem : EntitySystem
 	[Dependency] private readonly DamageableSystem _damageable = default!;
 	[Dependency] private readonly PopupSystem _popup = default!;
 	[Dependency] private readonly SharedAudioSystem _audio = default!;
-	[Dependency] private readonly StaminaSystem _stamina = default!;
 
 	public override void Initialize()
 	{
@@ -63,11 +60,6 @@ public sealed class BloodCultistReactionSystem : EntitySystem
 			if (args.Reagent.ID == "SanguinePerniculate")
 			{
 				HandleSanguinePerniculateTouch(uid, ref args);
-			}
-			// Check for Holy Water damage
-			else if (args.Reagent.ID == "Holywater")
-			{
-				HandleHolyWaterTouch(uid, ref args);
 			}
 		}
 	}
@@ -165,73 +157,6 @@ public sealed class BloodCultistReactionSystem : EntitySystem
 			new SoundPathSpecifier("/Audio/Effects/lightburn.ogg"),
 			Transform(uid).Coordinates
 		);
-	}
-
-	/// <summary>
-	/// Handles HolyWater touch reactions for blood cultists.
-	/// When a cultist is splashed with holy water, they take additional holy damage and gain deconversion progress.
-	/// </summary>
-	private void HandleHolyWaterTouch(EntityUid uid, ref ReactionEntityEvent args)
-	{
-		// Calculate damage amount based on HolyWater quantity
-		// The reagent already does 0.5 Holy damage per unit via its reactiveEffects
-		// We add an additional 1.0 Holy damage per unit for cultists (total: 1.5 per unit)
-		var damageAmount = args.ReagentQuantity.Quantity.Float() * 1.0f;
-		if (damageAmount <= 0)
-			return;
-		else
-		{
-			// Apply additional holy damage to the cultist
-			// This doesn't currently actually do anything as holy damage is not currently working
-			var damageHoly = new DamageSpecifier();
-			damageHoly.DamageDict.Add("Holy", FixedPoint2.New(damageAmount));
-			_damageable.TryChangeDamage(uid, damageHoly, false, true);
-
-			// Apply additional heat damage to the cultist
-			// It only does 1/10th of the holy damage, because it shouldn't crit them from holy damage, it should just make them burned.
-			var damageHeat = new DamageSpecifier();
-			damageHeat.DamageDict.Add("Heat", FixedPoint2.New(damageAmount/10));
-			_damageable.TryChangeDamage(uid, damageHeat, false, true);
-
-			// Visual and audio feedback
-			_popup.PopupEntity(
-				Loc.GetString("cult-holywater-burn", ("amount", Math.Round(damageAmount + args.ReagentQuantity.Quantity.Float() * 0.5f, 1))),
-				uid, uid, PopupType.LargeCaution
-			);
-
-			_audio.PlayPvs(
-				new SoundPathSpecifier("/Audio/Effects/lightburn.ogg"),
-				Transform(uid).Coordinates
-			);
-		}
-
-		if (!TryComp<BloodCultistComponent>(uid, out var bloodCultist))
-			return;
-
-		// Make it so that the deCultify effect is only 25% as strong as the metabolism version, because touch effects multiply how much is being sprayed
-		// The idea is to make it so you can deconvert with a fire extinguisher, but that a cultist would probably reasonably kill you first in a fair fight.
-		var deCultifyMultiplier = .35f; 
-		
-		var scale = args.ReagentQuantity.Quantity.Float();
-		var deCultifyAmount = scale * deCultifyMultiplier;
-
-		var oldDeCultification = bloodCultist.DeCultification;
-		var newDeCultification = oldDeCultification + deCultifyAmount;
-		bloodCultist.DeCultification = newDeCultification;
-
-		// If this application causes deconversion (crosses 100 threshold), play sound and knock down
-		if (oldDeCultification < 100.0f && newDeCultification >= 100.0f)
-		{
-			// Play holy sound
-			_audio.PlayPvs(
-				new SoundPathSpecifier("/Audio/Effects/holy.ogg"),
-				uid,
-				AudioParams.Default
-			);
-
-			// Apply stamina damage to knock them down
-			_stamina.TakeStaminaDamage(uid, 100f, visual: false);
-		}
 	}
 }
 

--- a/Resources/Prototypes/Reagents/medicine.yml
+++ b/Resources/Prototypes/Reagents/medicine.yml
@@ -1340,6 +1340,13 @@
         amount: 2.5
       - !type:HealthChange
         conditions:
+        - !type:IsBloodCultist
+        ignoreResistances: false
+        damage:
+          types:
+            Heat: 1
+      - !type:HealthChange
+        conditions:
         - !type:TotalDamage
           max: 50
         damage:
@@ -1361,18 +1368,6 @@
       methods: [ Touch ]
       effects:
       - !type:ExtinguishReaction
-    CultistPurge:
-      methods: [ Touch ]
-      effects:
-      - !type:HealthChange
-        conditions:
-        - !type:IsBloodCultist
-        damage:
-          types:
-            Heat: 8
-            Holy: 5
-      - !type:DeCultify
-        amount: 2.5
     Acidic:
       methods: [ Touch ]
       effects:

--- a/Resources/Prototypes/_Funkystation/Chemistry/reactive_groups.yml
+++ b/Resources/Prototypes/_Funkystation/Chemistry/reactive_groups.yml
@@ -5,6 +5,3 @@
 
 - type: reactiveGroup
   id: Medication
-
-- type: reactiveGroup
-  id: CultistPurge

--- a/Resources/ServerInfo/Funkystation/Guidebook/Antagonist/BloodCult.xml
+++ b/Resources/ServerInfo/Funkystation/Guidebook/Antagonist/BloodCult.xml
@@ -192,11 +192,10 @@ As the cult expands, the situation aboard the station will pass through several 
 
 ## Combatting the Cult
 
-Deconverting a blood cultist can happen in four ways
-1. Is through the forced imbibement of [color=#4466ff]holy water[/color] (at least 40u).
+Deconverting a blood cultist can happen in three ways
+1. Is through the forced imbibement of [color=#4466ff]holy water[/color] (at least 50u).
 2. Is by implanting a [color=#4466ff]mindshield[/color] into the cultist.
 3. Is by throwing a container of holy water onto the blood spilled by a cult. This will form a holy fog that will burn and purify cultists.
-4. By spraying a cultist with holy water from a spray bottle or extinguisher. Or splashing a container of holy water on them. It will burn and eventually purify them.
 
 Your Chaplain, a holy being, is largely immune to the more [italic]persuasive[/italic] aspects of the blood cult's methods, and is the only crewmember who may be trusted absolutely once the cult's presence is known. Chaplains are also resistant to blood magic and cult-manufactured weaponry, rendering the offensive abilities of most cultists useless against them -- unless the cultists resort to more traditional methods of attack.
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
Blood cultists don't deconvert or burn from being splashed with holy water.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Spraying the cult with holy water filled fire extinguishers was becoming an oppressive meta, and the RP of it wasn't very good either.

## Technical details
<!-- Summary of code changes for easier review. -->
Removed the system that handled it, changed some YML so it burns cultists who drink holy water a little. So there's at least some feedback.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->

:cl: Terkala
- tweak: BloodCult doesn't deconvert from being splashed with holy water anymore.
