### PR TITLE
SharedIdentitySystem updates on helmet toggle

### DIFF
--- a/Content.Shared/IdentityManagement/SharedIdentitySystem.cs
+++ b/Content.Shared/IdentityManagement/SharedIdentitySystem.cs
@@ -27,6 +27,7 @@ public abstract class SharedIdentitySystem : EntitySystem
         SubscribeLocalEvent<IdentityComponent, ComponentInit>(OnComponentInit);
         SubscribeLocalEvent<IdentityBlockerComponent, SeeIdentityAttemptEvent>(OnSeeIdentity);
         SubscribeLocalEvent<IdentityBlockerComponent, InventoryRelayedEvent<SeeIdentityAttemptEvent>>((e, c, ev) => OnSeeIdentity(e, c, ev.Args));
+        SubscribeLocalEvent<IdentityBlockerComponent, ItemHeadToggledEvent>(OnHeadToggled); // THIS
         SubscribeLocalEvent<IdentityBlockerComponent, ItemMaskToggledEvent>(OnMaskToggled);
     }
 
@@ -45,10 +46,16 @@ public abstract class SharedIdentitySystem : EntitySystem
         component.IdentityEntitySlot = _container.EnsureContainer<ContainerSlot>(uid, SlotName);
     }
 
+    private void OnHeadToggled(Entity<IdentityBlockerComponent> ent, ref ItemHeadToggledEvent args) // THIS
+    {
+        ent.Comp.Enabled = !args.IsToggled;
+    }
+
     private void OnMaskToggled(Entity<IdentityBlockerComponent> ent, ref ItemMaskToggledEvent args)
     {
         ent.Comp.Enabled = !args.IsToggled;
     }
+    
 }
 /// <summary>
 ///     Gets called whenever an entity changes their identity.


### PR DESCRIPTION
SharedIdentitySystem now updates your identity when toggling helmet.

<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->

Fixed hardsuit helmets not properly hiding your identity when you had a gas mask flipped up.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

Bugfix. Hardsuit helmets were always intended to hide your identity.

## Technical details
<!-- Summary of code changes for easier review. -->

When gas mask flipping was added, it added an event call to the identity system to update and change components accordingly.
Hardsuits were not changed to match, so when a gas mask flips up, and then a hardsuit goes on, it would not properly update your identity component, and thus your identity would be revealed with the helmet on.

This also applied to the other components of the helmet, like eating/drinking.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="1146" height="807" alt="hardsuit-fix" src="https://github.com/user-attachments/assets/19c5aee5-708c-4817-b07d-bf555edb3619" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- fix: Fixed hardsuit helmets not properly hiding your identity when wearing a flipped up gas mask.
