### PR TITLE
Field surgery kit now uses a large beaker

### DIFF
--- a/Resources/Prototypes/_Funkystation/Catalog/Fills/Items/surgerykits.yml
+++ b/Resources/Prototypes/_Funkystation/Catalog/Fills/Items/surgerykits.yml
@@ -36,4 +36,4 @@
       - id: ClothingMaskSterile
       - id: ClothingMaskBreathMedical
       - id: Syringe
-      - id: DrinkJugAnodynafil # Funky - Regular jug is too large now
+      - id: LargeBeakerAnodynafil # Funky - Jug is too large now

--- a/Resources/Prototypes/_Funkystation/Entities/Objects/Specific/Medical/surgerykits.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Objects/Specific/Medical/surgerykits.yml
@@ -36,11 +36,11 @@
   - type: Item
     heldPrefix: surgerykitsyndicate
 
-# Regular anodynafil jug is too large, so we'll just use a beverage jug instead. I mean, are you gonna use the whole 200 units anyway?
+# Regular anodynafil jug is too large, so we'll just use a large beaker instead. I mean, are you gonna use the whole 200 units anyway?
 - type: entity
-  parent: CustomDrinkJug
+  parent: LargeBeaker
   suffix: anodynafil
-  id: DrinkJugAnodynafil
+  id: LargeBeakerAnodynafil
   categories: [ HideSpawnMenu ]
   components:
   - type: Label
@@ -50,4 +50,4 @@
       beaker:
         reagents:
         - ReagentId: Anodynafil
-          Quantity: 150
+          Quantity: 100


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
The field surgery kit now uses a large beaker instead of a beverage jug.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
Fixes #3138. Given how effective anodynafil is, I doubt you'd need more than 100 units anyway.

## Technical details
<!-- Summary of code changes for easier review. -->
YAML.

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="417" height="142" alt="Screenshot_20260508_172125" src="https://github.com/user-attachments/assets/d53b347a-ee19-4f21-a1f3-9b85ae41064c" />


## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->
N/A.

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
:cl:
- tweak: The field surgery kit now uses a large beaker to store anodynafil, instead of a beverage jug.