### PR TITLE
Bugfix: Metashielded info removed from books + Slight SOP book changes

### DIFF
--- a/Resources/Prototypes/Guidebook/station.yml
+++ b/Resources/Prototypes/Guidebook/station.yml
@@ -23,7 +23,6 @@
   children:
   - Jobs
   - Survival
-  - Antagonists
   - Glossary
 
 - type: guideEntry

--- a/Resources/Prototypes/_Funkystation/Entities/Objects/Misc/books.yml
+++ b/Resources/Prototypes/_Funkystation/Entities/Objects/Misc/books.yml
@@ -28,11 +28,14 @@
   - type: Sprite
     layers:
     - state: paper
-    - state: cover_base
-      color: "#15abab"
-    - state: decor_wingette
-      color: "#5334e0"
-    - state: icon_briefcase
+    - state: cover_strong
+      color: "#134975"
+    - state: decor_wingette_circle
+      color: "#ffffff"
+    - state: detail_rivets
+      color: "#009100"
+    - state: icon_letter_N
+      color: "#ffffff"
   - type: MeleeWeapon
     wideAnimationRotation: 180
     attackRate: 0.10 # VERY slow attack speed so it cannot be used as an actual weapon but can still be used to bash the clown over the head
@@ -42,13 +45,4 @@
         Blunt: 10
   - type: GuideHelp
     guides:
-    - LegalSOP
-    - MedicalSOP
-    - ServiceSOP
-    - EngineeringSOP
-    - CargoSOP
-    - ScienceSOP
-    - CommandSOP # No idea why this was not in here before
-    - OrderOfSuccession # I find that this counts as SOP, good for an IAA to have
-    - SecuritySOP # Sec SOP
-    - AlertLevelsSOP # All alert level SOPs
+    - SOP101 # Who knew this was a preset thing that existed but was never added... i didn't... :(

--- a/Resources/Prototypes/_Funkystation/Guidebook/sop.yml
+++ b/Resources/Prototypes/_Funkystation/Guidebook/sop.yml
@@ -108,7 +108,6 @@
   name: guide-entry-command-sop
   text: "/ServerInfo/Funkystation/Guidebook/Command/GeneralCommandSOP.xml"
   children:
-  - CommandTrainingManual
   - OrderOfSuccession
   - CaptainSOP
 

--- a/Resources/ServerInfo/Funkystation/Guidebook/Command/GeneralCommandSOP.xml
+++ b/Resources/ServerInfo/Funkystation/Guidebook/Command/GeneralCommandSOP.xml
@@ -50,7 +50,6 @@ SPDX-License-Identifier: MIT
   - [textlink="Quartermaster" link="QMSOP"]
 
 Please also see:
-  - [textlink="Command Training Manual" link="CommandTrainingManual"]
   - [textlink="Order of Sucession" link="OrderOfSuccession"]
 
 <Box>


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- NOTE: All code submitted to this repository is ALWAYS licensed under the AGPL-3.0-or-later license. 
The REUSE Specification headers or separate .license files indicate a secondary license (e.g., MPL or MIT) solely to facilitate 
integration for projects that do not use the AGPL license. This secondary license does not replace the fact that AGPL-3.0-or-later remains the primary and binding license. 

IF YOU ARE PORTING A FEAUTRE: Please make sure that the license is supported and that you are using the appropriate license. For example, anything from Wizard's Den is MIT.

Uncomment and modify the following line if you wish to change the license from the default of AGPL.
-->
<!--- LICENSE: AGPL -->
## About the PR
<!-- What did you change? -->
CTM removed from the SOPbook which was very much unintended, CTM mention also removed from the commandSOP, space encyclopedia's antag section removed and finally SOP book now looks better.

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->
The removal of the CTM being a child of commandSOP was done so it no longer shows up in the SOP book and this was done because it broke the metashield and it was a oversight of mine. The look of the SOP book has also been redone, this was designed by @stabithar in the discord. The space encyclopedia has also been fixed as it had a list of every antagonist's guidebook in it, this was a oversight of the initial introduction of funky's metashield. The removal of the CTM mention in the command SOP is so it can be put in books without having to worry about causing confusion about that.
## Technical details
<!-- Summary of code changes for easier review. -->

Changes to YAML

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->
<img width="47" height="57" alt="image" src="https://github.com/user-attachments/assets/6c10391c-701a-4934-8a0b-3f24f62d5439" />
<img width="360" height="222" alt="image" src="https://github.com/user-attachments/assets/f4398ca0-9390-4bd6-8a4e-362297be2be0" />
<img width="210" height="317" alt="image" src="https://github.com/user-attachments/assets/f7f4b39d-1429-4ebe-ac2e-0c3768cdf87e" />

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- remove: CTM from SOP book
- remove: CTM mention from command SOP
- remove: Antag guides from space encyclopedia
- tweak: Changed the SOP book's look
