### PR TITLE
Fix: Medical Cyborg Pulling

### DIFF
--- a/Content.Server/Silicons/Borgs/BorgSwitchableTypeSystem.cs
+++ b/Content.Server/Silicons/Borgs/BorgSwitchableTypeSystem.cs
@@ -9,6 +9,8 @@ using Content.Server.Radio.Components;
 using Content.Shared.Inventory;
 using Content.Shared.Silicons.Borgs;
 using Content.Shared.Silicons.Borgs.Components;
+using Robust.Shared.Physics;
+using Robust.Shared.Physics.Systems;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 
@@ -21,6 +23,8 @@ public sealed class BorgSwitchableTypeSystem : SharedBorgSwitchableTypeSystem
 {
     [Dependency] private readonly BorgSystem _borgSystem = default!;
     [Dependency] private readonly ServerInventorySystem _inventorySystem = default!;
+    [Dependency] private readonly SharedPhysicsSystem _physicsSystem = default!;
+
 
     protected override void SelectBorgModule(Entity<BorgSwitchableTypeComponent> ent, ProtoId<BorgTypePrototype> borgType)
     {
@@ -76,6 +80,9 @@ public sealed class BorgSwitchableTypeSystem : SharedBorgSwitchableTypeSystem
         {
             EntityManager.AddComponents(ent, addComponents);
         }
+
+        //Inits a Cyborg's masses if there were changes to its fixtures above
+        _physicsSystem.ResetMassData(ent);
 
         // Configure inventory template (used for hat spacing)
         if (TryComp(ent, out InventoryComponent? inventory))


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
Fixed Medical Cyborgs being basically unable to pull until someone else pulls them, now they can just pull like normal

Also allows selectable Cyborgs to have different masses and fixtures in general now

## Why / Balance
Bug Fix and just a good thing to have generally

## Technical details
The reason why this bug existed is because when the fixture and physics was being changed by AddComponents, nothing actually... updated the base physics properties of the entity afterward, it was just considered near-massless. Why pulling fixed this is that the entity's various Masses is *forcibly re-calculated upon a pull initialization*.

So, after we Add Components to our Cyborgs, we now have an additional step that also forcibly re-calculates the Masses of the Cyborg, just incase we decided to update the Mass in our initialization, properly initializing it regardless of if there was any change or not.

## Media
Video Demo

https://github.com/user-attachments/assets/f69fb8ed-9368-4097-aa48-d0c358899493

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**

:cl:
- fix: Fixed Medical Cyborgs initially having the mass of an ant and thus being unable to pull until someone else pulled them. Now Medborgs can pull normally as expected.
